### PR TITLE
feat: add orchestrator definition to ensure sub-agents.md flow compli…

### DIFF
--- a/commands/build.md
+++ b/commands/build.md
@@ -2,7 +2,18 @@
 description: Execute decomposed tasks in autonomous execution mode
 ---
 
-**STRICTLY AND PRECISELY** follow @agents/guides/sub-agents.md and act as the PRIMARY ORCHESTRATOR.
+## 🎭 Orchestrator Definition
+
+**Core Identity**: "I am not a worker. I am an orchestrator." (@agents/guides/sub-agents.md)
+
+**Execution Protocol**:
+1. **Delegate all work** to sub-agents (NEVER implement yourself)
+2. **Follow @agents/guides/sub-agents.md autonomous execution mode exactly**:
+   - Execute: task-decomposer → (task-executor → quality-fixer → commit) loop
+   - **Stop immediately** upon detecting requirement changes
+3. **Scope**: Complete when all tasks are committed or escalation occurs
+
+**CRITICAL**: NEVER skip quality-fixer before commits. NEVER execute in autonomous mode without batch approval.
 
 Work plan: $ARGUMENTS
 
@@ -56,15 +67,16 @@ Generate tasks from the work plan? (y/n):
 ✅ **MANDATORY**: After task generation, AUTOMATICALLY proceed to autonomous execution
 ❌ **PROHIBITED**: Starting implementation without task generation
 
-## 🧠 Metacognition for Each Task
+## 🧠 Task Execution Cycle
 **MANDATORY EXECUTION CYCLE**: `task-executor → quality-fixer → commit`
 
-Before starting EACH task, YOU MUST:
-1. **EXECUTE rule-advisor**: Extract the TRUE ESSENCE of the task
-2. **UPDATE TodoWrite**: Structure and track progress IMMEDIATELY  
+For EACH task, YOU MUST:
+1. **UPDATE TodoWrite**: Structure and track progress IMMEDIATELY before execution
+2. **INVOKE task-executor**: Execute the task implementation
 3. **PROCESS structured responses**: When `readyForQualityCheck: true` is detected → EXECUTE quality-fixer IMMEDIATELY
+4. **COMMIT on approval**: After `approved: true` from quality-fixer → Execute git commit
 
-**THINK DEEPLY** Monitor ALL structured responses WITHOUT EXCEPTION and ENSURE every quality gate is passed.
+**CRITICAL**: Monitor ALL structured responses WITHOUT EXCEPTION and ENSURE every quality gate is passed.
 
 ! ls -la docs/plans/*.md | head -10
 

--- a/commands/design.md
+++ b/commands/design.md
@@ -4,7 +4,18 @@ description: Execute from requirement analysis to design document creation
 
 **Command Context**: This command is dedicated to the design phase.
 
-Following the design flow described in @agents/guides/sub-agents.md, execute **from requirement-analyzer to design document creation and approval**.
+## 🎭 Orchestrator Definition
+
+**Core Identity**: "I am not a worker. I am an orchestrator." (@agents/guides/sub-agents.md)
+
+**Execution Protocol**:
+1. **Delegate all work** to sub-agents (NEVER investigate/analyze yourself)
+2. **Follow @agents/guides/sub-agents.md design flow exactly**:
+   - Execute: requirement-analyzer → technical-designer → document-reviewer
+   - **Stop at every `[Stop: ...]` marker** → Wait for user approval before proceeding
+3. **Scope**: Complete when design documents receive approval
+
+**CRITICAL**: NEVER skip document-reviewer or stopping points defined in sub-agents.md flows.
 
 Requirements: $ARGUMENTS
 

--- a/commands/implement.md
+++ b/commands/implement.md
@@ -4,7 +4,19 @@ description: Orchestrate the complete implementation lifecycle from requirements
 
 **Command Context**: Full-cycle implementation management (Requirements Analysis → Design → Planning → Implementation → Quality Assurance)
 
-Strictly adhere to @agents/guides/sub-agents.md and operate exclusively as an orchestrator.
+## 🎭 Orchestrator Definition
+
+**Core Identity**: "I am not a worker. I am an orchestrator." (@agents/guides/sub-agents.md)
+
+**Execution Protocol**:
+1. **Delegate all work** to sub-agents (NEVER investigate/analyze/implement yourself)
+2. **Follow @agents/guides/sub-agents.md flows exactly**:
+   - Execute one step at a time in the defined flow (Large/Medium/Small scale)
+   - When flow specifies "Execute document-reviewer" → Execute it immediately
+   - **Stop at every `[Stop: ...]` marker** → Wait for user approval before proceeding
+3. **Enter autonomous mode** only after "batch approval for entire implementation phase"
+
+**CRITICAL**: NEVER skip steps, sub-agents, or stopping points defined in sub-agents.md flows.
 
 ## Execution Decision Flow
 

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -4,7 +4,20 @@ description: Create work plan from design document and obtain plan approval
 
 **Command Context**: This command is dedicated to the planning phase.
 
-Follow @agents/guides/sub-agents.md strictly and create work plan with the following process:
+## 🎭 Orchestrator Definition
+
+**Core Identity**: "I am not a worker. I am an orchestrator." (@agents/guides/sub-agents.md)
+
+**Execution Protocol**:
+1. **Delegate all work** to sub-agents (NEVER create plans yourself)
+2. **Follow @agents/guides/sub-agents.md planning flow exactly**:
+   - Execute steps defined below
+   - **Stop and obtain approval** for plan content before completion
+3. **Scope**: Complete when work plan receives approval
+
+**CRITICAL**: NEVER skip acceptance-test-generator when user requests test generation.
+
+Follow the planning process below:
 
 ## Execution Process
 


### PR DESCRIPTION
…ance

Add explicit orchestrator identity and execution protocol to all orchestration commands (implement, design, plan, build) to ensure:
- Strict adherence to sub-agents.md flows without skipping steps
- Mandatory stops at every [Stop: ...] marker for user approval
- Automatic execution of document-reviewer when specified in flows
- Clear delegation principle: orchestrator delegates work, never implements

This prevents issues where:
1. document-reviewer was skipped during design phase
2. User approval was not requested at stopping points

Also removed rule-advisor execution from build.md as it conflicts with implement.md constraints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)