### PR TITLE
fix: use absolute plugin paths for file references

### DIFF
--- a/agents/acceptance-test-generator.md
+++ b/agents/acceptance-test-generator.md
@@ -11,8 +11,8 @@ You are a specialized AI that interprets and concretizes Design Doc ACs to desig
 
 Before starting work, you MUST read and strictly follow these rule files:
 
-- **@agents/rules/testing-principles.md** - Test design standards (quality requirements, test structure, naming conventions)
-- **@agents/rules/documentation-criteria.md** - Documentation standards (Design Doc/PRD structure, AC format)
+- **~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/testing-principles.md** - Test design standards (quality requirements, test structure, naming conventions)
+- **~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/documentation-criteria.md** - Documentation standards (Design Doc/PRD structure, AC format)
 
 ### Implementation Approach Compliance
 - **Test Code Generation**: MUST strictly comply with Design Doc implementation patterns (function vs class selection)

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -10,10 +10,10 @@ You are a code review AI assistant specializing in Design Doc compliance validat
 ## Initial Required Tasks
 
 Load and follow these rule files before starting:
-- @agents/rules/ai-development-guide.md - AI Development Guide, pre-implementation existing code investigation process
-- @agents/rules/coding-principles.md - Language-Agnostic Coding Principles
-- @agents/rules/testing-principles.md - Language-Agnostic Testing Principles
-- @agents/rules/architecture/ files (if present)
+- ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/ai-development-guide.md - AI Development Guide, pre-implementation existing code investigation process
+- ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/coding-principles.md - Language-Agnostic Coding Principles
+- ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/testing-principles.md - Language-Agnostic Testing Principles
+- ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/architecture/ files (if present)
   - Load project-specific architecture rules when defined
   - Apply rules based on adopted architecture patterns
 
@@ -94,7 +94,7 @@ Load and follow these rule files before starting:
 - [ ] Component dependencies correct
 - [ ] Responsibilities properly separated
 - [ ] Existing codebase analysis section includes similar functionality investigation results
-- [ ] No unnecessary duplicate implementations (Pattern 5 from @agents/rules/ai-development-guide.md)
+- [ ] No unnecessary duplicate implementations (Pattern 5 from ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/ai-development-guide.md)
 
 ### Quality Validation
 - [ ] Comprehensive error handling

--- a/agents/document-reviewer.md
+++ b/agents/document-reviewer.md
@@ -10,9 +10,9 @@ You are an AI assistant specialized in technical document review.
 ## Initial Mandatory Tasks
 
 Before starting work, be sure to read and follow these rule files:
-- @agents/rules/documentation-criteria.md - Documentation creation criteria (review quality standards)
-- @agents/rules/coding-principles.md - Language-agnostic coding principles (required for code example verification)
-- @agents/rules/testing-principles.md - Language-agnostic testing principles
+- ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/documentation-criteria.md - Documentation creation criteria (review quality standards)
+- ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/coding-principles.md - Language-agnostic coding principles (required for code example verification)
+- ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/testing-principles.md - Language-agnostic testing principles
 
 ## Responsibilities
 
@@ -134,7 +134,7 @@ Structured markdown including the following sections:
 
 ## Template References
 
-Template storage locations follow @agents/rules/documentation-criteria.md.
+Template storage locations follow ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/documentation-criteria.md.
 
 ## Technical Information Verification Guidelines
 

--- a/agents/prd-creator.md
+++ b/agents/prd-creator.md
@@ -10,7 +10,7 @@ You are a specialized AI assistant for creating Product Requirements Documents (
 ## Initial Mandatory Tasks
 
 Before starting work, be sure to read and follow these rule files:
-- @agents/rules/documentation-criteria.md - Documentation creation criteria (storage locations and naming conventions)
+- ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/documentation-criteria.md - Documentation creation criteria (storage locations and naming conventions)
 
 ## Responsibilities
 
@@ -83,13 +83,13 @@ Output in the following structured format:
    - Reason: [Explain rationale in 1-2 sentences]
 
 ### For Final Version
-Storage location and naming convention follow @agents/rules/documentation-criteria.md.
+Storage location and naming convention follow ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/documentation-criteria.md.
 
 ## Output Policy
 Execute file output immediately (considered approved at execution).
 
 ### Notes for PRD Creation
-- Create following the template (`@agents/templates/prd-template.md`)
+- Create following the template (`~/.claude/plugins/marketplaces/claude-code-workflows/agents/templates/prd-template.md`)
 - Understand and describe intent of each section
 - Limit questions to 3-5 in interactive mode
 

--- a/agents/quality-fixer.md
+++ b/agents/quality-fixer.md
@@ -26,10 +26,10 @@ Executes quality checks and provides a state where all project quality checks co
 ## Initial Required Tasks
 
 Load and follow these rule files before starting:
-- @agents/rules/coding-principles.md - Language-Agnostic Coding Principles
-- @agents/rules/testing-principles.md - Language-Agnostic Testing Principles
-- @agents/rules/ai-development-guide.md - AI Development Guide
-- @agents/rules/architecture/ files (if present)
+- ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/coding-principles.md - Language-Agnostic Coding Principles
+- ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/testing-principles.md - Language-Agnostic Testing Principles
+- ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/ai-development-guide.md - AI Development Guide
+- ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/architecture/ files (if present)
   - Load project-specific architecture rules when defined
   - Apply rules based on adopted architecture patterns
 

--- a/agents/requirement-analyzer.md
+++ b/agents/requirement-analyzer.md
@@ -10,8 +10,8 @@ You are a specialized AI assistant for requirements analysis and work scale dete
 ## Initial Mandatory Tasks
 
 Before starting work, be sure to read and follow these rule files:
-- @agents/rules/ai-development-guide.md - AI development guide (refer to escalation criteria)
-- @agents/rules/documentation-criteria.md - Documentation creation criteria (scale determination and ADR conditions)
+- ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/ai-development-guide.md - AI development guide (refer to escalation criteria)
+- ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/documentation-criteria.md - Documentation creation criteria (scale determination and ADR conditions)
 
 ## Responsibilities
 
@@ -25,7 +25,7 @@ Before starting work, be sure to read and follow these rule files:
 
 ## Work Scale Determination Criteria
 
-Scale determination and required document details follow @agents/rules/documentation-criteria.md.
+Scale determination and required document details follow ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/documentation-criteria.md.
 
 ### Scale Overview (Minimum Criteria)
 - **Small**: 1-2 files, single function modification
@@ -44,7 +44,7 @@ Scale determination and required document details follow @agents/rules/documenta
 
 ## Conditions Requiring ADR
 
-Detailed ADR creation conditions follow @agents/rules/documentation-criteria.md.
+Detailed ADR creation conditions follow ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/documentation-criteria.md.
 
 ### Overview
 - Type system changes (3+ level nesting, types used in 3+ locations)

--- a/agents/rule-advisor.md
+++ b/agents/rule-advisor.md
@@ -11,9 +11,9 @@ You are an AI assistant specialized in rule selection. You analyze task nature a
 ## Required Tasks at Execution
 
 Before starting work, you must read:
-- `@agents/rules/rules-index.yaml` - Rule file metadata
+- `~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/rules-index.yaml` - Rule file metadata
 
-**Important**: Rule files are loaded from `@agents/rules/`.
+**Important**: Rule files are loaded from `~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/`.
 
 ## Main Responsibilities
 
@@ -87,7 +87,7 @@ Always return structured response in the following JSON format:
   },
   "selectedRules": [
     {
-      "file": "@agents/rules/coding-principles.md",
+      "file": "~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/coding-principles.md",
       "sections": [
         {
           "title": "Function Design",
@@ -102,7 +102,7 @@ Always return structured response in the following JSON format:
       "priority": "high"
     },
     {
-      "file": "@agents/rules/testing-principles.md",
+      "file": "~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/testing-principles.md",
       "sections": [
         {
           "title": "Red-Green-Refactor Process",
@@ -188,4 +188,4 @@ The `mandatoryChecks` section in output provides metacognitive guidance for task
 
 - Set confidence to "low" when uncertain
 - Proactively collect information and broadly include potentially related rules
-- Only reference files under `@agents/rules/`
+- Only reference files under `~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/`

--- a/agents/rules/documentation-criteria.md
+++ b/agents/rules/documentation-criteria.md
@@ -151,10 +151,10 @@ Interface Change Matrix:
 
 | Document | Path | Naming Convention | Template |
 |----------|------|------------------|----------|
-| PRD | `docs/prd/` | `[feature-name]-prd.md` | `@agents/templates/prd-template.md` |
-| ADR | `docs/adr/` | `ADR-[4-digits]-[title].md` | `@agents/templates/adr-template.md` |
-| Design Doc | `docs/design/` | `[feature-name]-design.md` | `@agents/templates/design-template.md` |
-| Work Plan | `docs/plans/` | `YYYYMMDD-{type}-{description}.md` | `@agents/templates/plan-template.md` |
+| PRD | `docs/prd/` | `[feature-name]-prd.md` | `~/.claude/plugins/marketplaces/claude-code-workflows/agents/templates/prd-template.md` |
+| ADR | `docs/adr/` | `ADR-[4-digits]-[title].md` | `~/.claude/plugins/marketplaces/claude-code-workflows/agents/templates/adr-template.md` |
+| Design Doc | `docs/design/` | `[feature-name]-design.md` | `~/.claude/plugins/marketplaces/claude-code-workflows/agents/templates/design-template.md` |
+| Work Plan | `docs/plans/` | `YYYYMMDD-{type}-{description}.md` | `~/.claude/plugins/marketplaces/claude-code-workflows/agents/templates/plan-template.md` |
 
 *Note: Work plans are excluded by `.gitignore`
 

--- a/agents/task-decomposer.md
+++ b/agents/task-decomposer.md
@@ -10,21 +10,21 @@ You are an AI assistant specialized in decomposing work plans into executable ta
 ## Initial Mandatory Tasks
 
 Before starting work, be sure to read and follow these rule files:
-- @agents/rules/ai-development-guide.md - Task management principles
-- @agents/rules/documentation-criteria.md - Documentation creation criteria
-- @agents/rules/testing-principles.md - TDD process (Red-Green-Refactor)
-- @agents/rules/coding-principles.md - Generic design guidelines considering future extensions
-- @agents/rules/architecture/implementation-approach.md - Implementation strategy patterns and verification level definitions
+- ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/ai-development-guide.md - Task management principles
+- ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/documentation-criteria.md - Documentation creation criteria
+- ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/testing-principles.md - TDD process (Red-Green-Refactor)
+- ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/coding-principles.md - Generic design guidelines considering future extensions
+- ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/architecture/implementation-approach.md - Implementation strategy patterns and verification level definitions
 
 ## Primary Principle of Task Division
 
 **Each task must be verifiable at an appropriate level**
 
 ### Verifiability Criteria
-Task design based on verification levels (L1/L2/L3) defined in @agents/rules/architecture/implementation-approach.md.
+Task design based on verification levels (L1/L2/L3) defined in ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/architecture/implementation-approach.md.
 
 ### Implementation Strategy Application
-Decompose tasks based on implementation strategy patterns determined in @agents/rules/architecture/implementation-approach.md.
+Decompose tasks based on implementation strategy patterns determined in ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/architecture/implementation-approach.md.
 
 ## Main Responsibilities
 

--- a/agents/task-executor.md
+++ b/agents/task-executor.md
@@ -12,13 +12,13 @@ You are a specialized AI assistant for reliably executing individual tasks.
 Load and follow these rule files before starting:
 
 ### Required Files to Load
-- **@agents/rules/coding-principles.md** - Language-agnostic coding principles
-- **@agents/rules/testing-principles.md** - Language-agnostic testing principles
-- **@agents/rules/architecture/ files (if present)**
+- **~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/coding-principles.md** - Language-agnostic coding principles
+- **~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/testing-principles.md** - Language-agnostic testing principles
+- **~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/architecture/ files (if present)**
   - Load project-specific architecture rules when defined
   - Apply rules based on adopted architecture patterns
   - Layered architecture, clean architecture, hexagonal, etc.
-- **@agents/rules/ai-development-guide.md** - AI development guide, pre-implementation existing code investigation process
+- **~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/ai-development-guide.md** - AI development guide, pre-implementation existing code investigation process
   **Follow**: All rules for implementation, testing, and code quality
   **Exception**: Quality assurance process (Phase 1-6) and commits are out of scope
 
@@ -142,7 +142,7 @@ Select and execute files with pattern `docs/plans/tasks/*-task-*.md` that have u
 
 #### Operation Verification
 - Execute "Operation Verification Methods" section in task
-- Perform verification according to level defined in @agents/rules/architecture/implementation-approach.md
+- Perform verification according to level defined in ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/architecture/implementation-approach.md
 - Record reason if unable to verify
 - Include results in structured response
 

--- a/agents/technical-designer.md
+++ b/agents/technical-designer.md
@@ -10,12 +10,12 @@ You are a technical design specialist AI assistant for creating Architecture Dec
 ## Initial Mandatory Tasks
 
 Before starting work, be sure to read and follow these rule files:
-- @agents/rules/documentation-criteria.md - Documentation creation criteria
-- @agents/rules/coding-principles.md - Language-agnostic coding principles
-- @agents/rules/testing-principles.md - Language-agnostic testing principles
-- @agents/rules/ai-development-guide.md - AI development guide, pre-implementation existing code investigation process
-- @agents/rules/architecture/implementation-approach.md - Metacognitive strategy selection process (used for implementation approach decisions)
-- @agents/rules/architecture/ architecture rule files (if exist)
+- ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/documentation-criteria.md - Documentation creation criteria
+- ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/coding-principles.md - Language-agnostic coding principles
+- ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/testing-principles.md - Language-agnostic testing principles
+- ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/ai-development-guide.md - AI development guide, pre-implementation existing code investigation process
+- ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/architecture/implementation-approach.md - Metacognitive strategy selection process (used for implementation approach decisions)
+- ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/architecture/ architecture rule files (if exist)
   - Read if project-specific architecture rules are defined
   - Apply rules according to adopted architecture patterns
 
@@ -30,7 +30,7 @@ Before starting work, be sure to read and follow these rule files:
 
 ## Document Creation Criteria
 
-Details of documentation creation criteria follow @agents/rules/documentation-criteria.md.
+Details of documentation creation criteria follow ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/documentation-criteria.md.
 
 ### Overview
 - ADR: Type system changes, data flow changes, architecture changes, external dependency changes
@@ -59,7 +59,7 @@ Must be performed before Design Doc creation:
    - List major public methods of target service (about 5 important ones if over 10)
    - Identify call sites with `Grep: "ServiceName\." --type ts`
 
-3. **Similar Functionality Search and Decision** (Pattern 5 prevention from @agents/rules/ai-development-guide.md)
+3. **Similar Functionality Search and Decision** (Pattern 5 prevention from ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/ai-development-guide.md)
    - Search existing code for keywords related to planned functionality
    - Look for implementations with same domain, responsibilities, or configuration patterns
    - Decision and action:
@@ -113,7 +113,7 @@ Must be performed at the beginning of Design Doc creation:
 Must be performed when creating Design Doc:
 
 1. **Approach Selection Criteria**
-   - Execute Phase 1-4 of @agents/rules/architecture/implementation-approach.md to select strategy
+   - Execute Phase 1-4 of ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/architecture/implementation-approach.md to select strategy
    - **Vertical Slice**: Complete by feature unit, minimal external dependencies, early value delivery
    - **Horizontal Slice**: Implementation by layer, important common foundation, technical consistency priority
    - **Hybrid**: Composite, handles complex requirements
@@ -121,7 +121,7 @@ Must be performed when creating Design Doc:
 
 2. **Integration Point Definition**
    - Which task first makes the whole system operational
-   - Verification level for each task (L1/L2/L3 defined in @agents/rules/architecture/implementation-approach.md)
+   - Verification level for each task (L1/L2/L3 defined in ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/architecture/implementation-approach.md)
 
 ### Change Impact Map【Required】
 Must be included when creating Design Doc:
@@ -231,7 +231,7 @@ Status: Proposed
 Option [X] selected. Reason: [2-3 sentences including trade-offs]
 ```
 
-See `@agents/templates/adr-template.md` for details.
+See `~/.claude/plugins/marketplaces/claude-code-workflows/agents/templates/adr-template.md` for details.
 
 ### Normal Document Creation
 - **ADR**: `docs/adr/ADR-[4-digit number]-[title].md` (e.g., ADR-0001)

--- a/agents/templates/plan-template.md
+++ b/agents/templates/plan-template.md
@@ -39,7 +39,7 @@ Related Issue/PR: #XXX (if any)
 #### Tasks
 - [ ] Task 1: Specific work content
 - [ ] Task 2: Specific work content
-- [ ] Quality check: Implement staged quality checks (refer to @agents/rules/ai-development-guide.md)
+- [ ] Quality check: Implement staged quality checks (refer to ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/ai-development-guide.md)
 - [ ] Unit tests: All related tests pass
 
 #### Phase Completion Criteria
@@ -57,7 +57,7 @@ Related Issue/PR: #XXX (if any)
 #### Tasks
 - [ ] Task 1: Specific work content
 - [ ] Task 2: Specific work content
-- [ ] Quality check: Implement staged quality checks (refer to @agents/rules/ai-development-guide.md)
+- [ ] Quality check: Implement staged quality checks (refer to ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/ai-development-guide.md)
 - [ ] Integration tests: Verify overall feature functionality
 
 #### Phase Completion Criteria
@@ -75,7 +75,7 @@ Related Issue/PR: #XXX (if any)
 #### Tasks
 - [ ] Task 1: Specific work content
 - [ ] Task 2: Specific work content
-- [ ] Quality check: Implement staged quality checks (refer to @agents/rules/ai-development-guide.md)
+- [ ] Quality check: Implement staged quality checks (refer to ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/ai-development-guide.md)
 - [ ] Integration tests: Verify component coordination
 
 #### Phase Completion Criteria
@@ -99,7 +99,7 @@ Related Issue/PR: #XXX (if any)
 [Copy operational verification procedures from Design Doc]
 
 ### Quality Assurance
-- [ ] Implement staged quality checks (details: refer to @agents/rules/ai-development-guide.md)
+- [ ] Implement staged quality checks (details: refer to ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/ai-development-guide.md)
 - [ ] All tests pass
 - [ ] Type check pass
 - [ ] Lint check pass

--- a/agents/work-planner.md
+++ b/agents/work-planner.md
@@ -10,12 +10,12 @@ You are a specialized AI assistant for creating work plan documents.
 ## Initial Mandatory Tasks
 
 Before starting work, be sure to read and follow these rule files:
-- @agents/rules/ai-development-guide.md - AI development guide, pre-implementation existing code investigation process, task management principles
-- @agents/rules/documentation-criteria.md - Documentation creation criteria
-- @agents/rules/coding-principles.md - Language-agnostic coding principles
-- @agents/rules/testing-principles.md - Language-agnostic testing principles
-- @agents/rules/architecture/implementation-approach.md - Implementation strategy patterns and verification level definitions (used for task decomposition)
-- @agents/rules/architecture/ architecture rule files (if exist)
+- ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/ai-development-guide.md - AI development guide, pre-implementation existing code investigation process, task management principles
+- ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/documentation-criteria.md - Documentation creation criteria
+- ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/coding-principles.md - Language-agnostic coding principles
+- ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/testing-principles.md - Language-agnostic testing principles
+- ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/architecture/implementation-approach.md - Implementation strategy patterns and verification level definitions (used for task decomposition)
+- ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/architecture/ architecture rule files (if exist)
   - Read if project-specific architecture rules are defined
   - Apply rules according to adopted architecture patterns
 
@@ -57,7 +57,7 @@ Please provide the following information in natural language:
 
 ## Work Plan Output Format
 
-- Storage location and naming convention follow @agents/rules/documentation-criteria.md
+- Storage location and naming convention follow ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/documentation-criteria.md
 - Format with checkboxes for progress tracking
 
 ## Work Plan Operational Flow
@@ -139,7 +139,7 @@ Gradually ensure quality based on Design Doc acceptance criteria.
 - E2E tests: Place "E2E test execution" in final phase (implementation not needed, execution only)
 
 ### Implementation Approach Application
-Decompose tasks based on implementation approach and technical dependencies decided in Design Doc, following verification levels (L1/L2/L3) from @agents/rules/architecture/implementation-approach.md.
+Decompose tasks based on implementation approach and technical dependencies decided in Design Doc, following verification levels (L1/L2/L3) from ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/architecture/implementation-approach.md.
 
 ### Task Dependency Minimization Rules
 - Dependencies up to 2 levels maximum (A→B→C acceptable, A→B→C→D requires redesign)

--- a/commands/build.md
+++ b/commands/build.md
@@ -4,11 +4,11 @@ description: Execute decomposed tasks in autonomous execution mode
 
 ## 🎭 Orchestrator Definition
 
-**Core Identity**: "I am not a worker. I am an orchestrator." (@agents/guides/sub-agents.md)
+**Core Identity**: "I am not a worker. I am an orchestrator." (~/.claude/plugins/marketplaces/claude-code-workflows/agents/guides/sub-agents.md)
 
 **Execution Protocol**:
 1. **Delegate all work** to sub-agents (NEVER implement yourself)
-2. **Follow @agents/guides/sub-agents.md autonomous execution mode exactly**:
+2. **Follow ~/.claude/plugins/marketplaces/claude-code-workflows/agents/guides/sub-agents.md autonomous execution mode exactly**:
    - Execute: task-decomposer → (task-executor → quality-fixer → commit) loop
    - **Stop immediately** upon detecting requirement changes
 3. **Scope**: Complete when all tasks are committed or escalation occurs

--- a/commands/design.md
+++ b/commands/design.md
@@ -6,11 +6,11 @@ description: Execute from requirement analysis to design document creation
 
 ## 🎭 Orchestrator Definition
 
-**Core Identity**: "I am not a worker. I am an orchestrator." (@agents/guides/sub-agents.md)
+**Core Identity**: "I am not a worker. I am an orchestrator." (~/.claude/plugins/marketplaces/claude-code-workflows/agents/guides/sub-agents.md)
 
 **Execution Protocol**:
 1. **Delegate all work** to sub-agents (NEVER investigate/analyze yourself)
-2. **Follow @agents/guides/sub-agents.md design flow exactly**:
+2. **Follow ~/.claude/plugins/marketplaces/claude-code-workflows/agents/guides/sub-agents.md design flow exactly**:
    - Execute: requirement-analyzer → technical-designer → document-reviewer
    - **Stop at every `[Stop: ...]` marker** → Wait for user approval before proceeding
 3. **Scope**: Complete when design documents receive approval

--- a/commands/implement.md
+++ b/commands/implement.md
@@ -6,11 +6,11 @@ description: Orchestrate the complete implementation lifecycle from requirements
 
 ## 🎭 Orchestrator Definition
 
-**Core Identity**: "I am not a worker. I am an orchestrator." (@agents/guides/sub-agents.md)
+**Core Identity**: "I am not a worker. I am an orchestrator." (~/.claude/plugins/marketplaces/claude-code-workflows/agents/guides/sub-agents.md)
 
 **Execution Protocol**:
 1. **Delegate all work** to sub-agents (NEVER investigate/analyze/implement yourself)
-2. **Follow @agents/guides/sub-agents.md flows exactly**:
+2. **Follow ~/.claude/plugins/marketplaces/claude-code-workflows/agents/guides/sub-agents.md flows exactly**:
    - Execute one step at a time in the defined flow (Large/Medium/Small scale)
    - When flow specifies "Execute document-reviewer" → Execute it immediately
    - **Stop at every `[Stop: ...]` marker** → Wait for user approval before proceeding

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -6,11 +6,11 @@ description: Create work plan from design document and obtain plan approval
 
 ## 🎭 Orchestrator Definition
 
-**Core Identity**: "I am not a worker. I am an orchestrator." (@agents/guides/sub-agents.md)
+**Core Identity**: "I am not a worker. I am an orchestrator." (~/.claude/plugins/marketplaces/claude-code-workflows/agents/guides/sub-agents.md)
 
 **Execution Protocol**:
 1. **Delegate all work** to sub-agents (NEVER create plans yourself)
-2. **Follow @agents/guides/sub-agents.md planning flow exactly**:
+2. **Follow ~/.claude/plugins/marketplaces/claude-code-workflows/agents/guides/sub-agents.md planning flow exactly**:
    - Execute steps defined below
    - **Stop and obtain approval** for plan content before completion
 3. **Scope**: Complete when work plan receives approval


### PR DESCRIPTION
Replace relative @agents/ references with absolute plugin paths to ensure files are correctly loaded when installed as a plugin.

Changes:
- @agents/rules/* → ~/.claude/plugins/marketplaces/claude-code-workflows/agents/rules/*
- @agents/templates/* → ~/.claude/plugins/marketplaces/claude-code-workflows/agents/templates/*
- @agents/guides/* → ~/.claude/plugins/marketplaces/claude-code-workflows/agents/guides/*

This ensures sub-agents can properly read rule files, templates, and guides after plugin installation.

Affects: 17 files (agents/*.md, commands/*.md, templates/*.md, rules/*.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)