### PR TITLE
fix: remove unsupported 'categories' field from plugin schema

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -26,11 +26,6 @@
         "coding-standards",
         "testing",
         "architecture"
-      ],
-      "categories": [
-        "productivity",
-        "quality",
-        "workflows"
       ]
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -19,11 +19,6 @@
     "testing",
     "architecture"
   ],
-  "categories": [
-    "productivity",
-    "quality",
-    "workflows"
-  ],
   "engines": {
     "claude-code": ">=1.0.0"
   },


### PR DESCRIPTION
Remove 'categories' field from both plugin.json and marketplace.json to resolve schema validation error when adding to Claude Code marketplace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)