### PR TITLE
fix: add required name field to all plugin command files

### DIFF
--- a/commands/build.md
+++ b/commands/build.md
@@ -1,4 +1,5 @@
 ---
+name: build
 description: Execute decomposed tasks in autonomous execution mode
 ---
 

--- a/commands/design.md
+++ b/commands/design.md
@@ -1,4 +1,5 @@
 ---
+name: design
 description: Execute from requirement analysis to design document creation
 ---
 

--- a/commands/implement.md
+++ b/commands/implement.md
@@ -1,4 +1,5 @@
 ---
+name: implement
 description: Orchestrate the complete implementation lifecycle from requirements to deployment
 ---
 

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -1,4 +1,5 @@
 ---
+name: plan
 description: Create work plan from design document and obtain plan approval
 ---
 

--- a/commands/review.md
+++ b/commands/review.md
@@ -1,4 +1,5 @@
 ---
+name: review
 description: Design Doc compliance validation with optional auto-fixes
 ---
 

--- a/commands/task.md
+++ b/commands/task.md
@@ -1,4 +1,5 @@
 ---
+name: task
 description: Execute tasks following appropriate rules with rule-advisor metacognition
 ---
 


### PR DESCRIPTION
Plugin commands require a 'name' field in their frontmatter to be recognized by Claude Code. All six command files were missing this required field, preventing them from being loaded as slash commands.

Added 'name' field to:
- commands/build.md
- commands/design.md
- commands/implement.md
- commands/plan.md
- commands/review.md
- commands/task.md

This fixes the issue where the plugin appeared installed but commands were not available in the command list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)