### PR TITLE
fix: remove unsupported engines field and correct install command

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "claude-code-workflows",
       "source": "./",
       "description": "Professional development workflows for Claude Code - Language-agnostic best practices, specialized agents, and quality assurance patterns for building production-ready software",
-      "version": "2.0.0",
+      "version": "0.2.5",
       "author": {
         "name": "Shinsuke Kagawa",
         "url": "https://github.com/shinpr"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-workflows",
-  "version": "2.0.0",
+  "version": "0.2.5",
   "description": "Professional development workflows for Claude Code - Language-agnostic best practices, specialized agents, and quality assurance patterns for building production-ready software",
   "author": {
     "name": "Shinsuke Kagawa",
@@ -19,9 +19,6 @@
     "testing",
     "architecture"
   ],
-  "engines": {
-    "claude-code": ">=1.0.0"
-  },
   "commands": [
     "./commands/build.md",
     "./commands/design.md",

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ claude
 
 # 2. Install plugin
 /plugin marketplace add shinpr/claude-code-workflows
-/plugin install claude-code-workflows@shinpr
+/plugin install claude-code-workflows@claude-code-workflows
 
 # 3. Restart session (required)
 # Exit and restart Claude Code


### PR DESCRIPTION
The 'engines' field in plugin.json was causing validation errors as it's not recognized in Claude Code's plugin schema. This prevented the plugin from being properly loaded.

Changes:
- Remove 'engines' field from plugin.json (schema violation)
- Update version from 2.0.0 to 0.2.5 in both plugin.json and marketplace.json
- Fix README install command: plugin@marketplace-name format requires marketplace name (from marketplace.json), not GitHub username

The correct install command is:
/plugin install claude-code-workflows@claude-code-workflows

This fix resolves plugin loading errors and ensures users can successfully install the plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)