### PR TITLE
chore: bump version to 0.3.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,6 @@
 {
   "name": "claude-code-workflows",
+  "version": "0.3.2",
   "owner": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/backend/.claude-plugin/plugin.json
+++ b/backend/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-workflows",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "description": "Professional development workflows for Claude Code - Language-agnostic best practices, specialized agents, and quality assurance patterns for building production-ready software",
   "author": {
     "name": "Shinsuke Kagawa",

--- a/frontend/.claude-plugin/plugin.json
+++ b/frontend/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-workflows-frontend",
-  "version": "0.1.0",
+  "version": "0.3.2",
   "description": "Professional frontend development workflows for Claude Code - React/TypeScript specialized agents, commands, and quality patterns for building production-ready web applications",
   "author": {
     "name": "Shinsuke Kagawa",


### PR DESCRIPTION
## Summary

Unified all plugin versions to 0.3.2 to align with the upcoming GitHub release tag.

## Changes

- **marketplace.json**: Added `"version": "0.3.2"` field
- **backend/plugin.json**: `0.3.0` → `0.3.2`
- **frontend/plugin.json**: `0.1.0` → `0.3.2`

## Rationale

Following a unified versioning strategy where the marketplace and all plugins maintain the same version number. This simplifies version management during the 0.x development phase and ensures users can properly detect updates via `/plugin marketplace update`.

## After Merge

Create GitHub release with tag `v0.3.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)