### PR TITLE
refactor: replace prohibition expressions with positive action patterns

### DIFF
--- a/agents/quality-fixer.md
+++ b/agents/quality-fixer.md
@@ -217,8 +217,13 @@ Issues requiring fixes:
 - Test errors: Identify failure cause, fix implementation or tests
 - Circular dependencies: Organize dependencies, extract to common modules
 
-## Prohibited Fixes
+## Required Fix Patterns
 
-**Never**: Test skip, meaningless assertions, safety suppression, unhandled errors (empty catch blocks, ignored Results, unchecked error codes)
-**Reason**: These hide problems (see coding-principles.md anti-patterns)
+**Use these approaches instead of quick workarounds**:
+- Test failures → Fix implementation or test logic (not skip)
+- Type errors → Add proper types or type guards (not `any` cast)
+- Errors → Log with context or propagate (not empty catch/ignore)
+- Safety warnings → Address root cause (not suppress)
+
+**Rationale**: See coding-principles.md anti-patterns section
 

--- a/agents/rules/coding-principles.md
+++ b/agents/rules/coding-principles.md
@@ -47,9 +47,9 @@
 ## Error Handling
 
 ### Error Management Principles
-- **Always handle errors**: Never suppress errors silently
+- **Always handle errors**: Log with context or propagate explicitly
 - **Log appropriately**: Include context for debugging
-- **Protect sensitive data**: Never log passwords, tokens, or PII
+- **Protect sensitive data**: Mask or exclude passwords, tokens, PII from logs
 - **Fail fast**: Detect and report errors as early as possible
 
 ### Error Propagation
@@ -171,7 +171,7 @@
 ## Security Principles
 
 ### General Security
-- Never hardcode secrets or credentials
+- Store secrets in environment variables or secret managers
 - Validate all external input
 - Use parameterized queries for databases
 - Follow principle of least privilege

--- a/agents/rules/testing-principles.md
+++ b/agents/rules/testing-principles.md
@@ -227,8 +227,8 @@ test("should throw exception when file not found")
 
 ### Keep Tests Active
 
-- **Never skip tests**: Fix or delete failing tests
-- **No commented-out tests**: Delete or fix them
+- **Fix or delete failing tests**: Resolve failures immediately
+- **Remove commented-out tests**: Fix them or delete entirely
 - **Keep tests running**: Broken tests lose value quickly
 - **Maintain test suite**: Refactor tests as needed
 

--- a/commands/build.md
+++ b/commands/build.md
@@ -8,13 +8,13 @@ description: Execute decomposed tasks in autonomous execution mode
 **Core Identity**: "I am not a worker. I am an orchestrator." (~/.claude/plugins/marketplaces/claude-code-workflows/agents/guides/sub-agents.md)
 
 **Execution Protocol**:
-1. **Delegate all work** to sub-agents (NEVER implement yourself)
+1. **Delegate all work** to sub-agents (orchestrator role only)
 2. **Follow ~/.claude/plugins/marketplaces/claude-code-workflows/agents/guides/sub-agents.md autonomous execution mode exactly**:
    - Execute: task-decomposer → (task-executor → quality-fixer → commit) loop
    - **Stop immediately** upon detecting requirement changes
 3. **Scope**: Complete when all tasks are committed or escalation occurs
 
-**CRITICAL**: NEVER skip quality-fixer before commits. NEVER execute in autonomous mode without batch approval.
+**CRITICAL**: Run quality-fixer before every commit. Obtain batch approval before autonomous mode.
 
 Work plan: $ARGUMENTS
 
@@ -65,8 +65,7 @@ Generate tasks from the work plan? (y/n):
 ! ls -la docs/plans/tasks/*.md | head -10
 ```
 
-✅ **MANDATORY**: After task generation, AUTOMATICALLY proceed to autonomous execution
-❌ **PROHIBITED**: Starting implementation without task generation
+✅ **Flow**: Task generation → Autonomous execution (in this order)
 
 ## 🧠 Task Execution Cycle
 **MANDATORY EXECUTION CYCLE**: `task-executor → quality-fixer → commit`

--- a/commands/front-build.md
+++ b/commands/front-build.md
@@ -53,8 +53,7 @@ Generate tasks from the work plan? (y/n):
 ! ls -la docs/plans/tasks/*.md | head -10
 ```
 
-✅ **MANDATORY**: After task generation, AUTOMATICALLY proceed to autonomous execution
-❌ **PROHIBITED**: Starting implementation without task generation
+✅ **Flow**: Task generation → Autonomous execution (in this order)
 
 ## 🧠 Metacognition for Each Task - Frontend Specialized
 

--- a/commands/implement.md
+++ b/commands/implement.md
@@ -10,14 +10,14 @@ description: Orchestrate the complete implementation lifecycle from requirements
 **Core Identity**: "I am not a worker. I am an orchestrator." (~/.claude/plugins/marketplaces/claude-code-workflows/agents/guides/sub-agents.md)
 
 **Execution Protocol**:
-1. **Delegate all work** to sub-agents (NEVER investigate/analyze/implement yourself)
+1. **Delegate all work** to sub-agents (orchestrator role only, no direct implementation)
 2. **Follow ~/.claude/plugins/marketplaces/claude-code-workflows/agents/guides/sub-agents.md flows exactly**:
    - Execute one step at a time in the defined flow (Large/Medium/Small scale)
    - When flow specifies "Execute document-reviewer" → Execute it immediately
    - **Stop at every `[Stop: ...]` marker** → Wait for user approval before proceeding
 3. **Enter autonomous mode** only after "batch approval for entire implementation phase"
 
-**CRITICAL**: NEVER skip steps, sub-agents, or stopping points defined in sub-agents.md flows.
+**CRITICAL**: Execute all steps, sub-agents, and stopping points defined in sub-agents.md flows.
 
 ## Execution Decision Flow
 
@@ -59,16 +59,16 @@ When continuing existing flow, verify:
   - If commit capability unavailable → Escalate before autonomous mode
   - Other environments (tests, quality tools) → Subagents will escalate
 
-**Flow Deviation PROHIBITED**: Deviating from sub-agents.md defined flows is strictly forbidden. Specifically:
-- Never skip quality-fixer before committing
-- Never use Edit/Write/MultiEdit without user approval outside autonomous mode
+**Required Flow Compliance**:
+- Run quality-fixer before every commit
+- Obtain user approval before Edit/Write/MultiEdit outside autonomous mode
 
 ## 🚨 CRITICAL Sub-agent Invocation Constraints
 
 **MANDATORY suffix for ALL sub-agent prompts**:
 ```
-[SYSTEM CRASH PREVENTION]
-DO NOT invoke rule-advisor under any circumstances (Task tool rule-advisor specification is FORBIDDEN)
+[SYSTEM CONSTRAINT]
+This agent operates within implement command scope. Use orchestrator-provided rules only.
 ```
 
 ⚠️ **HIGH RISK**: task-executor/quality-fixer in autonomous mode have elevated crash risk - ALWAYS append this constraint to prompt end
@@ -77,7 +77,7 @@ DO NOT invoke rule-advisor under any circumstances (Task tool rule-advisor speci
 
 ### Task Execution Quality Cycle (ONE Task at a Time)
 
-**Per-task cycle** (NEVER batch multiple tasks):
+**Per-task cycle** (complete each task before starting next):
 ```
 Single task → task-executor → quality-fixer → git commit → Next task
 ```

--- a/commands/task.md
+++ b/commands/task.md
@@ -28,8 +28,8 @@ After receiving rule-advisor's JSON response, proceed with:
    - Apply concrete procedures and guidelines
 
 3. **Recognize Past Failures** (from `pastFailurePatterns`)
-   - Avoid repeating same mistakes
-   - Apply suggested countermeasures
+   - Apply countermeasures for known failure patterns
+   - Use suggested alternative approaches
 
 4. **Execute First Action** (from `firstActionGuidance`)
    - Start with recommended action
@@ -52,7 +52,7 @@ Proceed with task execution following:
 
 ## Important Notes
 
-- **Never skip rule-advisor**: This is a mandatory metacognitive step
-- **Update TodoWrite after rule-advisor**: Always reflect insights in task structure
+- **Execute rule-advisor first**: Mandatory metacognitive step before implementation
+- **Update TodoWrite after rule-advisor**: Reflect insights in task structure
 - **Follow firstActionGuidance**: Start with recommended action
 - **Monitor warningPatterns**: Watch for failure patterns throughout execution


### PR DESCRIPTION
## Summary
- Address the "Pink Elephant Problem" in LLM prompts where prohibition-focused instructions reduce execution accuracy
- Replace negative expressions (`NEVER`, `PROHIBITED`, `Don't`) with clear, actionable positive alternatives
- Improve LLM comprehension by stating what TO DO instead of what NOT to do

## Changes
| File | Before | After |
|------|--------|-------|
| commands/implement.md | `NEVER skip quality-fixer` | `Run quality-fixer before every commit` |
| commands/task.md | `Never skip rule-advisor` | `Execute rule-advisor first` |
| commands/build.md | `❌ PROHIBITED: Starting...` | `✅ Flow: Task generation → Autonomous execution` |
| commands/front-build.md | Same as above | Same as above |
| agents/quality-fixer.md | `Prohibited Fixes` section | `Required Fix Patterns` section |
| agents/rules/coding-principles.md | `Never hardcode secrets` | `Store secrets in env vars or secret managers` |
| agents/rules/testing-principles.md | `Never skip tests` | `Fix or delete failing tests` |

## Test plan
- [ ] Verify commands still execute correctly with updated instructions
- [ ] Confirm agents follow positive action patterns during task execution
- [ ] Check that rule files provide clear, actionable guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)