### PR TITLE
chore: bump version to 0.3.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-workflows",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "owner": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/backend/.claude-plugin/plugin.json
+++ b/backend/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-workflows",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Professional development workflows for Claude Code - Language-agnostic best practices, specialized agents, and quality assurance patterns for building production-ready software",
   "author": {
     "name": "Shinsuke Kagawa",

--- a/frontend/.claude-plugin/plugin.json
+++ b/frontend/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-workflows-frontend",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Professional frontend development workflows for Claude Code - React/TypeScript specialized agents, commands, and quality patterns for building production-ready web applications",
   "author": {
     "name": "Shinsuke Kagawa",


### PR DESCRIPTION
## Summary
- Bump version from 0.3.2 to 0.3.3 across all plugin manifests

## Files Changed
- `.claude-plugin/marketplace.json`
- `backend/.claude-plugin/plugin.json`
- `frontend/.claude-plugin/plugin.json`

## Test plan
- [ ] Verify plugin installation works with new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)