### PR TITLE
feat: add shallow thinking suppression elements to templates and reviewer

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-workflows",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "owner": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/agents/document-reviewer.md
+++ b/agents/document-reviewer.md
@@ -44,6 +44,7 @@ Before starting work, be sure to read and follow these rule files:
 2. **Implementation consistency**: Code examples MUST strictly comply with coding-principles.md standards, interface definition alignment
 3. **Completeness**: Comprehensiveness from acceptance criteria to tasks, clarity of integration points
 4. **Common ADR compliance**: Coverage of common technical areas, appropriateness of references
+5. **Failure scenario review**: Coverage of scenarios where the design could fail
 
 ## Workflow
 
@@ -63,7 +64,8 @@ Before starting work, be sure to read and follow these rule files:
 - Rule compliance check: Compatibility with project rules
 - Feasibility check: Technical and resource perspectives
 - Assessment consistency check: Verify alignment between scale assessment and document requirements
-- **Technical information verification**: When sources exist, verify with WebSearch for latest information and validate claim validity
+- Technical information verification: When sources exist, verify with WebSearch for latest information and validate claim validity
+- Failure scenario review: Identify failure scenarios across normal usage, high load, and external failures
 
 #### Perspective-specific Mode
 - Implement review based on specified mode and focus
@@ -103,7 +105,12 @@ Structured markdown including the following sections:
 - [ ] Clarification of risks and countermeasures
 - [ ] Consistency with existing systems
 - [ ] Fulfillment of approval conditions
-- [ ] **Verification of sources for technical claims and consistency with latest information**
+- [ ] Verification of sources for technical claims and consistency with latest information
+- [ ] Failure scenario coverage
+
+## Failure Scenario Review
+
+Identify at least one failure scenario for each of the three categories—normal usage, high load, and external failures—and specify which design element becomes the bottleneck.
 
 ## Review Criteria (for Comprehensive Mode)
 

--- a/agents/templates/adr-template.md
+++ b/agents/templates/adr-template.md
@@ -12,6 +12,16 @@
 
 [Describe the actual decision made. Aim for specific and clear descriptions]
 
+### Decision Details
+
+| Item | Content |
+|------|---------|
+| **Decision** | [The decision in one sentence] |
+| **Why now** | [Why this needs to happen now (timing rationale)] |
+| **Why this** | [Why this option over alternatives (1-3 lines)] |
+| **Known unknowns** | [At least one uncertainty at this point] |
+| **Kill criteria** | [One signal that should trigger reversal of this decision] |
+
 ## Rationale
 
 [Explain why this decision was made and why it is the best option compared to alternatives]
@@ -47,7 +57,7 @@
 ## Implementation Guidance
 
 [Principled direction only. Implementation procedures go to Design Doc]
-Examples: "Use parameterized dependencies" ✓, "Prefer pure functions" ✓, "Implement in Phase 1" ✗
+Example: "Use dependency injection" ✓, "Implement in Phase 1" ✗
 
 ## Related Information
 

--- a/agents/templates/design-template.md
+++ b/agents/templates/design-template.md
@@ -4,6 +4,22 @@
 
 [Explain the purpose and overview of this feature in 2-3 sentences]
 
+## Design Summary (Meta)
+
+```yaml
+design_type: "new_feature|extension|refactoring"
+risk_level: "low|medium|high"
+main_constraints:
+  - "[constraint 1]"
+  - "[constraint 2]"
+biggest_risks:
+  - "[risk 1]"
+  - "[risk 2]"
+unknowns:
+  - "[uncertainty 1]"
+  - "[uncertainty 2]"
+```
+
 ## Background and Context
 
 ### Prerequisite ADRs

--- a/agents/templates/prd-template.md
+++ b/agents/templates/prd-template.md
@@ -29,8 +29,11 @@ So that [expected value/benefit]
 
 ### Must Have (MVP)
 - [ ] Requirement 1: [Detailed description]
+  - AC: [Acceptance criteria - Given/When/Then format or measurable standard]
 - [ ] Requirement 2: [Detailed description]
+  - AC: [Acceptance criteria]
 - [ ] Requirement 3: [Detailed description]
+  - AC: [Acceptance criteria]
 
 ### Nice to Have
 - [ ] Requirement 1: [Detailed description]
@@ -78,11 +81,22 @@ So that [expected value/benefit]
 - [Technical constraints]
 - [Resource constraints]
 
+### Assumptions
+- [Prerequisite requiring validation 1]
+- [Prerequisite requiring validation 2]
+
 ### Risks and Mitigation
 | Risk | Impact | Probability | Mitigation |
 |------|--------|-------------|------------|
 | [Risk 1] | High/Medium/Low | High/Medium/Low | [Countermeasure] |
 | [Risk 2] | High/Medium/Low | High/Medium/Low | [Countermeasure] |
+
+## Undetermined Items
+
+- [ ] [Question 1]: [Description of options or impacts]
+- [ ] [Question 2]: [Description of options or impacts]
+
+*Discuss with user until this section is empty, then delete after confirmation*
 
 ## Appendix
 

--- a/backend/.claude-plugin/plugin.json
+++ b/backend/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-workflows",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Professional development workflows for Claude Code - Language-agnostic best practices, specialized agents, and quality assurance patterns for building production-ready software",
   "author": {
     "name": "Shinsuke Kagawa",

--- a/frontend/.claude-plugin/plugin.json
+++ b/frontend/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-workflows-frontend",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Professional frontend development workflows for Claude Code - React/TypeScript specialized agents, commands, and quality patterns for building production-ready web applications",
   "author": {
     "name": "Shinsuke Kagawa",


### PR DESCRIPTION
## Summary

Add metacognitive elements to prevent shallow LLM exploration during document creation and review.

### Template Changes

| Template | Changes |
|----------|---------|
| **ADR** | Add "Decision Details" section (Why now, Why this, Known unknowns, Kill criteria) |
| **ADR** | Simplify Implementation Guidance example to reduce anchoring bias |
| **Design Doc** | Add "Design Summary (Meta)" section with risk/constraints/unknowns |
| **PRD** | Add acceptance criteria notation to Must Have requirements |
| **PRD** | Add "Assumptions" and "Undetermined Items" sections |

### Document Reviewer Changes

- Add "Failure scenario review" as 5th parallel verification item
- Add failure scenario review to comprehensive review workflow
- Add failure scenario coverage to review checklist
- Add dedicated "Failure Scenario Review" section requiring identification of failure scenarios across:
  - Normal usage
  - High load
  - External failures

## Why

LLMs tend to explore solutions superficially without acknowledging uncertainties or failure modes. These additions force explicit consideration of:
- **Known unknowns**: What we don't know yet
- **Kill criteria**: When to reverse a decision
- **Failure scenarios**: How designs can fail under different conditions

## Test plan

- [ ] Verify ADR template renders correctly with new Decision Details table
- [ ] Verify Design Doc template renders correctly with Design Summary (Meta) YAML block
- [ ] Verify PRD template renders correctly with new sections
- [ ] Verify document-reviewer correctly checks for failure scenarios during review

🤖 Generated with [Claude Code](https://claude.com/claude-code)