### PR TITLE
feat: add tautology test detection criterion

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-workflows",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "owner": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/agents/rules/testing-principles.md
+++ b/agents/rules/testing-principles.md
@@ -282,6 +282,7 @@ These criteria ensure reliable, maintainable tests.
 - Use hardcoded literal values in assertions
 - Calculate expected values independently from the implementation
 - If the implementation has a bug, the test catches it through independent verification
+- If expected value equals mock return value unchanged, the test verifies nothing (no transformation occurred)
 
 ### Result-Based Verification
 

--- a/backend/.claude-plugin/plugin.json
+++ b/backend/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-workflows",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Professional development workflows for Claude Code - Language-agnostic best practices, specialized agents, and quality assurance patterns for building production-ready software",
   "author": {
     "name": "Shinsuke Kagawa",

--- a/frontend/.claude-plugin/plugin.json
+++ b/frontend/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-workflows-frontend",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Professional frontend development workflows for Claude Code - React/TypeScript specialized agents, commands, and quality patterns for building production-ready web applications",
   "author": {
     "name": "Shinsuke Kagawa",


### PR DESCRIPTION
## Summary
- Add positive criterion for detecting tautology tests to `testing-principles.md`
- Bump version from 0.6.1 to 0.6.2

## Changes

### Testing Principles Enhancement
Added to "Literal Expected Values" section:
```
If expected value equals mock return value unchanged, the test verifies nothing (no transformation occurred)
```

This criterion enables AI to detect tautology tests (where mock return value is directly used as expected value) using **positive criteria** rather than listing antipatterns (avoiding pink elephant problem).

### Version Bump
- `.claude-plugin/marketplace.json`: 0.6.1 → 0.6.2
- `backend/.claude-plugin/plugin.json`: 0.6.1 → 0.6.2
- `frontend/.claude-plugin/plugin.json`: 0.6.1 → 0.6.2

## Why
Ported from [ai-coding-project-boilerplate#101](https://github.com/shinpr/ai-coding-project-boilerplate/pull/101), adapted to be language-agnostic for this repository.

## Test plan
- [ ] Verify AI can detect tautology tests using the new criterion

🤖 Generated with [Claude Code](https://claude.com/claude-code)