### PR TITLE
refactor: remove rule-advisor references from task-analyzer skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-workflows",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "owner": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/backend/.claude-plugin/plugin.json
+++ b/backend/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-workflows",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Professional development workflows for Claude Code - Language-agnostic best practices, specialized agents, and quality assurance patterns for building production-ready software",
   "author": {
     "name": "Shinsuke Kagawa",

--- a/frontend/.claude-plugin/plugin.json
+++ b/frontend/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-workflows-frontend",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Professional frontend development workflows for Claude Code - React/TypeScript specialized agents, commands, and quality patterns for building production-ready web applications",
   "author": {
     "name": "Shinsuke Kagawa",

--- a/skills/task-analyzer/SKILL.md
+++ b/skills/task-analyzer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: task-analyzer
-description: Metacognitive task analysis and skill selection. Analyzes task essence, estimates scale, and returns appropriate skills with metadata for rule-advisor to process.
+description: Metacognitive task analysis and skill selection. Analyzes task essence, estimates scale, and returns appropriate skills with metadata.
 ---
 
 # Task Analyzer
@@ -99,7 +99,7 @@ selectedSkills:
     sections: [...]  # All sections from yaml, unfiltered
 ```
 
-**Note**: Section selection (choosing which sections are relevant) is done by rule-advisor after reading the actual SKILL.md files.
+**Note**: Section selection (choosing which sections are relevant) is done after reading the actual SKILL.md files.
 
 ## Skill Selection Priority
 

--- a/skills/task-analyzer/references/skills-index.yaml
+++ b/skills/task-analyzer/references/skills-index.yaml
@@ -1,5 +1,5 @@
 # Skills Metadata Index
-# Used by rule-advisor to select appropriate skills based on task analysis
+# Used to select appropriate skills based on task analysis
 
 skills:
   coding-principles:


### PR DESCRIPTION
## Summary
- Remove rule-advisor references from task-analyzer skill for better loose coupling
- Skills should describe WHAT they do, not WHO uses them
- Bump version to 0.7.2

## Changes
- `skills/task-analyzer/SKILL.md`: Remove "for rule-advisor to process" and "by rule-advisor"
- `skills/task-analyzer/references/skills-index.yaml`: Remove "by rule-advisor" from comment
- Version bump: 0.7.1 → 0.7.2

## Rationale
Skills are standalone units that may be used in various contexts. Having explicit references to specific agents (like rule-advisor) reduces reusability and creates implicit coupling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)