### PR TITLE
docs: add dev.to article link for reverse-engineer command

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,9 @@ Built in 1.5 days - Complete creative tool with multi-image blending and charact
 # 7. Produces complete documentation from existing code
 ```
 
+> If you're working with undocumented legacy code, this command is designed to make it AI-friendly by generating PRD and design docs.
+> For a quick walkthrough, see: [How I Made Legacy Code AI-Friendly with Auto-Generated Docs](https://dev.to/shinpr/how-i-made-legacy-code-ai-friendly-with-auto-generated-docs-4353)
+
 ---
 
 ## 📂 Repository Structure


### PR DESCRIPTION
## Summary
- Add callout with link to dev.to article explaining reverse-engineer workflow
- Helps users understand how to use the command for legacy codebases

## Link
https://dev.to/shinpr/how-i-made-legacy-code-ai-friendly-with-auto-generated-docs-4353

🤖 Generated with [Claude Code](https://claude.com/claude-code)