### PR TITLE
feat(diagnose): enhance diagnostic framework with multi-cause support and confidence loop

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-workflows",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "owner": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/agents/investigator.md
+++ b/agents/investigator.md
@@ -17,6 +17,8 @@ You are an AI assistant specializing in problem investigation.
 
 - **Input**: Accepts both text and JSON formats. For JSON, use `problemSummary`
 - **Unclear input**: Adopt the most reasonable interpretation and include "Investigation target: interpreted as ~" in output
+- **With investigationFocus input**: Collect evidence for each focus point and include in hypotheses or factualObservations
+- **Without investigationFocus input**: Execute standard investigation flow
 - **Out of scope**: Hypothesis verification, conclusion derivation, and solution proposals are handled by other agents
 
 ## Output Scope

--- a/agents/solver.md
+++ b/agents/solver.md
@@ -36,9 +36,14 @@ If there are doubts about the conclusion, only report the need for additional ve
 ### Step 1: Cause Understanding and Input Validation
 
 **For JSON format**:
-- Confirm cause from `conclusion.mostLikelyCause`
+- Confirm causes (may be multiple) from `conclusion.causes`
+- Confirm causes relationship from `conclusion.causesRelationship`
 - Confirm confidence from `conclusion.confidence`
-- Grasp remaining uncertainty from `conclusion.remainingUncertainty`
+
+**Causes Relationship Handling**:
+- independent: Derive separate solution for each cause
+- dependent: Solving root cause resolves derived causes
+- exclusive: One cause is true (others are incorrect)
 
 **For text format**:
 - Extract cause-related descriptions
@@ -48,7 +53,7 @@ If there are doubts about the conclusion, only report the need for additional ve
 **User Report Consistency Check**:
 - Example: "I changed A and B broke" → Does the conclusion explain that causal relationship?
 - Example: "The implementation is wrong" → Does the conclusion include design-level issues?
-- If inconsistent, add "Possible need to reconsider the cause" to uncertaintyHandling
+- If inconsistent, add "Possible need to reconsider the cause" to residualRisks
 
 **Approach Selection Based on impactAnalysis**:
 - impactScope empty, recurrenceRisk: low → Direct fix only
@@ -98,9 +103,11 @@ Recommendation strategy based on confidence:
 ```json
 {
   "inputSummary": {
-    "identifiedCause": "Verified cause",
-    "confidence": "high|medium|low",
-    "remainingUncertainty": ["Remaining uncertainty"]
+    "identifiedCauses": [
+      {"hypothesisId": "H1", "description": "Cause description", "status": "confirmed|probable|possible"}
+    ],
+    "causesRelationship": "independent|dependent|exclusive",
+    "confidence": "high|medium|low"
   },
   "solutions": [
     {
@@ -142,7 +149,7 @@ Recommendation strategy based on confidence:
     "criticalPoints": ["Points requiring special attention"]
   },
   "uncertaintyHandling": {
-    "ifCauseWrong": "What to do if the cause is wrong",
+    "residualRisks": ["Risks that may remain after resolution"],
     "monitoringPlan": "Monitoring plan after resolution"
   }
 }
@@ -154,7 +161,7 @@ Recommendation strategy based on confidence:
 - [ ] Analyzed tradeoffs for each solution
 - [ ] Selected recommendation and explained rationale
 - [ ] Created concrete implementation steps
-- [ ] Documented uncertainty handling methods
+- [ ] Documented residual risks
 - [ ] Verified solutions align with project rules or best practices
 - [ ] Verified input consistency with user report
 

--- a/agents/verifier.md
+++ b/agents/verifier.md
@@ -30,7 +30,7 @@ Solution derivation is out of scope for this agent.
 1. **Triangulation Supplementation** - Explore information sources not covered in the investigation to supplement results
 2. **ACH (Analysis of Competing Hypotheses)** - Generate alternative hypotheses beyond those listed in the investigation and evaluate consistency with evidence
 3. **Devil's Advocate** - Assume "the investigation results are wrong" and actively seek refutation
-4. **Conclusion Derivation** - Derive conclusion as "the least refuted hypothesis"
+4. **Conclusion Derivation** - Adopt unrefuted hypotheses as causes and determine relationship when multiple
 
 ## Execution Steps
 
@@ -95,7 +95,7 @@ Classify each hypothesis by the following levels:
 - Example: "The implementation is wrong" → Was design_gap considered?
 - If inconsistent, explicitly note "Investigation focus may be misaligned with user report"
 
-**Conclusion**: Derive as "the least refuted hypothesis" and output in JSON format
+**Conclusion**: Adopt unrefuted hypotheses as causes. When multiple causes exist, determine their relationship (independent/dependent/exclusive) and output in JSON format
 
 ## Confidence Determination Criteria
 
@@ -160,10 +160,12 @@ Classify each hypothesis by the following levels:
     }
   ],
   "conclusion": {
-    "mostLikelyCause": "The least refuted hypothesis",
+    "causes": [
+      {"hypothesisId": "H1", "status": "confirmed|probable|possible"}
+    ],
+    "causesRelationship": "independent|dependent|exclusive",
     "confidence": "high|medium|low",
     "confidenceRationale": "Rationale for confidence level",
-    "alternativesToConsider": ["Alternative hypotheses still to consider"],
     "recommendedVerification": ["Additional verification needed to confirm conclusion"]
   },
   "verificationLimitations": ["Limitations of this verification process"]
@@ -179,7 +181,7 @@ Classify each hypothesis by the following levels:
 - [ ] Lowered confidence for hypotheses with official documentation-based counter-evidence
 - [ ] Verified consistency with user report
 - [ ] Determined verification level for each hypothesis
-- [ ] Derived final conclusion as "the least refuted hypothesis"
+- [ ] Adopted unrefuted hypotheses as causes and determined relationship when multiple
 
 ## Prohibited Actions
 

--- a/backend/.claude-plugin/plugin.json
+++ b/backend/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-workflows",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Skills + Subagents for backend development - Use skills for coding guidance, or run commands for full orchestrated agentic coding with 17 specialized agents",
   "author": {
     "name": "Shinsuke Kagawa",

--- a/frontend/.claude-plugin/plugin.json
+++ b/frontend/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-workflows-frontend",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Skills + Subagents for React/TypeScript - Use skills for coding guidance, or run commands for full orchestrated agentic coding with 14 specialized agents",
   "author": {
     "name": "Shinsuke Kagawa",


### PR DESCRIPTION
## Summary
- Add multi-cause support: verifier now outputs causes array with relationship type (independent/dependent/exclusive)
- Add confidence loop: diagnosis iterates up to 2 times until high confidence is achieved
- Add rule-advisor integration: diagnose invokes rule-advisor before investigation to identify problem essence
- Add investigation focus: pass targeted focus points to investigator for more precise evidence collection
- Add design_gap escalation: prompt user confirmation when design-level issues are detected
- Replace ifCauseWrong with residualRisks for clearer post-resolution risk documentation

## Test plan
- [ ] Verify diagnose command invokes rule-advisor before investigator
- [ ] Test investigationFocus is passed correctly to investigator
- [ ] Verify verifier outputs causes array with relationship
- [ ] Test confidence loop triggers re-investigation when confidence < high
- [ ] Verify design_gap escalation prompts user confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)