### PR TITLE
feat(design): add complexity gate for over-engineering detection

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-workflows",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "owner": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/agents/document-reviewer.md
+++ b/agents/document-reviewer.md
@@ -210,6 +210,7 @@ Include in output when `prior_context_count > 0`:
 - [ ] Fulfillment of approval conditions
 - [ ] Verification of sources for technical claims and consistency with latest information
 - [ ] Failure scenario coverage
+- [ ] Complexity justification: If complexity_level is medium/high, complexity_rationale must specify (1) requirements/ACs necessitating the complexity, (2) constraints/risks it addresses
 
 ## Review Criteria (for Comprehensive Mode)
 
@@ -233,6 +234,7 @@ Include in output when `prior_context_count > 0`:
 - Serious rule violations (severity: high)
 - Blocking issues present
 - Prior context items (if any): 2+ major unresolved OR any critical unresolved
+- complexity_level is medium/high but complexity_rationale lacks (1) requirements/ACs or (2) constraints/risks
 
 ### Rejected
 - Fundamental problems exist

--- a/agents/technical-designer-frontend.md
+++ b/agents/technical-designer-frontend.md
@@ -360,6 +360,7 @@ class Button extends React.Component {
 - [ ] Props change matrix completeness
 - [ ] Implementation approach selection rationale (vertical/horizontal/hybrid)
 - [ ] Latest React best practices researched and references cited
+- [ ] **Complexity assessment**: complexity_level set; if medium/high, complexity_rationale specifies (1) requirements/ACs, (2) constraints/risks
 
 ## Acceptance Criteria Creation Guidelines
 

--- a/agents/technical-designer.md
+++ b/agents/technical-designer.md
@@ -294,6 +294,7 @@ Implementation sample creation checklist:
 - [ ] Interface change matrix completeness
 - [ ] Implementation approach selection rationale (vertical/horizontal/hybrid)
 - [ ] Latest best practices researched and references cited
+- [ ] **Complexity assessment**: complexity_level set; if medium/high, complexity_rationale specifies (1) requirements/ACs, (2) constraints/risks
 
 
 ## Acceptance Criteria Creation Guidelines

--- a/backend/.claude-plugin/plugin.json
+++ b/backend/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-workflows",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Skills + Subagents for backend development - Use skills for coding guidance, or run commands for full orchestrated agentic coding with 17 specialized agents",
   "author": {
     "name": "Shinsuke Kagawa",

--- a/frontend/.claude-plugin/plugin.json
+++ b/frontend/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-workflows-frontend",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Skills + Subagents for React/TypeScript - Use skills for coding guidance, or run commands for full orchestrated agentic coding with 14 specialized agents",
   "author": {
     "name": "Shinsuke Kagawa",

--- a/skills/documentation-criteria/references/design-template.md
+++ b/skills/documentation-criteria/references/design-template.md
@@ -9,6 +9,8 @@
 ```yaml
 design_type: "new_feature|extension|refactoring"
 risk_level: "low|medium|high"
+complexity_level: "low|medium|high"
+complexity_rationale: "[Required if medium/high: (1) which requirements/ACs necessitate this complexity, (2) which constraints/risks it addresses]"
 main_constraints:
   - "[constraint 1]"
   - "[constraint 2]"


### PR DESCRIPTION
## Summary
- Add `complexity_level` and `complexity_rationale` fields to Design Doc template
- Add complexity justification check to document-reviewer checklist and Needs Revision criteria
- Add complexity assessment to technical-designer checklist

## Rationale
Existing workflow has YAGNI/simplicity principles in skills but lacks an explicit gate at design review stage. This change adds a structured check: when `complexity_level` is medium/high, `complexity_rationale` must specify:
1. Which requirements/ACs necessitate the complexity
2. Which constraints/risks it addresses

## Test plan
- [ ] Verify Design Doc template includes new fields
- [ ] Verify document-reviewer applies complexity check during review
- [ ] Verify technical-designer checklist includes complexity assessment

🤖 Generated with [Claude Code](https://claude.com/claude-code)