### PR TITLE
fix: remove command reference from subagents-orchestration-guide

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-workflows",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "owner": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/backend/.claude-plugin/plugin.json
+++ b/backend/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-workflows",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Skills + Subagents for backend development - Use skills for coding guidance, or run commands for full orchestrated agentic coding with 18 specialized agents",
   "author": {
     "name": "Shinsuke Kagawa",

--- a/frontend/.claude-plugin/plugin.json
+++ b/frontend/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-workflows-frontend",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Skills + Subagents for React/TypeScript - Use skills for coding guidance, or run commands for full orchestrated agentic coding with 16 specialized agents",
   "author": {
     "name": "Shinsuke Kagawa",

--- a/skills/subagents-orchestration-guide/SKILL.md
+++ b/skills/subagents-orchestration-guide/SKILL.md
@@ -202,32 +202,6 @@ According to scale determination:
 1. Create simplified plan **[Stop: Batch approval for entire implementation phase]**
 2. **Start autonomous execution mode**: Direct implementation → Completion report
 
-## Existing Codebase Test Addition Flow
-
-For existing backend implementations (e.g., after reverse-engineer), use the dedicated test addition workflow via `/add-integration-tests` command.
-
-### When to Use
-- Design Doc exists but tests are missing
-- After reverse-engineer completes PRD/Design Doc generation
-- Adding test coverage to legacy backend code
-
-### Flow
-1. **[Stop: Confirm Design Doc path]**
-2. acceptance-test-generator → Generate test skeletons
-3. Create task file → `docs/plans/tasks/integration-tests-YYYYMMDD.md`
-4. task-executor → Implement tests following task file
-5. integration-test-reviewer → Review test quality
-   - If `needs_revision` → Return to step 4
-6. quality-fixer → Final quality check
-7. git commit → Commit test files
-8. Completion report
-
-### Key Differences from Standard Flow
-- No implementation phase (code already exists)
-- Uses task file for test implementation (same pattern as review.md)
-- Mandatory integration-test-reviewer step
-- Backend only (acceptance-test-generator limitation)
-
 ## Autonomous Execution Mode
 
 ### Pre-Execution Environment Check


### PR DESCRIPTION
## Summary
- Remove "Existing Codebase Test Addition Flow" section from subagents-orchestration-guide skill
- This section referenced `/add-integration-tests` command, violating single responsibility principle
- Skills should not know about specific commands; command files should be self-contained

## Test plan
- [ ] Verify skill file no longer references any commands
- [ ] Verify command file (`commands/add-integration-tests.md`) remains functional and self-contained

🤖 Generated with [Claude Code](https://claude.com/claude-code)