### PR TITLE
feat: add Fact Disposition framework for codebase-analysis-to-design traceability

### DIFF
--- a/agents/codebase-analyzer.md
+++ b/agents/codebase-analyzer.md
@@ -75,7 +75,7 @@ For each file in `affectedFiles`:
    - File path and line number for each element
 4. **Map access patterns to schemas**: For each data access operation from Step 2, identify which schema it targets and what operation it performs (read, write, aggregate, join)
 
-### Step 4: Constraint and Assumption Extraction
+### Step 4: Constraint, Disposition Targets, and Assumption Extraction
 
 For each element discovered in Steps 2-3:
 
@@ -83,8 +83,9 @@ For each element discovered in Steps 2-3:
 2. **Business rules**: Extract rules embedded in code logic (conditional branches that enforce domain invariants)
 3. **Configuration dependencies**: Identify referenced config values, environment variables, feature flags
 4. **Hardcoded assumptions**: Note magic numbers, string literals with domain meaning, implicit dependencies
-5. **Existing test coverage**: Glob for test files matching each affected file. Record which elements have test coverage
-6. **Quality assurance mechanisms**: Identify how quality is enforced in the affected area
+5. **Disposition targets** (populated into `focusAreas`): Enumerate every existing fact within the change scope that the design must explicitly address. Group related facts into one focus area per coherent unit (e.g., one function with its callers; one data structure with its branches/cases; one external dependency with its usages). Each focus area aggregates: input fields, call sites/consumers, branching cases that produce distinct observable outcomes, data shapes, error paths, external dependencies, operational cases. Generate `fact_id` with this format: `<repo-relative-primary-file-path>:<primary-symbol-or-focus-area-label>` using the main file anchoring the fact set and the exact symbol name when one exists; otherwise use a short normalized focus-area label. Cardinality target: 5-15 entries for typical changes; group more aggressively if exceeding 20.
+6. **Existing test coverage**: Glob for test files matching each affected file. Record which elements have test coverage
+7. **Quality assurance mechanisms**: Identify how quality is enforced in the affected area
    - Grep for linter configuration files, CI workflow definitions, and static analysis configs that cover the affected files
    - Check if affected files are subject to domain-specific tools (e.g., schema validators, API spec validators, configuration file linters) by examining CI pipelines and pre-commit hooks
    - Identify domain-specific constraints (naming conventions, length limits, format requirements) from configuration files, CI checks, or documented standards
@@ -187,10 +188,11 @@ Return the JSON result as the final response. See Output Format for the schema.
   },
   "focusAreas": [
     {
-      "area": "Brief area name",
-      "reason": "Why the designer should pay attention to this",
-      "relatedFiles": ["path/to/file1"],
-      "risk": "What could go wrong if this is overlooked in the design"
+      "fact_id": "src/auth/createUser.ts:createUser",
+      "area": "Brief area name (one coherent unit of existing facts)",
+      "evidence": "existingElements[name=X] | constraints[location=file:line] | file:line",
+      "factsToAddress": "Concrete facts the designer must address (e.g., 'Function X is called by [a, b, c]'; 'Method Y branches into 4 outcome cases: case1...case4'; 'Field Z accepts values [v1, v2, v3]')",
+      "risk": "What goes wrong if these facts are omitted or contradicted by the design"
     }
   ],
   "testCoverage": {
@@ -213,7 +215,7 @@ Return the JSON result as the final response. See Output Format for the schema.
 - [ ] Extracted constraints with file:line evidence
 - [ ] Identified quality assurance mechanisms (linters, CI checks, domain-specific validators) covering affected files
 - [ ] Recorded domain-specific constraints (naming, length, format) from configuration or CI
-- [ ] Generated focus areas with risk descriptions
+- [ ] Generated focus areas as disposition targets (each entry aggregates a coherent unit of existing facts the designer must address; cardinality consolidated to ≤ ~15)
 - [ ] Checked test coverage for discovered elements
 - [ ] Final response is the JSON output
 
@@ -222,7 +224,7 @@ Return the JSON result as the final response. See Output Format for the schema.
 - [ ] All file paths verified to exist using Glob/Read
 - [ ] All signatures and names transcribed exactly from code (no normalization or correction)
 - [ ] Schema field names match actual definitions (not inferred from similar tables)
-- [ ] Each focus area cites specific files and concrete risks
+- [ ] Each focus area includes a stable `fact_id`, cites `evidence` (file:line or `existingElements`/`constraints` reference), enumerates `factsToAddress`, and states the `risk` of omission
 - [ ] `dataModel.detected` accurately reflects whether data operations were found
 - [ ] `dataTransformationPipelines` populated for every entry point that transforms data (empty array only when no transformations exist)
 - [ ] Each pipeline step's `externalLookups` lists all master table / config / constant references that modify output values

--- a/agents/design-sync.md
+++ b/agents/design-sync.md
@@ -83,6 +83,7 @@ Read the Design Doc specified in arguments and extract:
 - **Path identifiers**: URL paths, route definitions, API endpoints, config keys, file paths
 - **Integration points**: References to components, endpoints, or resources defined in other documents (e.g., service method calls, shared type imports, referenced route destinations)
 - **Acceptance criteria**: Specific conditions for functional requirements
+- **Fact dispositions**: Rows from the "Fact Disposition Table" — extract `(fact_id, disposition)` pairs. The `fact_id` value serves as the primary identifier for cross-document matching. `evidence` is supporting context only.
 
 **Extraction Output** (per item):
 ```yaml
@@ -110,6 +111,7 @@ Read the Design Doc specified in arguments and extract:
 |--------------|----------|----------|
 | **Type definition mismatch** | Same type/interface name, different properties or field types | critical |
 | **Path/integration point conflict** | Same or equivalent path/integration identifier, different target/method/handler | critical |
+| **Disposition conflict** | Same `fact_id` value across Fact Disposition Tables, different `disposition` value (e.g., one DD says `remove`, another says `preserve`) | critical |
 | **Numeric parameter mismatch** | Same config key, different value | high |
 | **Acceptance criteria conflict** | Same AC identifier or slot, different conditions or thresholds | high |
 | **Term definition mismatch** | Same term string, different definition text | medium |
@@ -309,4 +311,3 @@ Endpoint: POST /api/accounts/signup
 - All target files have been read
 - Structured markdown output completed
 - All quality checklist items verified
-

--- a/agents/document-reviewer.md
+++ b/agents/document-reviewer.md
@@ -34,7 +34,7 @@ You are an AI assistant specialized in technical document review.
   - When provided, incorporate as pre-verified evidence in Gate 1 quality assessment
   - Discrepancies and reverse coverage gaps inform consistency and completeness checks
 
-- **codebase_analysis**: Codebase analysis JSON from codebase-analyzer (optional, DesignDoc review)
+- **codebase_analysis**: Codebase analysis JSON (optional, DesignDoc review)
   - When provided, use `focusAreas` as the canonical source for Fact Disposition coverage checks
   - Without this input, do not assume focusArea completeness can be verified
 

--- a/agents/document-reviewer.md
+++ b/agents/document-reviewer.md
@@ -34,6 +34,10 @@ You are an AI assistant specialized in technical document review.
   - When provided, incorporate as pre-verified evidence in Gate 1 quality assessment
   - Discrepancies and reverse coverage gaps inform consistency and completeness checks
 
+- **codebase_analysis**: Codebase analysis JSON from codebase-analyzer (optional, DesignDoc review)
+  - When provided, use `focusAreas` as the canonical source for Fact Disposition coverage checks
+  - Without this input, do not assume focusArea completeness can be verified
+
 ## Review Modes
 
 ### Composite Perspective Review (composite) - Recommended
@@ -61,6 +65,7 @@ You are an AI assistant specialized in technical document review.
 - For DesignDoc: Verify "Applicable Standards" section exists with explicit/implicit classification
   - Missing or incomplete → `critical` issue; implicit standards without confirmation → `important` issue
 - If `code_verification` provided: extract discrepancy list and reverse coverage gaps; feed into Gate 1 as pre-verified evidence
+- If `codebase_analysis` provided: extract `focusAreas` and their `evidence` values for Gate 0 / Gate 1 Fact Disposition checks
 
 ### Step 2: Target Document Collection
 - Load document specified by target
@@ -77,6 +82,7 @@ For DesignDoc, additionally verify:
 - [ ] Applicable standards listed with explicit/implicit classification
 - [ ] Field propagation map present (when fields cross boundaries)
 - [ ] Verification Strategy section present with: correctness definition, verification method, verification timing, early verification point
+- [ ] Fact Disposition Table present and covers every `codebase_analysis.focusAreas` entry (when `codebase_analysis` is provided)
 
 #### Gate 1: Quality Assessment (only after Gate 0 passes)
 
@@ -96,6 +102,7 @@ For DesignDoc, additionally verify:
 - **Code verification integration**: When `code_verification` input is provided, each item in `undocumentedDataOperations` absent from the document → `important` issue (category: `completeness`). Each discrepancy from code verification with severity `critical` or `major` → incorporate as pre-verified evidence in the corresponding review check
 - **Verification Strategy quality check**: When Verification Strategy section exists, verify: (1) Correctness definition is specific and measurable — "tests pass" without specifying which tests or what they verify → `important` issue (category: `completeness`). (2) Verification method is sufficient for the change's risk and dependency type — method that cannot detect the primary risk category (e.g., schema correctness, behavioral equivalence, integration compatibility) → `important` issue (category: `consistency`). (3) Early verification point identifies a concrete first target — "TBD" or "final phase" → `important` issue (category: `completeness`). (4) When vertical slice is selected, verification timing deferred entirely to final phase → `important` issue (category: `consistency`)
 - **Output comparison check**: When the Design Doc describes replacing or modifying existing behavior, verify that a concrete output comparison method is defined (identical input, expected output fields/format, diff method). Missing output comparison for behavior-replacing changes → `critical` issue (category: `completeness`). When codebase analysis `dataTransformationPipelines` are referenced, verify each pipeline step's output is covered by the comparison — uncovered steps → `important` issue (category: `completeness`)
+- **Fact disposition completeness check**: When `codebase_analysis` is provided, every entry in `focusAreas` requires a corresponding row in the Fact Disposition Table. Missing rows → `critical` issue (category: `completeness`). `fact_id` missing or not carrying through the focusArea's `fact_id` value → `critical` issue (category: `consistency`). Disposition value other than `preserve` / `transform` / `remove` / `out-of-scope` → `important` issue (category: `consistency`). Rationale missing for `transform` / `remove` / `out-of-scope` → `important` issue (category: `completeness`). Evidence column not carrying through the focusArea's evidence value → `important` issue (category: `consistency`)
 
 **Perspective-specific Mode**:
 - Implement review based on specified mode and focus
@@ -254,6 +261,7 @@ Include in output when `prior_context_count > 0`:
 - [ ] Verification Strategy present with concrete correctness definition and early verification point
 - [ ] Verification Strategy aligns with design_type and implementation approach
 - [ ] Output comparison defined when design replaces/modifies existing behavior (covers all transformation pipeline steps)
+- [ ] Fact Disposition Table covers every `codebase_analysis.focusAreas` entry (when `codebase_analysis` is provided)
 
 ## Review Criteria (for Comprehensive Mode)
 

--- a/agents/technical-designer-frontend.md
+++ b/agents/technical-designer-frontend.md
@@ -61,14 +61,14 @@ Must be performed before Design Doc creation:
    - Include dependency existence verification results (verified existing / requires new creation)
    - Record adopted decision (use existing/improvement proposal/new implementation) and rationale
 
-### Fact Disposition【Required when codebase-analyzer output is provided】
+### Fact Disposition【Required when Codebase Analysis input is provided】
 
-For every entry in `codebase-analyzer.focusAreas`, produce one row in the Design Doc's "Fact Disposition Table" section:
+For every entry in `Codebase Analysis.focusAreas`, produce one row in the Design Doc's "Fact Disposition Table" section:
 
 | Column | Content |
 |--------|---------|
-| Fact ID | The `fact_id` value from codebase-analyzer |
-| Focus Area | The `area` value from codebase-analyzer |
+| Fact ID | The `fact_id` value from the Codebase Analysis input |
+| Focus Area | The `area` value from the Codebase Analysis input |
 | Disposition | One of: `preserve` / `transform` / `remove` / `out-of-scope` |
 | Rationale | For `transform`: state new outcome. For `remove`: state reason. For `out-of-scope`: state which scope boundary excludes it. For `preserve`: brief confirmation. |
 | Evidence | The `evidence` value from the focusArea (carried through verbatim) |
@@ -184,7 +184,7 @@ When a UI Spec exists for the feature (`docs/ui-spec/{feature-name}-ui-spec.md`)
   - `constraints` → incorporate into design constraints and assumptions
   - Conduct additional investigation only for areas not covered by the analysis or flagged in `limitations`
 
-- **Prior-Layer Verification** (optional, fullstack flow only): When this Design Doc references contracts from a prior-layer Design Doc that has been verified by code-verifier, the verification result JSON is provided. Use it as follows:
+- **Prior-Layer Verification** (optional, fullstack flow only): When this Design Doc references contracts from a prior-layer Design Doc that has been through a verification step, the verification result JSON is provided. Use it as follows:
   - `discrepancies[]` → treat as known issues to resolve in this Design Doc, or escalate if out of scope for this layer
   - Do not infer verified claims beyond what the verifier output states explicitly; use the prior-layer Design Doc itself as reference context, not as proof of verification coverage
 - **PRD**: PRD document (if exists)
@@ -323,7 +323,7 @@ class Button extends React.Component {
 **All modes**:
 - [ ] **Standards identification gate completed** (required)
 - [ ] **Code inspection evidence recorded** (required)
-- [ ] **Fact Disposition Table covers every codebase-analyzer focusArea, each row with fact_id + disposition + rationale + evidence** (required when codebase-analyzer output is provided)
+- [ ] **Fact Disposition Table covers every Codebase Analysis focusArea, each row with fact_id + disposition + rationale + evidence** (required when Codebase Analysis input is provided)
 - [ ] **Integration points enumerated with contracts** (required)
 - [ ] **Props type contracts clarified** (required)
 - [ ] Component hierarchy and data flow clearly expressed in diagrams

--- a/agents/technical-designer-frontend.md
+++ b/agents/technical-designer-frontend.md
@@ -61,6 +61,20 @@ Must be performed before Design Doc creation:
    - Include dependency existence verification results (verified existing / requires new creation)
    - Record adopted decision (use existing/improvement proposal/new implementation) and rationale
 
+### Fact Disposition【Required when codebase-analyzer output is provided】
+
+For every entry in `codebase-analyzer.focusAreas`, produce one row in the Design Doc's "Fact Disposition Table" section:
+
+| Column | Content |
+|--------|---------|
+| Fact ID | The `fact_id` value from codebase-analyzer |
+| Focus Area | The `area` value from codebase-analyzer |
+| Disposition | One of: `preserve` / `transform` / `remove` / `out-of-scope` |
+| Rationale | For `transform`: state new outcome. For `remove`: state reason. For `out-of-scope`: state which scope boundary excludes it. For `preserve`: brief confirmation. |
+| Evidence | The `evidence` value from the focusArea (carried through verbatim) |
+
+The Fact Disposition Table is the single mechanism that binds existing-behavior facts to the design. Other Design Doc sections that describe existing behavior reference the corresponding Disposition Table row by Focus Area name.
+
 ### Integration Point Analysis【Important】
 Document all integration points with existing components in "## Integration Point Map" section:
 
@@ -164,11 +178,15 @@ When a UI Spec exists for the feature (`docs/ui-spec/{feature-name}-ui-spec.md`)
 - **Requirements Analysis Results**: Requirements analysis results (scale determination, technical requirements, etc.)
 - **Codebase Analysis** (optional, from codebase analysis phase):
   - When provided, use as the primary source for the "Existing Codebase Analysis" section
+  - `focusAreas` → produce the Fact Disposition Table (one row per focusArea, with fact_id + disposition + rationale + evidence)
   - `existingElements` → populate Implementation Path Mapping and Code Inspection Evidence
   - `dataModel` → populate data-related sections (schema references, data contracts)
-  - `focusAreas` → prioritize investigation depth on flagged areas
   - `constraints` → incorporate into design constraints and assumptions
   - Conduct additional investigation only for areas not covered by the analysis or flagged in `limitations`
+
+- **Prior-Layer Verification** (optional, fullstack flow only): When this Design Doc references contracts from a prior-layer Design Doc that has been verified by code-verifier, the verification result JSON is provided. Use it as follows:
+  - `discrepancies[]` → treat as known issues to resolve in this Design Doc, or escalate if out of scope for this layer
+  - Do not infer verified claims beyond what the verifier output states explicitly; use the prior-layer Design Doc itself as reference context, not as proof of verification coverage
 - **PRD**: PRD document (if exists)
 - **UI Spec**: UI Specification document (if exists, for frontend features)
 - **Documents to Create**: ADR, Design Doc, or both
@@ -305,6 +323,7 @@ class Button extends React.Component {
 **All modes**:
 - [ ] **Standards identification gate completed** (required)
 - [ ] **Code inspection evidence recorded** (required)
+- [ ] **Fact Disposition Table covers every codebase-analyzer focusArea, each row with fact_id + disposition + rationale + evidence** (required when codebase-analyzer output is provided)
 - [ ] **Integration points enumerated with contracts** (required)
 - [ ] **Props type contracts clarified** (required)
 - [ ] Component hierarchy and data flow clearly expressed in diagrams

--- a/agents/technical-designer.md
+++ b/agents/technical-designer.md
@@ -87,6 +87,20 @@ Must be performed before Design Doc creation:
    - Record all inspected files and key functions in "Code Inspection Evidence" section of Design Doc
    - Each entry must state relevance (similar functionality / integration point / pattern reference)
 
+### Fact Disposition【Required when codebase-analyzer output is provided】
+
+For every entry in `codebase-analyzer.focusAreas`, produce one row in the Design Doc's "Fact Disposition Table" section:
+
+| Column | Content |
+|--------|---------|
+| Fact ID | The `fact_id` value from codebase-analyzer |
+| Focus Area | The `area` value from codebase-analyzer |
+| Disposition | One of: `preserve` / `transform` / `remove` / `out-of-scope` |
+| Rationale | For `transform`: state new outcome. For `remove`: state reason. For `out-of-scope`: state which scope boundary excludes it. For `preserve`: brief confirmation. |
+| Evidence | The `evidence` value from the focusArea (carried through verbatim) |
+
+The Fact Disposition Table is the single mechanism that binds existing-behavior facts to the design. Other Design Doc sections that describe existing behavior reference the corresponding Disposition Table row by Focus Area name.
+
 ### Data Representation Decision【Required】
 When the design introduces or significantly modifies data structures:
 
@@ -208,12 +222,16 @@ Document state definitions and transitions for stateful components.
 - **Requirements Analysis Results**: Requirements analysis results (scale determination, technical requirements, etc.)
 - **Codebase Analysis** (optional, from codebase analysis phase):
   - When provided, use as the primary source for the "Existing Codebase Analysis" section
+  - `focusAreas` → produce the Fact Disposition Table (one row per focusArea, with fact_id + disposition + rationale + evidence)
   - `existingElements` → populate Implementation Path Mapping and Code Inspection Evidence
   - `dataModel` → populate data-related sections (schema references, data contracts)
-  - `focusAreas` → prioritize investigation depth on flagged areas
   - `constraints` → incorporate into design constraints and assumptions
   - `dataTransformationPipelines` → populate Verification Strategy's Output Comparison section (each pipeline step must be covered by the comparison method)
   - Conduct additional investigation only for areas not covered by the analysis or flagged in `limitations`
+
+- **Prior-Layer Verification** (optional, fullstack flow only): When this Design Doc references contracts from a prior-layer Design Doc that has been verified by code-verifier, the verification result JSON is provided. Use it as follows:
+  - `discrepancies[]` → treat as known issues to resolve in this Design Doc, or escalate if out of scope for this layer
+  - Do not infer verified claims beyond what the verifier output states explicitly; use the prior-layer Design Doc itself as reference context, not as proof of verification coverage
 - **PRD**: PRD document (if exists)
 - **Documents to Create**: ADR, Design Doc, or both
 - **Existing Architecture Information**: 
@@ -291,6 +309,7 @@ Implementation sample creation checklist:
 - [ ] **Standards identification gate completed** (required)
 - [ ] **Quality assurance mechanisms identified with adopted/noted status** (required)
 - [ ] **Code inspection evidence recorded** (required)
+- [ ] **Fact Disposition Table covers every codebase-analyzer focusArea, each row with fact_id + disposition + rationale + evidence** (required when codebase-analyzer output is provided)
 - [ ] **Integration points enumerated with contracts** (required)
 - [ ] **Data contracts clarified** (required)
 - [ ] Architecture and data flow clearly expressed in diagrams

--- a/agents/technical-designer.md
+++ b/agents/technical-designer.md
@@ -87,14 +87,14 @@ Must be performed before Design Doc creation:
    - Record all inspected files and key functions in "Code Inspection Evidence" section of Design Doc
    - Each entry must state relevance (similar functionality / integration point / pattern reference)
 
-### Fact Disposition【Required when codebase-analyzer output is provided】
+### Fact Disposition【Required when Codebase Analysis input is provided】
 
-For every entry in `codebase-analyzer.focusAreas`, produce one row in the Design Doc's "Fact Disposition Table" section:
+For every entry in `Codebase Analysis.focusAreas`, produce one row in the Design Doc's "Fact Disposition Table" section:
 
 | Column | Content |
 |--------|---------|
-| Fact ID | The `fact_id` value from codebase-analyzer |
-| Focus Area | The `area` value from codebase-analyzer |
+| Fact ID | The `fact_id` value from the Codebase Analysis input |
+| Focus Area | The `area` value from the Codebase Analysis input |
 | Disposition | One of: `preserve` / `transform` / `remove` / `out-of-scope` |
 | Rationale | For `transform`: state new outcome. For `remove`: state reason. For `out-of-scope`: state which scope boundary excludes it. For `preserve`: brief confirmation. |
 | Evidence | The `evidence` value from the focusArea (carried through verbatim) |
@@ -229,7 +229,7 @@ Document state definitions and transitions for stateful components.
   - `dataTransformationPipelines` → populate Verification Strategy's Output Comparison section (each pipeline step must be covered by the comparison method)
   - Conduct additional investigation only for areas not covered by the analysis or flagged in `limitations`
 
-- **Prior-Layer Verification** (optional, fullstack flow only): When this Design Doc references contracts from a prior-layer Design Doc that has been verified by code-verifier, the verification result JSON is provided. Use it as follows:
+- **Prior-Layer Verification** (optional, fullstack flow only): When this Design Doc references contracts from a prior-layer Design Doc that has been through a verification step, the verification result JSON is provided. Use it as follows:
   - `discrepancies[]` → treat as known issues to resolve in this Design Doc, or escalate if out of scope for this layer
   - Do not infer verified claims beyond what the verifier output states explicitly; use the prior-layer Design Doc itself as reference context, not as proof of verification coverage
 - **PRD**: PRD document (if exists)
@@ -309,7 +309,7 @@ Implementation sample creation checklist:
 - [ ] **Standards identification gate completed** (required)
 - [ ] **Quality assurance mechanisms identified with adopted/noted status** (required)
 - [ ] **Code inspection evidence recorded** (required)
-- [ ] **Fact Disposition Table covers every codebase-analyzer focusArea, each row with fact_id + disposition + rationale + evidence** (required when codebase-analyzer output is provided)
+- [ ] **Fact Disposition Table covers every Codebase Analysis focusArea, each row with fact_id + disposition + rationale + evidence** (required when Codebase Analysis input is provided)
 - [ ] **Integration points enumerated with contracts** (required)
 - [ ] **Data contracts clarified** (required)
 - [ ] Architecture and data flow clearly expressed in diagrams

--- a/backend/.claude-plugin/plugin.json
+++ b/backend/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-workflows",
-  "version": "0.16.13",
+  "version": "0.16.14",
   "description": "Skills + Subagents for backend development - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
   "author": {
     "name": "Shinsuke Kagawa",

--- a/frontend/.claude-plugin/plugin.json
+++ b/frontend/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-workflows-frontend",
-  "version": "0.16.13",
+  "version": "0.16.14",
   "description": "Skills + Subagents for React/TypeScript - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
   "author": {
     "name": "Shinsuke Kagawa",

--- a/skills-only/.claude-plugin/plugin.json
+++ b/skills-only/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-skills",
-  "version": "0.16.13",
+  "version": "0.16.14",
   "description": "Lightweight skills for users with existing workflows - coding best practices, testing principles, and design guidelines without commands or agents",
   "author": {
     "name": "Shinsuke Kagawa",

--- a/skills/documentation-criteria/references/design-template.md
+++ b/skills/documentation-criteria/references/design-template.md
@@ -123,6 +123,14 @@ Keywords determine test type and reduce ambiguity.
 |---------------|-----------|
 | [path:function] | [similar functionality / integration point / pattern reference] |
 
+### Fact Disposition Table
+
+One row per `codebase-analyzer.focusAreas` entry. This table is the single binding between existing-behavior facts and the design — other sections that describe existing behavior reference the row by Focus Area name.
+
+| Fact ID | Focus Area | Disposition | Rationale | Evidence |
+|---------|------------|-------------|-----------|----------|
+| [fact_id from focusAreas] | [area name from focusAreas] | preserve / transform / remove / out-of-scope | [for transform: state new outcome; for remove: state reason; for out-of-scope: state which scope boundary excludes it; for preserve: brief confirmation] | [evidence value carried verbatim from focusAreas] |
+
 ## Design
 
 ### Change Impact Map

--- a/skills/documentation-criteria/references/design-template.md
+++ b/skills/documentation-criteria/references/design-template.md
@@ -125,7 +125,7 @@ Keywords determine test type and reduce ambiguity.
 
 ### Fact Disposition Table
 
-One row per `codebase-analyzer.focusAreas` entry. This table is the single binding between existing-behavior facts and the design — other sections that describe existing behavior reference the row by Focus Area name.
+One row per codebase analysis `focusAreas` entry. This table is the single binding between existing-behavior facts and the design — other sections that describe existing behavior reference the row by Focus Area name.
 
 | Fact ID | Focus Area | Disposition | Rationale | Evidence |
 |---------|------------|-------------|-----------|----------|

--- a/skills/subagents-orchestration-guide/SKILL.md
+++ b/skills/subagents-orchestration-guide/SKILL.md
@@ -216,45 +216,20 @@ Criteria for timing when to call each agent:
 
 ## Basic Flow for Work Planning
 
-When receiving new features or change requests, start with requirement-analyzer.
-According to scale determination:
+Always start with requirement-analyzer, then select the minimum document flow required by scale and affected layers.
 
-### Large Scale (6+ Files) - 13 Steps (backend) / 15 Steps (frontend/fullstack)
+| Scale | Required flow |
+|-------|---------------|
+| Large | requirement-analyzer → PRD → PRD review → optional UI Spec → optional ADR → codebase-analyzer → Design Doc → code-verifier → document-reviewer → design-sync → acceptance-test-generator → work-planner → task-decomposer |
+| Medium | requirement-analyzer → codebase-analyzer → optional UI Spec → optional ADR → Design Doc → code-verifier → document-reviewer → design-sync → acceptance-test-generator → work-planner → task-decomposer |
+| Small | requirement-analyzer → work-planner → direct implementation |
 
-1. requirement-analyzer → Requirement analysis + Check existing PRD **[Stop]**
-2. prd-creator → PRD creation
-3. document-reviewer → PRD review **[Stop: PRD Approval]**
-4. **(frontend/fullstack only)** Ask user for prototype code → ui-spec-designer → UI Spec creation
-5. **(frontend/fullstack only)** document-reviewer → UI Spec review **[Stop: UI Spec Approval]**
-6. technical-designer → ADR creation (if architecture/technology/data flow changes)
-7. document-reviewer → ADR review (if ADR created) **[Stop: ADR Approval]**
-8. codebase-analyzer → Codebase analysis (pass requirement-analyzer output + PRD path)
-9. technical-designer → Design Doc creation (pass codebase-analyzer output as additional context)
-10. code-verifier → Verify Design Doc against existing code (doc_type: design-doc)
-11. document-reviewer → Design Doc review (pass code-verifier results as code_verification)
-12. design-sync → Consistency verification **[Stop: Design Doc Approval]**
-13. acceptance-test-generator → Test skeleton generation, pass to work-planner (*1)
-14. work-planner → Work plan creation **[Stop: Batch approval]**
-15. task-decomposer → Autonomous execution → Completion report
-
-### Medium Scale (3-5 Files) - 9 Steps (backend) / 11 Steps (frontend/fullstack)
-
-1. requirement-analyzer → Requirement analysis **[Stop]**
-2. codebase-analyzer → Codebase analysis (pass requirement-analyzer output)
-3. **(frontend/fullstack only)** Ask user for prototype code → ui-spec-designer → UI Spec creation
-4. **(frontend/fullstack only)** document-reviewer → UI Spec review **[Stop: UI Spec Approval]**
-5. technical-designer → Design Doc creation (pass codebase-analyzer output as additional context)
-6. code-verifier → Verify Design Doc against existing code (doc_type: design-doc)
-7. document-reviewer → Design Doc review (pass code-verifier results as code_verification)
-8. design-sync → Consistency verification **[Stop: Design Doc Approval]**
-9. acceptance-test-generator → Test skeleton generation, pass to work-planner (*1)
-10. work-planner → Work plan creation **[Stop: Batch approval]**
-11. task-decomposer → Autonomous execution → Completion report
-
-### Small Scale (1-2 Files) - 2 Steps
-
-1. work-planner → Simplified work plan creation **[Stop: Batch approval]**
-2. Direct implementation → Completion report
+Rules:
+- Large scale requires PRD before Design Doc creation
+- Frontend/fullstack flows add UI Spec before Design Doc creation
+- Fullstack layer sequencing is defined only in `references/monorepo-flow.md`
+- `design-sync` is required whenever multiple Design Docs exist
+- `task-decomposer` begins only after work-planner batch approval
 
 ## Autonomous Execution Mode
 
@@ -375,15 +350,29 @@ Register overall phases using TaskCreate. Update each phase with TaskUpdate as i
    - Compose commit messages from changeSummary
    - Explicitly integrate initial and additional requirements when requirements change
 
-   #### codebase-analyzer → technical-designer
+   ### Handoff Contracts
 
-   **Pass to codebase-analyzer**: requirement-analyzer JSON output, PRD path (if exists), original user requirements
-   **Pass to technical-designer**: codebase-analyzer JSON output as additional context in the Design Doc creation prompt. The designer uses `focusAreas`, `dataModel`, `dataTransformationPipelines`, and `qualityAssurance` to inform the Existing Codebase Analysis, Verification Strategy, and Quality Assurance Mechanisms sections.
+   #### HC-01: requirement-analyzer → codebase-analyzer
+   - Pass: `requirement_analysis`, `prd_path` (if exists), original user requirements
 
-   #### code-verifier → document-reviewer (Design Doc review)
+   #### HC-02: codebase-analyzer → technical-designer
+   - Pass: full codebase-analyzer JSON as additional context
+   - Required downstream uses:
+     - `focusAreas` → canonical disposition-target list for the Fact Disposition Table
+     - `dataModel`, `dataTransformationPipelines`, `qualityAssurance` → Existing Codebase Analysis / Verification Strategy / Quality Assurance sections
 
-   **Pass to code-verifier**: Design Doc path (doc_type: design-doc). `code_paths` is intentionally omitted — the verifier independently discovers code scope from the document.
-   **Pass to document-reviewer**: code-verifier JSON output as `code_verification` parameter.
+   #### HC-03: technical-designer → code-verifier
+   - Pass: Design Doc path (`doc_type: design-doc`)
+   - Do not pass `code_paths`; code-verifier discovers scope from the document
+
+   #### HC-04: code-verifier + codebase-analyzer → document-reviewer
+   - Pass: `code_verification` JSON and the same `codebase_analysis` JSON previously given to the designer
+   - Purpose: reviewer validates both discrepancy integration and Fact Disposition coverage against `focusAreas`
+
+   #### HC-05: code-verifier → next-layer technical-designer (fullstack only)
+   - Defined only for multi-layer fullstack flow in `references/monorepo-flow.md`
+   - Pass: prior-layer Design Doc path plus `prior_layer_verification`
+   - Use only `discrepancies[]` as known issues to address or escalate. Do not infer verified claims that are not explicitly present in the verifier output.
 
    #### technical-designer → work-planner
 
@@ -397,9 +386,7 @@ Register overall phases using TaskCreate. Update each phase with TaskUpdate as i
 
    Work-planner produces a Design-to-Plan Traceability table mapping each extracted item to covering task(s). Items without a covering task must be marked as `gap` with justification. Unjustified gaps are errors. Justified gaps require user confirmation before plan approval.
 
-   #### *1 acceptance-test-generator → work-planner
-
-   **Purpose**: Prepare information for work-planner to incorporate into work plan
+   #### HC-06: acceptance-test-generator → work-planner
 
    **Pass to acceptance-test-generator**:
    - Design Doc: [path]

--- a/skills/subagents-orchestration-guide/references/monorepo-flow.md
+++ b/skills/subagents-orchestration-guide/references/monorepo-flow.md
@@ -10,7 +10,7 @@ This reference defines the orchestration flow for projects spanning multiple lay
 
 ## Design Phase
 
-### Large Scale Fullstack (6+ Files) - 14 Steps
+### Large Scale Fullstack (6+ Files) - 15 Steps
 
 | Step | Agent | Purpose | Output |
 |------|-------|---------|--------|
@@ -22,14 +22,15 @@ This reference defines the orchestration flow for projects spanning multiple lay
 | 6 | document-reviewer | UI Spec review **[Stop]** | Approval |
 | 7 | codebase-analyzer ×2 | Codebase analysis per layer (pass req-analyzer output + PRD path, filtered to layer) | Codebase guidance per layer |
 | 8 | technical-designer | **Backend** Design Doc (with backend codebase-analyzer context) | Backend Design Doc |
-| 9 | technical-designer-frontend | **Frontend** Design Doc (with frontend codebase-analyzer context + backend Integration Points + UI Spec) | Frontend Design Doc |
-| 10 | code-verifier ×2 | Verify each Design Doc against existing code | Verification results |
-| 11 | document-reviewer ×2 | Review each Design Doc (with code-verifier results as code_verification) | Reviews |
-| 12 | design-sync | Cross-layer consistency verification (source: frontend Design Doc) **[Stop]** | Sync status |
-| 13 | acceptance-test-generator | Integration/E2E test skeleton from cross-layer contracts | Test skeletons |
-| 14 | work-planner | Work plan from all Design Docs **[Stop: Batch approval]** | Work plan |
+| 9 | code-verifier | Verify **Backend** Design Doc against existing code (its result JSON is passed to step 10 as `prior_layer_verification`) | Backend verification |
+| 10 | technical-designer-frontend | **Frontend** Design Doc (with frontend codebase-analyzer context + backend Design Doc + `prior_layer_verification` from step 9 + UI Spec) | Frontend Design Doc |
+| 11 | code-verifier | Verify **Frontend** Design Doc against existing code | Frontend verification |
+| 12 | document-reviewer ×2 | Review each Design Doc (with code-verifier results as `code_verification`) | Reviews |
+| 13 | design-sync | Cross-layer consistency verification (source: frontend Design Doc) **[Stop]** | Sync status |
+| 14 | acceptance-test-generator | Integration/E2E test skeleton from cross-layer contracts | Test skeletons |
+| 15 | work-planner | Work plan from all Design Docs **[Stop: Batch approval]** | Work plan |
 
-### Medium Scale Fullstack (3-5 Files) - 12 Steps
+### Medium Scale Fullstack (3-5 Files) - 13 Steps
 
 | Step | Agent | Purpose | Output |
 |------|-------|---------|--------|
@@ -39,56 +40,42 @@ This reference defines the orchestration flow for projects spanning multiple lay
 | 4 | ui-spec-designer | UI Spec from requirements + optional prototype | UI Spec |
 | 5 | document-reviewer | UI Spec review **[Stop]** | Approval |
 | 6 | technical-designer | **Backend** Design Doc (with backend codebase-analyzer context) | Backend Design Doc |
-| 7 | technical-designer-frontend | **Frontend** Design Doc (with frontend codebase-analyzer context + backend Integration Points + UI Spec) | Frontend Design Doc |
-| 8 | code-verifier ×2 | Verify each Design Doc against existing code | Verification results |
-| 9 | document-reviewer ×2 | Review each Design Doc (with code-verifier results as code_verification) | Reviews |
-| 10 | design-sync | Cross-layer consistency verification (source: frontend Design Doc) **[Stop]** | Sync status |
-| 11 | acceptance-test-generator | Integration/E2E test skeleton from cross-layer contracts | Test skeletons |
-| 12 | work-planner | Work plan from all Design Docs **[Stop: Batch approval]** | Work plan |
+| 7 | code-verifier | Verify **Backend** Design Doc against existing code (its result JSON is passed to step 8 as `prior_layer_verification`) | Backend verification |
+| 8 | technical-designer-frontend | **Frontend** Design Doc (with frontend codebase-analyzer context + backend Design Doc + `prior_layer_verification` from step 7 + UI Spec) | Frontend Design Doc |
+| 9 | code-verifier | Verify **Frontend** Design Doc against existing code | Frontend verification |
+| 10 | document-reviewer ×2 | Review each Design Doc (with code-verifier results as `code_verification`) | Reviews |
+| 11 | design-sync | Cross-layer consistency verification (source: frontend Design Doc) **[Stop]** | Sync status |
+| 12 | acceptance-test-generator | Integration/E2E test skeleton from cross-layer contracts | Test skeletons |
+| 13 | work-planner | Work plan from all Design Docs **[Stop: Batch approval]** | Work plan |
 
 ### Parallelization in Multi-Agent Steps
 
-Steps marked with ×2 (codebase-analyzer ×2, code-verifier ×2, document-reviewer ×2) invoke the agent once per layer. These invocations are independent and can run in parallel when the orchestrator supports concurrent Agent tool calls.
-
-### Codebase Analysis Before Design Doc Creation
-
-Before each Design Doc creation, invoke codebase-analyzer with the requirement-analyzer output filtered to the relevant layer's affected files. Pass the codebase-analyzer output to the corresponding technical-designer invocation as additional context.
+Steps marked with ×2 (codebase-analyzer ×2, document-reviewer ×2) invoke the agent once per layer. These invocations are independent and can run in parallel when the orchestrator supports concurrent Agent tool calls. The two code-verifier invocations run sequentially: backend verification completes before frontend authoring begins so the frontend designer references verified backend contracts.
 
 ### Layer Context in Design Doc Creation
 
-When invoking technical-designer for each layer, pass explicit context. Template varies by scale:
+Use the common handoff contracts in `../SKILL.md`:
+- Backend DD creation uses `HC-01` + `HC-02`
+- Frontend DD creation uses `HC-01` + `HC-02` + `HC-05`
+- Design Doc review uses `HC-03` + `HC-04`
 
-**Large Scale (PRD available)** — Backend Design Doc:
-```
-Create a backend Design Doc from PRD at [path].
+Prompt templates:
+
+**Backend Design Doc**
+```text
+Create a backend Design Doc from [PRD path or requirement_analysis].
 Codebase analysis: [JSON from codebase-analyzer for backend layer]
 Focus on: API contracts, data layer, business logic, service architecture.
 ```
 
-**Large Scale (PRD available)** — Frontend Design Doc:
-```
-Create a frontend Design Doc from PRD at [path].
+**Frontend Design Doc**
+```text
+Create a frontend Design Doc from [PRD path or requirement_analysis].
 Codebase analysis: [JSON from codebase-analyzer for frontend layer]
-Reference backend Design Doc at [path] for API contracts and Integration Points.
+Backend Design Doc: [path]
+prior_layer_verification: [JSON from code-verifier on backend Design Doc]
 Reference UI Spec at [path] for component structure and state design.
-Focus on: component hierarchy, state management, UI interactions, data fetching.
-```
-
-**Medium Scale (no PRD)** — Backend Design Doc:
-```
-Create a backend Design Doc based on the following requirements:
-[Pass requirement-analyzer output including purpose, affectedFiles, affectedLayers, technicalConsiderations]
-Codebase analysis: [JSON from codebase-analyzer for backend layer]
-Focus on: API contracts, data layer, business logic, service architecture.
-```
-
-**Medium Scale (no PRD)** — Frontend Design Doc:
-```
-Create a frontend Design Doc based on the following requirements:
-[Pass requirement-analyzer output including purpose, affectedFiles, affectedLayers, technicalConsiderations]
-Codebase analysis: [JSON from codebase-analyzer for frontend layer]
-Reference backend Design Doc at [path] for API contracts and Integration Points.
-Reference UI Spec at [path] for component structure and state design.
+Use `prior_layer_verification.discrepancies[]` as known issues to address or escalate. Do not infer verified claims beyond what the verifier output states explicitly.
 Focus on: component hierarchy, state management, UI interactions, data fetching.
 ```
 
@@ -137,42 +124,16 @@ Layer is determined from the task's **Target files** paths — this is a factual
 
 ## Task Cycle
 
-Each task uses the standard 4-step cycle with layer-appropriate agents:
+Each task follows the standard 4-step cycle from `../SKILL.md`. Only agent routing varies by layer:
 
-### backend-task
-```
-1. task-executor → Implementation
-2. Escalation check
-3. quality-fixer → Quality check and fixes (always pass task file path as task_file)
-   - stub_detected → Return to step 1 with incompleteImplementations details
-   - blocked → Escalate to user
-   - approved → Proceed to step 4
-4. git commit (on approved)
-```
-
-### frontend-task
-```
-1. task-executor-frontend → Implementation
-2. Escalation check
-3. quality-fixer-frontend → Quality check and fixes (always pass task file path as task_file)
-   - stub_detected → Return to step 1 with incompleteImplementations details
-   - blocked → Escalate to user
-   - approved → Proceed to step 4
-4. git commit (on approved)
-```
+| Task pattern | Executor | Quality fixer |
+|-------------|----------|---------------|
+| `*-backend-task-*` | `task-executor` | `quality-fixer` |
+| `*-frontend-task-*` | `task-executor-frontend` | `quality-fixer-frontend` |
 
 ### integration-test-reviewer Placement
 
 When `requiresTestReview` is `true`:
 - Standard flow (integration-test-reviewer after task-executor, before quality-fixer)
 
-## Agent Routing Summary
-
-The orchestrator selects agents by **filename pattern matching** — no conditional inference required:
-
-```
-*-backend-task-*   → task-executor + quality-fixer
-*-frontend-task-*  → task-executor-frontend + quality-fixer-frontend
-```
-
-All other orchestration rules (stop points, structured responses, escalation handling, task management) follow the standard subagents-orchestration-guide.
+All other orchestration rules follow the standard subagents-orchestration-guide.


### PR DESCRIPTION
## Summary

- **Fact Disposition framework**: codebase-analyzer surfaces disposition-required facts as `focusAreas` with `fact_id`/`evidence`/`factsToAddress`. technical-designer produces a Disposition Table (preserve/transform/remove/out-of-scope) for each. document-reviewer gates on completeness. design-sync detects cross-layer disposition conflicts via `fact_id` matching.
- **Fullstack flow reorder**: backend Design Doc is verified by code-verifier before frontend Design Doc authoring begins, with `prior_layer_verification` explicitly passed to the frontend designer.
- **Handoff Contracts (HC-01~06)**: formalized in SKILL.md; Basic Flow consolidated from verbose numbered lists into a compact table + rules, reducing context overhead.

## Motivation

When codebase-analyzer surfaces detailed facts about existing behavior (call sites, branching cases, input fields, data shapes), those facts need to **bind** the design — not merely inform it. Without a structural mechanism, Design Docs can silently omit or contradict analyzed facts. The Fact Disposition Table creates explicit traceability from analysis to design, enforced by reviewer gates and cross-layer consistency checks.

## Changes by file

| File | Change |
|------|--------|
| `agents/codebase-analyzer.md` | `focusAreas` schema: added `fact_id`, `evidence`, `factsToAddress`; Step 4 disposition target enumeration |
| `agents/technical-designer.md` | Fact Disposition section + checklist item + Prior-Layer Verification input |
| `agents/technical-designer-frontend.md` | Same as backend designer |
| `agents/document-reviewer.md` | `codebase_analysis` input parameter; Gate 0 + Gate 1 disposition checks |
| `agents/design-sync.md` | `fact_id`-based disposition conflict type + extraction target |
| `skills/documentation-criteria/references/design-template.md` | Fact Disposition Table template section |
| `skills/subagents-orchestration-guide/SKILL.md` | HC-01~06 handoff contracts; compact Basic Flow table |
| `skills/subagents-orchestration-guide/references/monorepo-flow.md` | Sequential backend verification before frontend authoring; updated Layer Context templates; deduplicated Task Cycle |
| `*/.claude-plugin/plugin.json` | Version bump 0.16.13 → 0.16.14 |

## Test plan

- [ ] Run `recipe-design` on a medium-scale backend change and verify codebase-analyzer produces `focusAreas` with `fact_id`/`evidence`/`factsToAddress`
- [ ] Verify technical-designer produces a Fact Disposition Table with one row per focusArea
- [ ] Verify document-reviewer raises `critical` issue when Disposition Table rows are missing
- [ ] Run fullstack `recipe-design` and verify backend code-verifier runs before frontend DD authoring
- [ ] Verify design-sync detects disposition conflicts when two DDs assign different dispositions to the same `fact_id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)