### PR TITLE
docs: add Windows symlink note to Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## ⚡ Quick Start
 
-> **Windows:** Git doesn't create symlinks by default. Clone with `git clone -c core.symlinks=true` in an admin PowerShell, then install plugins from the local clone. Admin is only needed for initial setup.
+> **Windows:** Git doesn't create symlinks by default. Use WSL, or clone with `git clone -c core.symlinks=true` in an admin PowerShell, then install plugins from the local clone. Admin is only needed for initial setup.
 
 This marketplace includes the following plugins:
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## ⚡ Quick Start
 
-> **Windows:** Git doesn't create symlinks by default. Use WSL, or clone with `git clone -c core.symlinks=true` in an admin PowerShell, then install plugins from the local clone. Admin is only needed for initial setup.
+> **Windows:** This repo uses symlinks. Git doesn't create them by default. Use WSL, or clone with `git clone -c core.symlinks=true` in an admin PowerShell, then install plugins from the local clone. Admin is only needed for initial setup.
 
 This marketplace includes the following plugins:
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 
 ## ⚡ Quick Start
 
+> **Windows:** Git doesn't create symlinks by default. Clone with `git clone -c core.symlinks=true` in an admin PowerShell, then install plugins from the local clone. Admin is only needed for initial setup.
+
 This marketplace includes the following plugins:
 
 **Core plugins:**


### PR DESCRIPTION
## Summary
- Add a callout in Quick Start for Windows users: Git doesn't create symlinks by default, so plugins need to be installed from a local clone with `core.symlinks=true`

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)