### PR TITLE
chore: tighten agent prompt contracts (v0.16.17)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "dev-workflows",
       "source": "./dev-workflows",
       "strict": true,
-      "version": "0.16.16",
+      "version": "0.16.17",
       "description": "Skills + Subagents for backend development - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
       "author": {
         "name": "Shinsuke Kagawa",
@@ -81,7 +81,7 @@
       "name": "dev-workflows-frontend",
       "source": "./dev-workflows-frontend",
       "strict": true,
-      "version": "0.16.16",
+      "version": "0.16.17",
       "description": "Skills + Subagents for React/TypeScript - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
       "author": {
         "name": "Shinsuke Kagawa",
@@ -149,7 +149,7 @@
       "name": "dev-skills",
       "source": "./dev-skills",
       "strict": true,
-      "version": "0.16.16",
+      "version": "0.16.17",
       "description": "Lightweight skills for users with existing workflows - coding best practices, testing principles, and design guidelines without recipe workflows or agents",
       "author": {
         "name": "Shinsuke Kagawa",

--- a/agents/acceptance-test-generator.md
+++ b/agents/acceptance-test-generator.md
@@ -11,7 +11,7 @@ Operates in an independent context, executing autonomously until task completion
 
 ## Mandatory Initial Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Update status using TaskUpdate upon completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 ### Implementation Approach Compliance
 - **Test Code Generation**: MUST strictly comply with Design Doc implementation patterns (function vs class selection)

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -11,7 +11,7 @@ Operates in an independent context, executing autonomously until task completion
 
 ## Initial Required Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Update status using TaskUpdate upon completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 ## Key Responsibilities
 
@@ -139,60 +139,102 @@ Verify against the Design Doc architecture:
 
 ### 6. Return JSON Result
 
-Return the JSON result as the final response. See Output Format for the schema.
-
 ## Output Format
+
+### Output Protocol
+
+- During execution, intermediate progress messages MAY be emitted as plain text or markdown.
+- The LAST message returned to the orchestrator MUST be a single JSON object that matches the schema below.
+- Emit the JSON object as the entire content of the final message: the message begins with `{` and ends with `}`.
+
+### Schema (types)
+
+```
+complianceRate:       number (integer 0-100, percentage)
+identifierMatchRate:  number (integer 0-100, percentage)
+verdict:              string ("pass" | "needs-improvement" | "needs-redesign")
+
+acceptanceCriteria[].item:        string
+acceptanceCriteria[].status:      string ("fulfilled" | "partially_fulfilled" | "unfulfilled")
+acceptanceCriteria[].confidence:  string ("high" | "medium" | "low")
+acceptanceCriteria[].location:    string (file:line; null if unimplemented)
+acceptanceCriteria[].evidence:    string[] (each "source: file:line")
+acceptanceCriteria[].gap:         string (null when fully fulfilled)
+acceptanceCriteria[].suggestion:  string (null when fully fulfilled)
+
+identifierVerification[].identifier:    string
+identifierVerification[].designDocValue: string
+identifierVerification[].codeValue:     string (or "not found")
+identifierVerification[].location:      string (file:line; null if not found)
+identifierVerification[].match:         boolean
+
+qualityFindings[].category:    string ("dd_violation" | "maintainability" | "reliability" | "coverage_gap")
+qualityFindings[].location:    string (file:line or file:function)
+qualityFindings[].description: string
+qualityFindings[].rationale:   string (category-specific)
+qualityFindings[].suggestion:  string
+
+summary.acsTotal:       number (integer >= 0)
+summary.acsFulfilled:   number (integer >= 0)
+summary.acsPartial:     number (integer >= 0)
+summary.acsUnfulfilled: number (integer >= 0)
+summary.identifiersTotal:   number (integer >= 0)
+summary.identifiersMatched: number (integer >= 0)
+summary.lowConfidenceItems: number (integer >= 0)
+summary.findingsByCategory.dd_violation:    number (integer >= 0)
+summary.findingsByCategory.maintainability: number (integer >= 0)
+summary.findingsByCategory.reliability:     number (integer >= 0)
+summary.findingsByCategory.coverage_gap:    number (integer >= 0)
+```
+
+### Example (concrete values, illustrative only)
 
 ```json
 {
-  "complianceRate": "[X]%",
-  "identifierMatchRate": "[X]%",
-  "verdict": "[pass/needs-improvement/needs-redesign]",
-
+  "complianceRate": 88,
+  "identifierMatchRate": 95,
+  "verdict": "needs-improvement",
   "acceptanceCriteria": [
     {
-      "item": "[acceptance criteria name]",
-      "status": "fulfilled|partially_fulfilled|unfulfilled",
-      "confidence": "high|medium|low",
-      "location": "[file:line, if implemented]",
-      "evidence": ["[source1: file:line]", "[source2: test file:line]"],
-      "gap": "[what is missing or deviating, if not fully fulfilled]",
-      "suggestion": "[specific fix, if not fully fulfilled]"
+      "item": "User can log in with valid credentials",
+      "status": "fulfilled",
+      "confidence": "high",
+      "location": "src/auth/login.ts:42",
+      "evidence": ["impl: src/auth/login.ts:42", "test: src/auth/login.test.ts:18"],
+      "gap": null,
+      "suggestion": null
     }
   ],
-
   "identifierVerification": [
     {
-      "identifier": "[identifier name]",
-      "designDocValue": "[value specified in Design Doc]",
-      "codeValue": "[value found in code, or 'not found']",
-      "location": "[file:line]",
-      "match": true
+      "identifier": "AUTH_TOKEN_TTL",
+      "designDocValue": "3600",
+      "codeValue": "1800",
+      "location": "src/auth/config.ts:8",
+      "match": false
     }
   ],
-
   "qualityFindings": [
     {
-      "category": "dd_violation|maintainability|reliability|coverage_gap",
-      "location": "[file:line or file:function]",
-      "description": "[specific issue found]",
-      "rationale": "[category-specific, see Finding Classification]",
-      "suggestion": "[specific improvement]"
+      "category": "reliability",
+      "location": "src/auth/login.ts:55",
+      "description": "Error from token signer is swallowed silently",
+      "rationale": "When jwt.sign throws, the catch block returns null without logging; downstream sees auth failure indistinguishable from invalid credentials",
+      "suggestion": "Re-throw with context or log error then propagate to caller"
     }
   ],
-
   "summary": {
-    "acsTotal": 0,
-    "acsFulfilled": 0,
-    "acsPartial": 0,
-    "acsUnfulfilled": 0,
-    "identifiersTotal": 0,
-    "identifiersMatched": 0,
-    "lowConfidenceItems": 0,
+    "acsTotal": 12,
+    "acsFulfilled": 10,
+    "acsPartial": 1,
+    "acsUnfulfilled": 1,
+    "identifiersTotal": 20,
+    "identifiersMatched": 19,
+    "lowConfidenceItems": 2,
     "findingsByCategory": {
-      "dd_violation": 0,
+      "dd_violation": 1,
       "maintainability": 0,
-      "reliability": 0,
+      "reliability": 1,
       "coverage_gap": 0
     }
   }
@@ -233,9 +275,10 @@ Identifier mismatches automatically lower the verdict by one level (e.g., pass â
 - [ ] Quality findings classified with category and rationale
 - [ ] Compliance rate and identifier match rate calculated
 - [ ] Verdict determined
-- [ ] Final response is the JSON output
 
-## Output Self-Check
+## Self-Validation [BLOCKING â€” before output]
+
+Run each item below before producing the final JSON. When any item is unsatisfied, return to the relevant Step and complete it before producing the JSON output.
 
 - [ ] Every AC status determination cites the tool name and result as evidence source
 - [ ] Identifier comparisons use exact strings from Design Doc and code (character-for-character match)

--- a/agents/code-verifier.md
+++ b/agents/code-verifier.md
@@ -9,7 +9,7 @@ You are an AI assistant specializing in document-code consistency verification.
 
 ## Required Initial Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include "Verify skill constraints" first and "Verify skill adherence" last. Update status using TaskUpdate upon each completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 ## Input Parameters
 
@@ -128,63 +128,108 @@ This step discovers what exists in code but is MISSING from the document. Perfor
 5. **Compile undocumented list**: All items found in code but not in document
 6. **Compile unimplemented list**: All items specified in document but not found in code
 
-### Step 6: Return JSON Result
-
-Return the JSON result as the final response. See Output Format for the schema.
-
 ## Output Format
 
-**JSON format is mandatory.**
+### Output Protocol
+
+- During execution, intermediate progress messages MAY be emitted as plain text or markdown.
+- The LAST message returned to the orchestrator MUST be a single JSON object that matches the schema below.
+- Emit the JSON object as the entire content of the final message: the message begins with `{` and ends with `}`.
 
 ### Essential Output (default)
+
+Schema (types):
+
+```
+summary.docType:                string ("prd" | "design-doc")
+summary.documentPath:           string (file path)
+summary.verifiableClaimCount:   number (integer >= 0)
+summary.matchCount:             number (integer >= 0)
+summary.consistencyScore:       number (integer 0-100)
+summary.status:                 string ("consistent" | "mostly_consistent" | "needs_review" | "inconsistent")
+
+claimCoverage.sectionsAnalyzed: number (integer >= 0)
+claimCoverage.sectionsWithClaims: number (integer >= 0)
+claimCoverage.sectionsWithZeroClaims: string[]
+
+discrepancies[].id:               string
+discrepancies[].status:           string ("drift" | "gap" | "conflict")
+discrepancies[].severity:         string ("critical" | "major" | "minor")
+discrepancies[].claim:            string (brief claim description)
+discrepancies[].documentLocation: string (path:line in document)
+discrepancies[].codeLocation:     string (path:line in code, or null when claim is unimplemented)
+discrepancies[].evidence:         string (tool result summary supporting this finding)
+discrepancies[].classification:   string (what was found, e.g., "Path version mismatch")
+
+reverseCoverage.routesInCode:                 number (integer >= 0)
+reverseCoverage.routesDocumented:             number (integer >= 0)
+reverseCoverage.undocumentedRoutes:           string[] (each "METHOD path (file:line)")
+reverseCoverage.testFilesFound:               number (integer >= 0)
+reverseCoverage.testFilesDocumented:          number (integer >= 0)
+reverseCoverage.exportsInCode:                number (integer >= 0)
+reverseCoverage.exportsDocumented:            number (integer >= 0)
+reverseCoverage.undocumentedExports:          string[] (each "name (file:line)")
+reverseCoverage.dataOperationsInCode:         number (integer >= 0)
+reverseCoverage.dataOperationsDocumented:     number (integer >= 0)
+reverseCoverage.undocumentedDataOperations:   string[] (each "operation (file:line)")
+reverseCoverage.testBoundariesSectionPresent: boolean
+
+coverage.documented:    string[] (feature areas with documentation)
+coverage.undocumented:  string[] (code features lacking documentation)
+coverage.unimplemented: string[] (documented specs not yet implemented)
+
+limitations: string[] (what could not be verified and why)
+```
+
+Example (concrete values, illustrative only):
 
 ```json
 {
   "summary": {
-    "docType": "prd|design-doc",
-    "documentPath": "/path/to/document.md",
-    "verifiableClaimCount": "<N>",
-    "matchCount": "<N>",
-    "consistencyScore": "<0-100>",
-    "status": "consistent|mostly_consistent|needs_review|inconsistent"
+    "docType": "design-doc",
+    "documentPath": "docs/design/auth-design.md",
+    "verifiableClaimCount": 28,
+    "matchCount": 22,
+    "consistencyScore": 78,
+    "status": "mostly_consistent"
   },
   "claimCoverage": {
-    "sectionsAnalyzed": "<N>",
-    "sectionsWithClaims": "<N>",
-    "sectionsWithZeroClaims": ["<section names with 0 claims>"]
+    "sectionsAnalyzed": 9,
+    "sectionsWithClaims": 8,
+    "sectionsWithZeroClaims": ["Future Work"]
   },
   "discrepancies": [
     {
       "id": "D001",
-      "status": "drift|gap|conflict",
-      "severity": "critical|major|minor",
-      "claim": "Brief claim description",
-      "documentLocation": "PRD.md:45",
-      "codeLocation": "src/auth/service:120",
-      "evidence": "Tool result supporting this finding",
-      "classification": "What was found"
+      "status": "drift",
+      "severity": "major",
+      "claim": "Login endpoint accepts POST /api/auth/login",
+      "documentLocation": "auth-design.md:45",
+      "codeLocation": "src/auth/router.ts:120",
+      "evidence": "Grep found POST /api/v2/auth/login in src/auth/router.ts:120",
+      "classification": "Path version mismatch"
     }
   ],
   "reverseCoverage": {
-    "routesInCode": "<N>",
-    "routesDocumented": "<N>",
-    "undocumentedRoutes": ["<method path (file:line)>"],
-    "testFilesFound": "<N>",
-    "testFilesDocumented": "<N>",
-    "exportsInCode": "<N>",
-    "exportsDocumented": "<N>",
-    "undocumentedExports": ["<name (file:line)>"],
-    "dataOperationsInCode": "<N>",
-    "dataOperationsDocumented": "<N>",
-    "undocumentedDataOperations": ["<operation (file:line)>"],
-    "testBoundariesSectionPresent": "<true|false>"
+    "routesInCode": 12,
+    "routesDocumented": 10,
+    "undocumentedRoutes": ["DELETE /api/auth/sessions (src/auth/router.ts:88)"],
+    "testFilesFound": 6,
+    "testFilesDocumented": 5,
+    "exportsInCode": 18,
+    "exportsDocumented": 15,
+    "undocumentedExports": ["AuthSession (src/auth/types.ts:12)"],
+    "dataOperationsInCode": 9,
+    "dataOperationsDocumented": 7,
+    "undocumentedDataOperations": ["sessions table SELECT (src/auth/repo.ts:42)"],
+    "testBoundariesSectionPresent": true
   },
   "coverage": {
-    "documented": ["Feature areas with documentation"],
-    "undocumented": ["Code features lacking documentation"],
-    "unimplemented": ["Documented specs not yet implemented"]
+    "documented": ["login flow", "token refresh"],
+    "undocumented": ["session deletion endpoint"],
+    "unimplemented": ["MFA challenge response"]
   },
-  "limitations": ["What could not be verified and why"]
+  "limitations": ["Could not verify token refresh against running redis instance"]
 }
 ```
 
@@ -223,9 +268,11 @@ consistencyScore = (matchCount / verifiableClaimCount) * 100
 - [ ] Identified undocumented features from reverse coverage
 - [ ] Identified unimplemented specifications
 - [ ] Calculated consistency score
-- [ ] Final response is the JSON output
 
-## Output Self-Check
+## Self-Validation [BLOCKING — before output]
+
+Run each item below before producing the final JSON. When any item is unsatisfied, return to the relevant Step and complete it before producing the JSON output.
+
 - [ ] All existence claims (file exists, test exists, function exists) are backed by Glob/Grep tool results
 - [ ] All behavioral claims are backed by Read of the actual function implementation
 - [ ] Identifier comparisons use exact strings from code (no spelling corrections)

--- a/agents/codebase-analyzer.md
+++ b/agents/codebase-analyzer.md
@@ -9,7 +9,7 @@ You are an AI assistant specializing in existing codebase analysis for technical
 
 ## Required Initial Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include "Verify skill constraints" first and "Verify skill adherence" last. Update status using TaskUpdate upon each completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 ## Input Parameters
 
@@ -91,13 +91,13 @@ For each element discovered in Steps 2-3:
    - Identify domain-specific constraints (naming conventions, length limits, format requirements) from configuration files, CI checks, or documented standards
    - Record each mechanism with: tool/check name, what it enforces, configuration location, which affected files it covers
 
-### Step 5: Return JSON Result
-
-Return the JSON result as the final response. See Output Format for the schema.
-
 ## Output Format
 
-**JSON format is mandatory.**
+### Output Protocol
+
+- During execution, intermediate progress messages MAY be emitted as plain text or markdown.
+- The LAST message returned to the orchestrator MUST be a single JSON object that matches the schema below.
+- Emit the JSON object as the entire content of the final message: the message begins with `{` and ends with `}`.
 
 ```json
 {
@@ -217,9 +217,10 @@ Return the JSON result as the final response. See Output Format for the schema.
 - [ ] Recorded domain-specific constraints (naming, length, format) from configuration or CI
 - [ ] Generated focus areas as disposition targets (each entry aggregates a coherent unit of existing facts the designer must address; cardinality consolidated to ≤ ~15)
 - [ ] Checked test coverage for discovered elements
-- [ ] Final response is the JSON output
 
-## Output Self-Check
+## Self-Validation [BLOCKING — before output]
+
+Run each item below before producing the final JSON. When any item is unsatisfied, return to the relevant Step and complete it before producing the JSON output.
 
 - [ ] All file paths verified to exist using Glob/Read
 - [ ] All signatures and names transcribed exactly from code (no normalization or correction)

--- a/agents/design-sync.md
+++ b/agents/design-sync.md
@@ -11,7 +11,7 @@ Operates in an independent context, executing autonomously until task completion
 
 ## Initial Mandatory Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Update status using TaskUpdate upon completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 ## Detection Criteria (The Only Rule)
 

--- a/agents/document-reviewer.md
+++ b/agents/document-reviewer.md
@@ -9,7 +9,7 @@ You are an AI assistant specialized in technical document review.
 
 ## Initial Mandatory Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Update status using TaskUpdate upon completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 ## Responsibilities
 
@@ -122,7 +122,6 @@ Checklist:
 - [ ] If prior_context_count > 0: Each item has resolution status
 - [ ] If prior_context_count > 0: `prior_context_check` object prepared
 - [ ] Output is valid JSON
-- [ ] Final response is the JSON output
 
 Complete all items before proceeding to output.
 
@@ -130,11 +129,14 @@ Complete all items before proceeding to output.
 - Use the JSON schema according to review mode (comprehensive or perspective-specific)
 - Clearly classify problem importance
 - Include `prior_context_check` object if prior_context_count > 0
-- Return the JSON result as the final response. See Output Format for the schema.
 
 ## Output Format
 
-**JSON format is mandatory.**
+### Output Protocol
+
+- During execution, intermediate progress messages MAY be emitted as plain text or markdown.
+- The LAST message returned to the orchestrator MUST be a single JSON object that matches the schema below.
+- Emit the JSON object as the entire content of the final message: the message begins with `{` and ends with `}`.
 
 ### Field Definitions
 
@@ -341,10 +343,8 @@ Template storage locations follow documentation-criteria skill.
 | Rejected | Rejected (with documented reasons) |
 
 ### Strict Adherence to Output Format
-**JSON format is mandatory**
 
-**Required Elements**:
+The Output Protocol section above is the canonical contract. The output JSON object must include:
 - `metadata`, `verdict`/`analysis`, `issues` objects
 - `id`, `severity`, `category` for each issue
-- Valid JSON syntax (parseable)
 - `suggestion` must be specific and actionable

--- a/agents/integration-test-reviewer.md
+++ b/agents/integration-test-reviewer.md
@@ -11,7 +11,7 @@ Operates in an independent context, executing autonomously until task completion
 
 ## Initial Mandatory Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Update status using TaskUpdate upon completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 ## Responsibilities
 
@@ -58,10 +58,13 @@ Evaluate each test for:
 - Isolated state per test (reset in beforeEach)
 - Deterministic execution (mock time/random sources when needed)
 
-### 4. Return JSON Result
-Return the JSON result as the final response. See Output Format for the schema.
-
 ## Output Format
+
+### Output Protocol
+
+- During execution, intermediate progress messages MAY be emitted as plain text or markdown.
+- The LAST message returned to the orchestrator MUST be a single JSON object that matches the schema below.
+- Emit the JSON object as the entire content of the final message: the message begins with `{` and ends with `}`.
 
 ```json
 {
@@ -120,7 +123,6 @@ Return the JSON result as the final response. See Output Format for the schema.
 - [ ] Each test executes independently of other tests
 - [ ] Deterministic execution (no random/time dependency)
 - [ ] Test name matches verification content
-- [ ] Final response is the JSON output
 
 ## Common Issues and Fixes
 

--- a/agents/investigator.md
+++ b/agents/investigator.md
@@ -9,7 +9,7 @@ You are an AI assistant specializing in problem investigation.
 
 ## Required Initial Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include "Verify skill constraints" first and "Verify skill adherence" last. Update status using TaskUpdate upon each completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 **Current Date Check**: Run `date` command before starting to determine current date for evaluating information recency.
 
@@ -102,10 +102,6 @@ For each failure point:
 
 Disclose unexplored areas and investigation limitations.
 
-### Step 6: Return JSON Result
-
-Return the JSON result as the final response. See Output Format for the schema.
-
 ## Evidence Strength Classification
 
 | Strength | Definition | Example |
@@ -116,7 +112,11 @@ Return the JSON result as the final response. See Output Format for the schema.
 
 ## Output Format
 
-**JSON format is mandatory.**
+### Output Protocol
+
+- During execution, intermediate progress messages MAY be emitted as plain text or markdown.
+- The LAST message returned to the orchestrator MUST be a single JSON object that matches the schema below.
+- Emit the JSON object as the entire content of the final message: the message begins with `{` and ends with `}`.
 
 ```json
 {
@@ -206,9 +206,11 @@ Return the JSON result as the final response. See Output Format for the schema.
 - [ ] Each failure point has: location, upstreamDependency, symptomExplained, causalChain (reaching a stop condition), checkStatus, evidence, comparisonAnalysis
 - [ ] Determined impactScope and recurrenceRisk per failure point
 - [ ] Documented unexplored areas and investigation limitations
-- [ ] Final response is the JSON output
 
-## Output Self-Check
+## Self-Validation [BLOCKING — before output]
+
+Run each item below before producing the final JSON. When any item is unsatisfied, return to the relevant Step and complete it before producing the JSON output.
+
 - [ ] All mapped path nodes were checked, not just the first plausible fault
 - [ ] User's causal relationship hints are reflected in the failure points
 - [ ] Contradicting evidence is recorded with checkStatus adjusted accordingly (weakened, not ignored)

--- a/agents/prd-creator.md
+++ b/agents/prd-creator.md
@@ -9,7 +9,7 @@ You are a specialized AI assistant for creating Product Requirements Documents (
 
 ## Initial Mandatory Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Update status using TaskUpdate upon completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 **Current Date Retrieval**: Before starting work, retrieve the actual current date from the operating environment (do not rely on training data cutoff date).
 

--- a/agents/quality-fixer-frontend.md
+++ b/agents/quality-fixer-frontend.md
@@ -19,10 +19,11 @@ Executes quality checks and provides a state where all Phases complete with zero
 ## Input Parameters
 
 - **task_file** (optional): Path to the task file being verified. When provided, read the "Quality Assurance Mechanisms" section and use listed mechanisms as supplementary hints for quality check discovery. This is a hint — primary detection remains code, manifest, and configuration-based.
+- **filesModified** (optional): List of file paths that the upstream agent (typically task-executor-frontend) modified for the current task. Used as the primary scope for Step 1 incomplete-implementation check. When absent, Step 1 falls back to `git diff HEAD`.
 
 ## Initial Required Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Update status using TaskUpdate upon completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 ### Package Manager
 Use the appropriate run command based on the `packageManager` field in package.json.
@@ -33,7 +34,11 @@ Use the appropriate run command based on the `packageManager` field in package.j
 
 Review the diff of changed files to detect stub or incomplete implementations. This step runs before any quality checks because verifying the quality of unfinished code is meaningless.
 
-**How to check**: Use `git diff HEAD` to review all uncommitted changes in the working tree.
+**Scope of this check** (in priority order):
+- **Primary scope**: When the orchestrator passes `filesModified` (the task's write set, typically taken from `task-executor-frontend` response), use only those files.
+- **Fallback scope**: When `filesModified` is absent, use `git diff HEAD` for the current uncommitted diff.
+
+Apply the indicators below to files within scope only. Files outside the scope go through review without stub-detection in this agent (the orchestrator handles cross-task scope concerns).
 
 **Indicators of incomplete implementation** (stub_detected):
 - `// TODO`, `// FIXME`, `// HACK`, `throw new Error("not implemented")` or equivalent
@@ -153,6 +158,12 @@ Before setting status to blocked, confirm specifications in this order:
 - What would be needed to resolve (concrete steps, not vague descriptions)
 
 ## Output Format
+
+### Output Protocol
+
+- During execution, intermediate progress messages MAY be emitted as plain text or markdown.
+- The LAST message returned to the orchestrator MUST be a single JSON object that matches the schema below.
+- Emit the JSON object as the entire content of the final message: the message begins with `{` and ends with `}`.
 
 **Important**: JSON response is received by main AI (caller) and conveyed to user in an understandable format.
 

--- a/agents/quality-fixer-frontend.md
+++ b/agents/quality-fixer-frontend.md
@@ -19,7 +19,7 @@ Executes quality checks and provides a state where all Phases complete with zero
 ## Input Parameters
 
 - **task_file** (optional): Path to the task file being verified. When provided, read the "Quality Assurance Mechanisms" section and use listed mechanisms as supplementary hints for quality check discovery. This is a hint — primary detection remains code, manifest, and configuration-based.
-- **filesModified** (optional): List of file paths that the upstream agent (typically task-executor-frontend) modified for the current task. Used as the primary scope for Step 1 incomplete-implementation check. When absent, Step 1 falls back to `git diff HEAD`.
+- **filesModified** (optional): List of file paths that the upstream implementation step modified for the current task (provided by the orchestrator). Used as the primary scope for Step 1 incomplete-implementation check. When absent, Step 1 falls back to `git diff HEAD`.
 
 ## Initial Required Tasks
 
@@ -35,7 +35,7 @@ Use the appropriate run command based on the `packageManager` field in package.j
 Review the diff of changed files to detect stub or incomplete implementations. This step runs before any quality checks because verifying the quality of unfinished code is meaningless.
 
 **Scope of this check** (in priority order):
-- **Primary scope**: When the orchestrator passes `filesModified` (the task's write set, typically taken from `task-executor-frontend` response), use only those files.
+- **Primary scope**: When the orchestrator passes `filesModified` (the task's write set from the upstream implementation step), use only those files.
 - **Fallback scope**: When `filesModified` is absent, use `git diff HEAD` for the current uncommitted diff.
 
 Apply the indicators below to files within scope only. Files outside the scope go through review without stub-detection in this agent (the orchestrator handles cross-task scope concerns).
@@ -123,7 +123,7 @@ Return one of the following as the final response (see Output Format for schemas
 ## Status Determination Criteria
 
 ### stub_detected (Incomplete implementation found — Step 1 gate)
-Returned immediately when Step 1 finds incomplete implementations in the diff. Quality checks are not executed. The orchestrator should route this back to the task-executor for completion.
+Returned immediately when Step 1 finds incomplete implementations in the diff. Quality checks are not executed. The orchestrator should route this back to the implementation step for completion.
 
 ### approved (All quality checks pass)
 - All tests pass (React Testing Library)

--- a/agents/quality-fixer.md
+++ b/agents/quality-fixer.md
@@ -19,7 +19,7 @@ Executes quality checks and provides a state where all Phases complete with zero
 ## Input Parameters
 
 - **task_file** (optional): Path to the task file being verified. When provided, read the "Quality Assurance Mechanisms" section and use listed mechanisms as supplementary hints for quality check discovery. This is a hint — primary detection remains code, manifest, and configuration-based.
-- **filesModified** (optional): List of file paths that the upstream agent (typically task-executor) modified for the current task. Used as the primary scope for Step 1 incomplete-implementation check. When absent, Step 1 falls back to `git diff HEAD`.
+- **filesModified** (optional): List of file paths that the upstream implementation step modified for the current task (provided by the orchestrator). Used as the primary scope for Step 1 incomplete-implementation check. When absent, Step 1 falls back to `git diff HEAD`.
 
 ## Initial Required Tasks
 
@@ -32,7 +32,7 @@ Executes quality checks and provides a state where all Phases complete with zero
 Review the diff of changed files to detect stub or incomplete implementations. This step runs before any quality checks because verifying the quality of unfinished code is meaningless.
 
 **Scope of this check** (in priority order):
-- **Primary scope**: When the orchestrator passes `filesModified` (the task's write set, typically taken from `task-executor` response), use only those files.
+- **Primary scope**: When the orchestrator passes `filesModified` (the task's write set from the upstream implementation step), use only those files.
 - **Fallback scope**: When `filesModified` is absent, use `git diff HEAD` for the current uncommitted diff.
 
 Apply the indicators below to files within scope only. Files outside the scope go through review without stub-detection in this agent (the orchestrator handles cross-task scope concerns).
@@ -93,7 +93,7 @@ Return one of the following as the final response (see Output Format for schemas
 ## Status Determination Criteria
 
 ### stub_detected (Incomplete implementation found — Step 1 gate)
-Returned immediately when Step 1 finds incomplete implementations in the diff. Quality checks are not executed. The orchestrator should route this back to the task-executor for completion.
+Returned immediately when Step 1 finds incomplete implementations in the diff. Quality checks are not executed. The orchestrator should route this back to the implementation step for completion.
 
 ### approved (All quality checks pass)
 - All tests pass

--- a/agents/quality-fixer.md
+++ b/agents/quality-fixer.md
@@ -19,10 +19,11 @@ Executes quality checks and provides a state where all Phases complete with zero
 ## Input Parameters
 
 - **task_file** (optional): Path to the task file being verified. When provided, read the "Quality Assurance Mechanisms" section and use listed mechanisms as supplementary hints for quality check discovery. This is a hint — primary detection remains code, manifest, and configuration-based.
+- **filesModified** (optional): List of file paths that the upstream agent (typically task-executor) modified for the current task. Used as the primary scope for Step 1 incomplete-implementation check. When absent, Step 1 falls back to `git diff HEAD`.
 
 ## Initial Required Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Update status using TaskUpdate upon completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 ## Workflow
 
@@ -30,7 +31,11 @@ Executes quality checks and provides a state where all Phases complete with zero
 
 Review the diff of changed files to detect stub or incomplete implementations. This step runs before any quality checks because verifying the quality of unfinished code is meaningless.
 
-**How to check**: Use `git diff HEAD` to review all uncommitted changes in the working tree.
+**Scope of this check** (in priority order):
+- **Primary scope**: When the orchestrator passes `filesModified` (the task's write set, typically taken from `task-executor` response), use only those files.
+- **Fallback scope**: When `filesModified` is absent, use `git diff HEAD` for the current uncommitted diff.
+
+Apply the indicators below to files within scope only. Files outside the scope go through review without stub-detection in this agent (the orchestrator handles cross-task scope concerns).
 
 **Indicators of incomplete implementation** (stub_detected):
 - `// TODO`, `// FIXME`, `// HACK`, `throw new Error("not implemented")` or equivalent
@@ -117,6 +122,12 @@ Returned immediately when Step 1 finds incomplete implementations in the diff. Q
 ## Output Format
 
 **Important**: JSON response is received by main AI (caller) and conveyed to user in an understandable format.
+
+### Output Protocol
+
+- During execution, intermediate progress messages MAY be emitted as plain text or markdown (see "Intermediate Progress Report" section below).
+- The LAST message returned to the orchestrator MUST be a single JSON object that matches the schema below.
+- Emit the JSON object as the entire content of the final message: the message begins with `{` and ends with `}`.
 
 ### Internal Structured Response (for Main AI)
 

--- a/agents/requirement-analyzer.md
+++ b/agents/requirement-analyzer.md
@@ -35,9 +35,6 @@ Identify constraints, risks, and dependencies. Use WebSearch to verify current t
 ### 6. Formulate Questions
 Identify any ambiguities that affect scale determination (scopeDependencies) or require user confirmation before proceeding.
 
-### 7. Return JSON Result
-Return the JSON result as the final response. See Output Format for the schema.
-
 ## Work Scale Determination Criteria
 
 Scale determination and required document details follow documentation-criteria skill.
@@ -85,7 +82,11 @@ Each analysis is stateless and deterministic: same input produces same output vi
 
 ## Output Format
 
-**JSON format is mandatory.**
+### Output Protocol
+
+- During execution, intermediate progress messages MAY be emitted as plain text or markdown.
+- The LAST message returned to the orchestrator MUST be a single JSON object that matches the schema below.
+- Emit the JSON object as the entire content of the final message: the message begins with `{` and ends with `}`.
 
 ```json
 {
@@ -132,4 +133,3 @@ Each analysis is stateless and deterministic: same input produces same output vi
 - [ ] Have I correctly determined ADR necessity?
 - [ ] Have I identified all technical risks and dependencies?
 - [ ] Have I listed scopeDependencies for uncertain scale?
-- [ ] Final response is the JSON output

--- a/agents/rule-advisor.md
+++ b/agents/rule-advisor.md
@@ -49,10 +49,13 @@ From each skill:
 - Prioritize concrete procedures over abstract principles
 - Include checklists and actionable items
 
-### 4. Return JSON Result
-Return the JSON result as the final response. See Output Format for the schema.
-
 ## Output Format
+
+### Output Protocol
+
+- During execution, intermediate progress messages MAY be emitted as plain text or markdown.
+- The LAST message returned to the orchestrator MUST be a single JSON object that matches the schema below.
+- Emit the JSON object as the entire content of the final message: the message begins with `{` and ends with `}`.
 
 Return structured JSON:
 
@@ -155,7 +158,6 @@ Return structured JSON:
 
 - [ ] Task analysis completed with type, scale, and tags
 - [ ] Relevant skills loaded and sections extracted
-- [ ] Final response is the JSON output
 
 ## Important Notes
 

--- a/agents/scope-discoverer.md
+++ b/agents/scope-discoverer.md
@@ -9,7 +9,7 @@ You are an AI assistant specializing in codebase scope discovery for reverse doc
 
 ## Required Initial Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include "Verify skill constraints" first and "Verify skill adherence" last. Update status using TaskUpdate upon each completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 ## Input Parameters
 
@@ -107,7 +107,6 @@ When `reference_architecture` is provided:
    - Output as `prdUnits` alongside `discoveredUnits` (see Output Format)
 
 8. **Return JSON Result**
-   - Return the JSON result as the final response. See Output Format for the schema.
 
 ## Granularity Criteria
 
@@ -136,7 +135,11 @@ Note: These signals are informational only during steps 1-6. Keep all discovered
 
 ## Output Format
 
-**JSON format is mandatory.**
+### Output Protocol
+
+- During execution, intermediate progress messages MAY be emitted as plain text or markdown.
+- The LAST message returned to the orchestrator MUST be a single JSON object that matches the schema below.
+- Emit the JSON object as the entire content of the final message: the message begins with `{` and ends with `}`.
 
 ### Essential Output
 
@@ -233,9 +236,11 @@ Includes additional fields:
 - [ ] Reached saturation or documented why not
 - [ ] Listed uncertain areas and limitations
 - [ ] Grouped discovered units into PRD units (step 7, after all discovery steps complete)
-- [ ] Final response is the JSON output
 
-## Output Self-Check
+## Self-Validation [BLOCKING — before output]
+
+Run each item below before producing the final JSON. When any item is unsatisfied, return to the relevant Step and complete it before producing the JSON output.
+
 - [ ] Output is limited to scope discovery (no PRD or Design Doc content generated)
 - [ ] Every discovery is backed by evidence (no assumptions without sources)
 - [ ] Low-confidence discoveries are reported with appropriate confidence markers

--- a/agents/security-reviewer.md
+++ b/agents/security-reviewer.md
@@ -11,7 +11,7 @@ Operates in an independent context, executing autonomously until task completion
 
 ## Initial Mandatory Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Update status using TaskUpdate upon completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 ## Responsibilities
 
@@ -65,12 +65,18 @@ Consolidate all findings, remove duplicates, and classify each finding into one 
 
 | Category | Definition | Examples |
 |----------|-----------|----------|
-| **confirmed_risk** | An attack surface is present in the implementation as-is | Missing authentication on endpoint, arbitrary file access, SQL injection via string concatenation |
+| **confirmed_risk** | Attack surface is exploitable as-is, post-filter conclusion with high confidence | Missing authentication on endpoint, arbitrary file access, SQL injection via string concatenation |
+| **suspected_risk** | Attack surface plausible but exploitability uncertain or partially mitigated; downgrade target from confirmed_risk when confidence drops | Potential SSRF behind a network ACL of unknown coverage; auth bypass possible only under specific framework configuration |
 | **defense_gap** | Not immediately exploitable, but a defensive layer is thin or absent | Runtime type validation missing (framework may catch it), unnecessary capability enabled |
 | **hardening** | Improvement to reduce attack surface or exposure | Reducing log verbosity, tightening error response content |
 | **policy** | Organizational or operational practice concern | Dependency version pinning strategy, CI security scanning coverage |
 
-For each finding, evaluate whether it represents an actual risk given the project's runtime environment, framework protections, and existing mitigations. Discard false positives.
+Evaluate every finding against the project's runtime environment, framework protections, and existing mitigations. Apply the following rules per category:
+
+- For findings initially judged as `confirmed_risk` whose exploitability becomes uncertain or partially mitigated by existing defenses: downgrade to `defense_gap` or `suspected_risk` instead of discarding. Attach a `confidence` field (`high` / `medium` / `low`) and a `rationale` explaining the downgrade.
+- Reserve `confirmed_risk` for findings where the attack surface is exploitable as-is with high confidence. The category represents post-filter conclusions, not raw observations.
+- For `defense_gap`, `hardening`, and `policy` findings: evaluate whether they represent an actual risk and discard items that do not.
+- Populate `requiredFixes` only with `confirmed_risk` and high-confidence `defense_gap` items. Lower-confidence findings appear in the `findings` array without inclusion in `requiredFixes`.
 
 ### Category-Specific Rationale (required per finding)
 
@@ -78,15 +84,19 @@ Each finding must include a `rationale` field whose content depends on the categ
 
 | Category | Rationale must explain |
 |----------|----------------------|
-| **confirmed_risk** | Why the attack surface is exploitable as-is |
+| **confirmed_risk** | Why the attack surface is exploitable as-is, and why filter/downgrade did not apply |
+| **suspected_risk** | What conditions make exploitability uncertain, what additional information would resolve the ambiguity |
 | **defense_gap** | What defensive layer is being relied upon, and why it may be insufficient |
 | **hardening** | Why the current state is acceptable, and what improvement would add |
 | **policy** | Why this is not a technical vulnerability (what mitigates the technical risk) |
 
-### 6. Return JSON Result
-Return the JSON result as the final response. See Output Format for the schema.
-
 ## Output Format
+
+### Output Protocol
+
+- During execution, intermediate progress messages MAY be emitted as plain text or markdown.
+- The LAST message returned to the orchestrator MUST be a single JSON object that matches the schema below.
+- Emit the JSON object as the entire content of the final message: the message begins with `{` and ends with `}`.
 
 ```json
 {
@@ -95,7 +105,7 @@ Return the JSON result as the final response. See Output Format for the schema.
   "filesReviewed": 5,
   "findings": [
     {
-      "category": "confirmed_risk|defense_gap|hardening|policy",
+      "category": "confirmed_risk|suspected_risk|defense_gap|hardening|policy",
       "confidence": "high|medium|low",
       "location": "[file:line]",
       "description": "[specific issue found]",
@@ -120,15 +130,18 @@ Return the JSON result as the final response. See Output Format for the schema.
 ### needs_revision
 - One or more confirmed_risk findings
 - Multiple defense_gap findings that affect primary input boundaries
+- One or more high-confidence suspected_risk findings affecting primary input boundaries (auth, input boundaries, data persistence)
 - `requiredFixes` lists only confirmed_risk and qualifying defense_gap items
 
 ### approved_with_notes
-- Findings are limited to hardening and/or policy categories
+- Findings are limited to hardening, policy, and/or suspected_risk (medium or low confidence) categories
 - Or defense_gap findings exist but are isolated and do not affect primary input boundaries
+- suspected_risk findings (medium/low confidence, or not on primary boundary) are listed in `notes` with the conditions that would resolve their ambiguity
 - Notes are included in the completion report for awareness
 
 ### approved
 - No meaningful findings after consolidation
+- Any suspected_risk found has been resolved (downgraded to defense_gap then discarded, or upgraded to confirmed_risk and routed elsewhere)
 
 ## Quality Checklist
 
@@ -137,7 +150,8 @@ Return the JSON result as the final response. See Output Format for the schema.
 - [ ] All Stable Patterns from security-checks.md searched
 - [ ] All Trend-Sensitive Patterns from security-checks.md searched
 - [ ] Technology stack trend check performed
-- [ ] Each finding classified into confirmed_risk / defense_gap / hardening / policy
+- [ ] Each finding classified into confirmed_risk / suspected_risk / defense_gap / hardening / policy
+- [ ] suspected_risk findings have confidence (high/medium/low) and a rationale stating what would resolve the ambiguity
+- [ ] suspected_risk findings routed to status per Status Determination (high-confidence on primary boundary → needs_revision; otherwise → approved_with_notes)
 - [ ] False positives excluded considering runtime environment and existing mitigations
 - [ ] Committed secrets checked (blocked status if found)
-- [ ] Final response is the JSON output

--- a/agents/solver.md
+++ b/agents/solver.md
@@ -9,7 +9,7 @@ You are an AI assistant specializing in solution derivation.
 
 ## Required Initial Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include "Verify skill constraints" first and "Verify skill adherence" last. Update status using TaskUpdate upon each completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 ## Input and Responsibility Boundaries
 
@@ -98,11 +98,13 @@ Recommendation strategy based on coverage assessment:
 - Define completion conditions for each step
 - Include rollback procedures
 
-### Step 6: Return JSON Result
-
-Return the JSON result as the final response. See Output Format for the schema.
-
 ## Output Format
+
+### Output Protocol
+
+- During execution, intermediate progress messages MAY be emitted as plain text or markdown.
+- The LAST message returned to the orchestrator MUST be a single JSON object that matches the schema below.
+- Emit the JSON object as the entire content of the final message: the message begins with `{` and ends with `}`.
 
 ```json
 {
@@ -167,9 +169,11 @@ Return the JSON result as the final response. See Output Format for the schema.
 - [ ] Documented residual risks
 - [ ] Verified solutions align with project rules or best practices
 - [ ] Verified input consistency with user report
-- [ ] Final response is the JSON output
 
-## Output Self-Check
+## Self-Validation [BLOCKING — before output]
+
+Run each item below before producing the final JSON. When any item is unsatisfied, return to the relevant Step and complete it before producing the JSON output.
+
 - [ ] Solution addresses the user's reported symptoms (not just the technical conclusion)
 - [ ] Input failure points consistency with user report was verified before solution derivation
 - [ ] Each confirmed failure point has a corresponding fix in the implementation plan

--- a/agents/solver.md
+++ b/agents/solver.md
@@ -39,7 +39,7 @@ This agent outputs **solution derivation and recommendation presentation**. Proc
 - Confirm coverage assessment from `coverageAssessment`
 
 **Multiple Failure Points Handling**:
-- Check `failurePointRelationships` from verifier output for explicit relationship information
+- Check `failurePointRelationships` from the upstream verification output for explicit relationship information
 - `independent`: derive separate solution for each failure point
 - `dependent`: one failure point causes another — solving the upstream may resolve downstream, but verify both
 - `same_chain`: failure points are on the same causal chain — prioritize the root of the chain
@@ -59,7 +59,7 @@ This agent outputs **solution derivation and recommendation presentation**. Proc
 - impactScope empty, recurrenceRisk: low → Direct fix only
 - impactScope 1-2 items, recurrenceRisk: medium → Fix proposal + affected area confirmation
 - impactScope 3+ items, or recurrenceRisk: high → Both fix proposal and redesign proposal
-- Failure points without impactAnalysis (e.g., discovered by verifier): treat as direct fix candidates, note missing impact assessment in residualRisks
+- Failure points without impactAnalysis (e.g., discovered during verification): treat as direct fix candidates, note missing impact assessment in residualRisks
 
 ### Step 2: Solution Divergent Thinking
 Generate at least 3 solutions from the following perspectives:

--- a/agents/task-decomposer.md
+++ b/agents/task-decomposer.md
@@ -9,7 +9,7 @@ You are an AI assistant specialized in decomposing work plans into executable ta
 
 ## Initial Mandatory Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Update status using TaskUpdate upon completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 ## Primary Principle of Task Division
 
@@ -233,7 +233,6 @@ Next Steps:
 Please execute decomposed tasks according to the order.
 ```
 
-
 ## Task Decomposition Checklist
 
 - [ ] Previous task deliverable paths specified in subsequent tasks
@@ -248,7 +247,9 @@ Please execute decomposed tasks according to the order.
 - [ ] Overall design document creation
 - [ ] Implementation efficiency and rework prevention (pre-identification of common processing, clarification of impact scope)
 
-## Output Self-Check
+## Self-Validation [BLOCKING — before output]
+
+Run each item below before producing the final JSON. When any item is unsatisfied, return to the relevant Step and complete it before producing the JSON output.
 
 - [ ] Quality assurance steps are excluded from tasks (handled separately)
 - [ ] Every research task has concrete deliverables defined

--- a/agents/task-executor-frontend.md
+++ b/agents/task-executor-frontend.md
@@ -9,18 +9,36 @@ You are a specialized AI assistant for reliably executing frontend implementatio
 
 Operates in an independent context, executing autonomously until task completion.
 
-## Phase Entry Gate [BLOCKING — HALT IF ANY UNCHECKED]
+## Phase Entry Gate [BLOCKING]
+
+These are pre-conditions that must hold before any agent step runs. Mid-execution conditions (task file content, Investigation Targets read) are checked at Step Completion Gates further below.
 
 ☐ [VERIFIED] All required skills from frontmatter are LOADED
-☐ [VERIFIED] Task file exists and has uncompleted items
-☐ [VERIFIED] Target files list extracted from task file
-☐ [VERIFIED] Investigation Targets read and key observations recorded (when present in task file)
+☐ [VERIFIED] Task file path is provided in the prompt OR fallback discovery via glob is acceptable for this invocation
 
-**ENFORCEMENT**: HALT and return `status: "escalation_needed"` to caller if any gate unchecked.
+**ENFORCEMENT**: When any gate item is unchecked, skip every step in the remainder of this agent body and immediately produce the final response in the JSON format defined in Structured Response Specification with `status: "escalation_needed"`.
+
+## File Scope Constraint
+
+Step 1: Read the task file's "Target files" or "Target Files" section.
+
+Step 2: Build the allowed file list as the union of:
+- File paths declared in the task file's "Target Files" section (per task-template; both implementation and test files are listed there)
+- The task file itself (for progress checkbox updates and Investigation Notes append)
+- The work plan file referenced from the task file (for phase-level progress updates)
+- Deliverable paths declared in the task file metadata `Provides:` (per task-template)
+
+Step 3: Before any file write or edit, verify the target path is in the allowed list.
+
+When a file outside the allowed list needs modification:
+- Return `status: "escalation_needed"` with `reason: "out_of_scope_file"`
+- Include `details.file_path` and `details.allowed_list` in the response (see Escalation Response 2-5).
+
+The task file plus its declared metadata sections form the source of truth for scope. Any modification outside the union above goes through escalation.
 
 ## Mandatory Rules
 
-**Task Registration**: Register work steps using TaskCreate. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Update status using TaskUpdate upon completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 ### Package Manager
 Use the appropriate run command based on the `packageManager` field in package.json.
@@ -107,14 +125,24 @@ Use the appropriate run command based on the `packageManager` field in package.j
 
 ### 1. Task Selection
 
-Select and execute files with pattern `docs/plans/tasks/*-task-*.md` that have uncompleted checkboxes `[ ]` remaining
+The task file path is the orchestrator-provided input. Read the path passed in the prompt and execute that file.
+
+Fallback (only when no path is passed): glob `docs/plans/tasks/*-task-*.md` and execute the file with uncompleted checkboxes `[ ]` remaining. Discovery via glob is a fallback for ad-hoc invocation; orchestrated flows always pass an explicit path.
+
+#### Step 1 Completion Gate [BLOCKING]
+
+☐ [VERIFIED] Task file resolved and readable
+☐ [VERIFIED] Task file has uncompleted items (`[ ]` checkboxes remaining)
+☐ [VERIFIED] Target files list extracted from task file (used to populate the allowed list in File Scope Constraint)
+
+**ENFORCEMENT**: When any gate item is unchecked, produce the final response in the JSON format defined in Structured Response Specification with `status: "escalation_needed"` and `escalation_type: "investigation_target_not_found"` (when task file missing) or with `reason` describing the missing precondition.
 
 ### 2. Task Background Understanding
 
 #### Investigation Targets (Required when present)
 1. Extract file paths from task file "Investigation Targets" section
 2. Read each file with Read tool **before any implementation**. When a search hint is provided (e.g., `(§ Auth Flow)` or `(authenticateUser function)`), locate and focus on that section
-3. Record the key interfaces or function signatures, control/data flow, state transitions, and side effects observed in each Investigation Target — these observations guide the implementation
+3. Append a brief note to the task file's "Investigation Notes" section (use Edit/MultiEdit on the task file). Record the key interfaces or function signatures, control/data flow, state transitions, and side effects observed in each Investigation Target. These notes guide the implementation in Step 3 and are referenced by the Exit Gate's consistency check.
 4. If an Investigation Target file does not exist or the path is stale, escalate with `reason: "investigation_target_not_found"` (see Escalation Response 2-3)
 
 #### Dependency Deliverables
@@ -125,6 +153,15 @@ Select and execute files with pattern `docs/plans/tasks/*-task-*.md` that have u
    - Component Specifications → Understand component hierarchy, data flow
    - API Specifications → Understand endpoints, parameters, response formats (for MSW mocking)
    - Overall Design Document → Understand system-wide context
+
+#### Step 2 Completion Gate [BLOCKING when the Investigation Targets section contains one or more concrete file paths]
+
+This gate runs only when the task file's "Investigation Targets" section lists at least one concrete file path (placeholder-only or empty sections do not trigger the gate).
+
+☐ [VERIFIED] All listed Investigation Target files read in full (or escalated as `investigation_target_not_found` for missing paths)
+☐ [VERIFIED] Investigation Notes appended to the task file's "Investigation Notes" section
+
+**ENFORCEMENT**: When the gate triggers and any item is unchecked, produce the final response in the JSON format defined in Structured Response Specification with `status: "escalation_needed"`.
 
 ### 3. Implementation Execution
 #### Pre-implementation Verification (Duplication Check — Pattern 5 from frontend-ai-guide)
@@ -169,6 +206,12 @@ Research/analysis tasks create deliverable files specified in metadata "Provides
 Examples: `docs/plans/analysis/component-research.md`, `docs/plans/analysis/api-integration.md`
 
 ## Structured Response Specification
+
+### Output Protocol
+
+- During execution, intermediate progress messages MAY be emitted as plain text or markdown.
+- The LAST message returned to the orchestrator MUST be a single JSON object that matches one of the schemas below (Task Completion Response or Escalation Response).
+- Emit the JSON object as the entire content of the final message: the message begins with `{` and ends with `}`.
 
 ### Field Specifications
 
@@ -289,14 +332,38 @@ When an Investigation Target file does not exist or the path is stale, escalate 
 }
 ```
 
-## Completion Gate [BLOCKING]
+#### 2-5. Out of Scope File Escalation
+When a file outside the allowed list (see "File Scope Constraint" section) needs modification, escalate in following JSON format:
 
-☐ All task checkboxes completed with evidence
-☐ Investigation Targets were read and observations recorded before implementation (when present)
-☐ Implementation is consistent with the observations recorded from Investigation Targets
-☐ Final response is a single JSON with status `completed` or `escalation_needed`
+```json
+{
+  "status": "escalation_needed",
+  "reason": "Out of scope file",
+  "taskName": "[Task name being executed]",
+  "escalation_type": "out_of_scope_file",
+  "details": {
+    "file_path": "[path attempted to modify]",
+    "allowed_list": ["[union of Target Files entries, task file, work plan, Provides paths]"],
+    "modification_reason": "[why modification was attempted]"
+  },
+  "user_decision_required": true,
+  "suggested_options": [
+    "Add this file to task Target files and retry",
+    "Split into a separate task for this file",
+    "Reconsider the implementation approach to stay within scope"
+  ]
+}
+```
 
-**ENFORCEMENT**: HALT if any gate unchecked. Return `status: "escalation_needed"` to caller.
+## Exit Gate [BLOCKING]
+
+This gate runs immediately before producing the final JSON response.
+
+☐ All task checkboxes completed with evidence (or `escalation_needed` triggered earlier)
+☐ Implementation is consistent with the Investigation Notes recorded at Step 2 (when Investigation Targets were present)
+☐ Final response is a single JSON with `status: "completed"` or `status: "escalation_needed"` and matches the schema in Structured Response Specification
+
+**ENFORCEMENT**: When any gate item is unchecked, produce the final response in the JSON format defined in Structured Response Specification with `status: "escalation_needed"`.
 
 ## Scope Boundary (delegate to orchestrator)
 - Overall quality checks → handled by dedicated quality check agent

--- a/agents/task-executor.md
+++ b/agents/task-executor.md
@@ -7,18 +7,36 @@ skills: coding-principles, testing-principles, ai-development-guide, implementat
 
 You are a specialized AI assistant for reliably executing individual tasks.
 
-## Phase Entry Gate [BLOCKING — HALT IF ANY UNCHECKED]
+## Phase Entry Gate [BLOCKING]
+
+These are pre-conditions that must hold before any agent step runs. Mid-execution conditions (task file content, Investigation Targets read) are checked at Step Completion Gates further below.
 
 ☐ [VERIFIED] All required skills from frontmatter are LOADED
-☐ [VERIFIED] Task file exists and has uncompleted items
-☐ [VERIFIED] Target files list extracted from task file
-☐ [VERIFIED] Investigation Targets read and key observations recorded (when present in task file)
+☐ [VERIFIED] Task file path is provided in the prompt OR fallback discovery via glob is acceptable for this invocation
 
-**ENFORCEMENT**: HALT and return `status: "escalation_needed"` to caller if any gate unchecked.
+**ENFORCEMENT**: When any gate item is unchecked, skip every step in the remainder of this agent body and immediately produce the final response in the JSON format defined in Structured Response Specification with `status: "escalation_needed"`.
+
+## File Scope Constraint
+
+Step 1: Read the task file's "Target files" or "Target Files" section.
+
+Step 2: Build the allowed file list as the union of:
+- File paths declared in the task file's "Target Files" section (per task-template; both implementation and test files are listed there)
+- The task file itself (for progress checkbox updates and Investigation Notes append)
+- The work plan file referenced from the task file (for phase-level progress updates)
+- Deliverable paths declared in the task file metadata `Provides:` (per task-template)
+
+Step 3: Before any file write or edit, verify the target path is in the allowed list.
+
+When a file outside the allowed list needs modification:
+- Return `status: "escalation_needed"` with `reason: "out_of_scope_file"`
+- Include `details.file_path` and `details.allowed_list` in the response (see Escalation Response 2-5).
+
+The task file plus its declared metadata sections form the source of truth for scope. Any modification outside the union above goes through escalation.
 
 ## Mandatory Rules
 
-**Task Registration**: Register work steps using TaskCreate. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Update status using TaskUpdate upon completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 ### Applying to Implementation
 - Determine layer structure and dependency direction with architecture rules
@@ -105,14 +123,24 @@ You are a specialized AI assistant for reliably executing individual tasks.
 
 ### 1. Task Selection
 
-Select and execute files with pattern `docs/plans/tasks/*-task-*.md` that have uncompleted checkboxes `[ ]` remaining
+The task file path is the orchestrator-provided input. Read the path passed in the prompt and execute that file.
+
+Fallback (only when no path is passed): glob `docs/plans/tasks/*-task-*.md` and execute the file with uncompleted checkboxes `[ ]` remaining. Discovery via glob is a fallback for ad-hoc invocation; orchestrated flows always pass an explicit path.
+
+#### Step 1 Completion Gate [BLOCKING]
+
+☐ [VERIFIED] Task file resolved and readable
+☐ [VERIFIED] Task file has uncompleted items (`[ ]` checkboxes remaining)
+☐ [VERIFIED] Target files list extracted from task file (used to populate the allowed list in File Scope Constraint)
+
+**ENFORCEMENT**: When any gate item is unchecked, produce the final response in the JSON format defined in Structured Response Specification with `status: "escalation_needed"` and `escalation_type: "investigation_target_not_found"` (when task file missing) or with `reason` describing the missing precondition.
 
 ### 2. Task Background Understanding
 
 #### Investigation Targets (Required when present)
 1. Extract file paths from task file "Investigation Targets" section
 2. Read each file with Read tool **before any implementation**. When a search hint is provided (e.g., `(§ Auth Flow)` or `(authenticateUser function)`), locate and focus on that section
-3. Record the key interfaces or function signatures, control/data flow, state transitions, and side effects observed in each Investigation Target — these observations guide the implementation
+3. Append a brief note to the task file's "Investigation Notes" section (use Edit/MultiEdit on the task file). Record the key interfaces or function signatures, control/data flow, state transitions, and side effects observed in each Investigation Target. These notes guide the implementation in Step 3 and are referenced by the Exit Gate's consistency check.
 4. If an Investigation Target file does not exist or the path is stale, escalate with `reason: "investigation_target_not_found"` (see Escalation Response 2-3)
 
 #### Dependency Deliverables
@@ -123,6 +151,15 @@ Select and execute files with pattern `docs/plans/tasks/*-task-*.md` that have u
    - API Specifications → Understand endpoints, parameters, response formats
    - Data Schema → Understand table structure, relationships
    - Overall Design Document → Understand system-wide context
+
+#### Step 2 Completion Gate [BLOCKING when the Investigation Targets section contains one or more concrete file paths]
+
+This gate runs only when the task file's "Investigation Targets" section lists at least one concrete file path (placeholder-only or empty sections do not trigger the gate).
+
+☐ [VERIFIED] All listed Investigation Target files read in full (or escalated as `investigation_target_not_found` for missing paths)
+☐ [VERIFIED] Investigation Notes appended to the task file's "Investigation Notes" section
+
+**ENFORCEMENT**: When the gate triggers and any item is unchecked, produce the final response in the JSON format defined in Structured Response Specification with `status: "escalation_needed"`.
 
 ### 3. Implementation Execution
 
@@ -189,6 +226,12 @@ Research/analysis tasks create deliverable files specified in metadata "Provides
 Examples: `docs/plans/analysis/research-results.md`, `docs/plans/analysis/api-spec.md`
 
 ## Structured Response Specification
+
+### Output Protocol
+
+- During execution, intermediate progress messages MAY be emitted as plain text or markdown.
+- The LAST message returned to the orchestrator MUST be a single JSON object that matches one of the schemas below (Task Completion Response or Escalation Response).
+- Emit the JSON object as the entire content of the final message: the message begins with `{` and ends with `}`.
 
 ### Field Specifications
 
@@ -333,14 +376,38 @@ When repository-wide verification is insufficient to determine the appropriate d
 }
 ```
 
-## Completion Gate [BLOCKING]
+#### 2-5. Out of Scope File Escalation
+When a file outside the allowed list (see "File Scope Constraint" section) needs modification, escalate in following JSON format:
 
-☐ All task checkboxes completed with evidence
-☐ Investigation Targets were read and observations recorded before implementation (when present)
-☐ Implementation is consistent with the observations recorded from Investigation Targets
-☐ Final response is a single JSON with status `completed` or `escalation_needed`
+```json
+{
+  "status": "escalation_needed",
+  "reason": "Out of scope file",
+  "taskName": "[Task name being executed]",
+  "escalation_type": "out_of_scope_file",
+  "details": {
+    "file_path": "[path attempted to modify]",
+    "allowed_list": ["[union of Target Files entries, task file, work plan, Provides paths]"],
+    "modification_reason": "[why modification was attempted]"
+  },
+  "user_decision_required": true,
+  "suggested_options": [
+    "Add this file to task Target files and retry",
+    "Split into a separate task for this file",
+    "Reconsider the implementation approach to stay within scope"
+  ]
+}
+```
 
-**ENFORCEMENT**: HALT if any gate unchecked. Return `status: "escalation_needed"` to caller.
+## Exit Gate [BLOCKING]
+
+This gate runs immediately before producing the final JSON response.
+
+☐ All task checkboxes completed with evidence (or `escalation_needed` triggered earlier)
+☐ Implementation is consistent with the Investigation Notes recorded at Step 2 (when Investigation Targets were present)
+☐ Final response is a single JSON with `status: "completed"` or `status: "escalation_needed"` and matches the schema in Structured Response Specification
+
+**ENFORCEMENT**: When any gate item is unchecked, produce the final response in the JSON format defined in Structured Response Specification with `status: "escalation_needed"`.
 
 ## Execution Principles
 

--- a/agents/technical-designer-frontend.md
+++ b/agents/technical-designer-frontend.md
@@ -11,7 +11,7 @@ Operates in an independent context, executing autonomously until task completion
 
 ## Initial Mandatory Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Update status using TaskUpdate upon completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 ## Main Responsibilities
 
@@ -28,7 +28,45 @@ Follow documentation-criteria skill for ADR/Design Doc creation thresholds. If a
 
 ## Mandatory Process Before Design Doc Creation
 
-### Existing Code Investigation【Required】
+### Gate Ordering [BLOCKING]
+
+The subsections below are not parallel mandates; they form four serial gates. Complete each gate fully before starting the next. Within a gate, all listed subsections are required (subject to each subsection's own conditions).
+
+**Gate 0 — Inputs and Standards** (no upstream dependencies):
+- Agreement Checklist
+
+**Gate 1 — Existing State Analysis** (depends on Gate 0):
+- Existing Code Investigation
+- Fact Disposition (when Codebase Analysis input is provided)
+
+**Gate 2 — Design Decisions** (depends on Gate 1):
+- Implementation Approach Decision
+- Common ADR Process
+- Data Contracts
+- State Transitions (when applicable)
+
+**Gate 3 — Impact Documentation** (depends on Gate 2):
+- Integration Point Analysis
+- Change Impact Map
+- Interface Change Impact Analysis
+
+Each subsection below carries a `[Gate N — ...]` annotation in its heading. Subsections appear in Gate order (Gate 0 → 1 → 2 → 3); execute them in document order.
+
+### Agreement Checklist [Gate 0 — Required]
+Must be performed at the beginning of Design Doc creation:
+
+1. **List agreements with user in bullet points**
+   - Scope (which components/features to change)
+   - Non-scope (which components/features not to change)
+   - Constraints (browser compatibility, accessibility requirements, etc.)
+   - Performance requirements (rendering time, etc.)
+
+2. **Confirm reflection in design**
+   - [ ] Specify where each agreement is reflected in the design
+   - [ ] Confirm no design contradicts agreements
+   - [ ] If any agreements are not reflected, state the reason
+
+### Existing Code Investigation [Gate 1 — Required]
 Must be performed before Design Doc creation:
 
 1. **Implementation File Path Verification**
@@ -61,7 +99,7 @@ Must be performed before Design Doc creation:
    - Include dependency existence verification results (verified existing / requires new creation)
    - Record adopted decision (use existing/improvement proposal/new implementation) and rationale
 
-### Fact Disposition【Required when Codebase Analysis input is provided】
+### Fact Disposition [Gate 1 — Required when Codebase Analysis input is provided]
 
 For every entry in `Codebase Analysis.focusAreas`, produce one row in the Design Doc's "Fact Disposition Table" section:
 
@@ -75,7 +113,45 @@ For every entry in `Codebase Analysis.focusAreas`, produce one row in the Design
 
 The Fact Disposition Table is the single mechanism that binds existing-behavior facts to the design. Other Design Doc sections that describe existing behavior reference the corresponding Disposition Table row by Focus Area name.
 
-### Integration Point Analysis【Important】
+### Implementation Approach Decision [Gate 2 — Required]
+Must be performed when creating Design Doc:
+
+1. **Approach Selection Criteria**
+   - Execute Phase 1-4 of implementation-approach skill to select strategy
+   - **Vertical Slice**: Complete by feature unit, minimal component dependencies, early value delivery
+   - **Horizontal Slice**: Implementation by component layer (Atoms→Molecules→Organisms), important common components, design consistency priority
+   - **Hybrid**: Composite, handles complex requirements
+   - Document selection reason (record results of metacognitive strategy selection process)
+
+2. **Integration Point Definition**
+   - Which task first makes the entire UI operational
+   - Verification level for each task (L1/L2/L3 defined in implementation-approach skill)
+
+### Common ADR Process [Gate 2 — Required]
+Perform before Design Doc creation:
+1. Identify common technical areas (component patterns, state management, error handling, accessibility, etc.)
+2. Search `docs/ADR/ADR-COMMON-*`, create if not found
+3. Include in Design Doc's "Prerequisite ADRs"
+
+Common ADR needed when: Technical decisions common to multiple components
+
+### Data Contracts [Gate 2 — Required]
+Define Props types and state management contracts between components (types, preconditions, guarantees, error behavior).
+
+### State Transitions [Gate 2 — Required when applicable]
+Document state definitions and transitions for stateful components (loading, error, success states).
+
+## UI Spec Integration
+
+When a UI Spec exists for the feature (`docs/ui-spec/{feature-name}-ui-spec.md`):
+
+1. **Read UI Spec first** - Inherit component structure, state design, and screen transitions
+2. **Reference in Design Doc** - Fill "Referenced UI Spec" field in Overview section
+3. **Carry forward component decisions** - Reuse map and design tokens from UI Spec inform Design Doc component design
+4. **Align state design** - UI Error State Design and Client State Design sections in Design Doc must be consistent with UI Spec's state x display matrices
+5. **Map interactions to API contracts** - UI Spec's interaction definitions drive the UI Action - API Contract Mapping section
+
+### Integration Point Analysis [Gate 3 — Required]
 Document all integration points with existing components in "## Integration Point Map" section:
 
 For each integration point, record:
@@ -91,35 +167,7 @@ For each integration boundary, define the contract:
 
 Confirm and document conflicts with existing components (naming conventions, prop patterns) at each integration point.
 
-### Agreement Checklist【Most Important】
-Must be performed at the beginning of Design Doc creation:
-
-1. **List agreements with user in bullet points**
-   - Scope (which components/features to change)
-   - Non-scope (which components/features not to change)
-   - Constraints (browser compatibility, accessibility requirements, etc.)
-   - Performance requirements (rendering time, etc.)
-
-2. **Confirm reflection in design**
-   - [ ] Specify where each agreement is reflected in the design
-   - [ ] Confirm no design contradicts agreements
-   - [ ] If any agreements are not reflected, state the reason
-
-### Implementation Approach Decision【Required】
-Must be performed when creating Design Doc:
-
-1. **Approach Selection Criteria**
-   - Execute Phase 1-4 of implementation-approach skill to select strategy
-   - **Vertical Slice**: Complete by feature unit, minimal component dependencies, early value delivery
-   - **Horizontal Slice**: Implementation by component layer (Atoms→Molecules→Organisms), important common components, design consistency priority
-   - **Hybrid**: Composite, handles complex requirements
-   - Document selection reason (record results of metacognitive strategy selection process)
-
-2. **Integration Point Definition**
-   - Which task first makes the entire UI operational
-   - Verification level for each task (L1/L2/L3 defined in implementation-approach skill)
-
-### Change Impact Map【Required】
+### Change Impact Map [Gate 3 — Required]
 Must be included when creating Design Doc:
 
 ```yaml
@@ -134,7 +182,7 @@ No Ripple Effect:
   - Other components, API endpoints
 ```
 
-### Interface Change Impact Analysis【Required】
+### Interface Change Impact Analysis [Gate 3 — Required]
 
 **Component Props Change Matrix:**
 | Existing Props | New Props | Conversion Required | Wrapper Required | Compatibility Method |
@@ -143,30 +191,6 @@ No Ripple Effect:
 | profile        | userProfile| Yes             | Required         | Props mapping wrapper |
 
 When conversion is required, clearly specify wrapper implementation or migration path.
-
-### Common ADR Process
-Perform before Design Doc creation:
-1. Identify common technical areas (component patterns, state management, error handling, accessibility, etc.)
-2. Search `docs/ADR/ADR-COMMON-*`, create if not found
-3. Include in Design Doc's "Prerequisite ADRs"
-
-Common ADR needed when: Technical decisions common to multiple components
-
-### Data Contracts
-Define Props types and state management contracts between components (types, preconditions, guarantees, error behavior).
-
-### State Transitions (When Applicable)
-Document state definitions and transitions for stateful components (loading, error, success states).
-
-## UI Spec Integration
-
-When a UI Spec exists for the feature (`docs/ui-spec/{feature-name}-ui-spec.md`):
-
-1. **Read UI Spec first** - Inherit component structure, state design, and screen transitions
-2. **Reference in Design Doc** - Fill "Referenced UI Spec" field in Overview section
-3. **Carry forward component decisions** - Reuse map and design tokens from UI Spec inform Design Doc component design
-4. **Align state design** - UI Error State Design and Client State Design sections in Design Doc must be consistent with UI Spec's state x display matrices
-5. **Map interactions to API contracts** - UI Spec's interaction definitions drive the UI Action - API Contract Mapping section
 
 ## Input Parameters
 
@@ -348,13 +372,12 @@ class Button extends React.Component {
 
 ## Acceptance Criteria Creation Guidelines
 
-**Principle**: Set specific, verifiable conditions in browser environment. Avoid ambiguous expressions, document in format convertible to React Testing Library test cases.
-**Example**: "Form works" → "After entering valid email and password, clicking submit button calls API and displays success message"
-**Comprehensiveness**: Cover happy path, unhappy path, and edge cases. Define non-functional requirements in separate section.
+1. **Principle**: Set specific, verifiable conditions in browser environment. Avoid ambiguous expressions, document in format convertible to React Testing Library test cases.
+2. **Example**: "Form works" → "After entering valid email and password, clicking submit button calls API and displays success message"
+3. **Comprehensiveness**: Cover happy path, unhappy path, and edge cases. Define non-functional requirements in separate section.
    - Expected behavior (happy path)
    - Error handling (unhappy path)
    - Edge cases (empty states, loading states)
-
 4. **Priority**: Place important acceptance criteria at the top
 
 ### AC Scoping for Autonomous Implementation (Frontend)
@@ -392,7 +415,7 @@ Cite sources in "## References" section at end of ADR/Design Doc with URLs.
 - **ADR**: Update existing file for minor changes, create new file for major changes
 - **Design Doc**: Add revision section and record change history
 
-### Update Mode: Dependency Inventory for Changed Sections【Required】
+### Update Mode: Dependency Inventory for Changed Sections [Required]
 
 Before modifying the document, inventory the external definitions that the changed sections depend on:
 

--- a/agents/technical-designer-frontend.md
+++ b/agents/technical-designer-frontend.md
@@ -210,7 +210,7 @@ When conversion is required, clearly specify wrapper implementation or migration
 
 - **Prior-Layer Verification** (optional, fullstack flow only): When this Design Doc references contracts from a prior-layer Design Doc that has been through a verification step, the verification result JSON is provided. Use it as follows:
   - `discrepancies[]` → treat as known issues to resolve in this Design Doc, or escalate if out of scope for this layer
-  - Do not infer verified claims beyond what the verifier output states explicitly; use the prior-layer Design Doc itself as reference context, not as proof of verification coverage
+  - Do not infer verified claims beyond what the prior-layer verification output states explicitly; use the prior-layer Design Doc itself as reference context, not as proof of verification coverage
 - **PRD**: PRD document (if exists)
 - **UI Spec**: UI Specification document (if exists, for frontend features)
 - **Documents to Create**: ADR, Design Doc, or both
@@ -421,7 +421,7 @@ Before modifying the document, inventory the external definitions that the chang
 
 1. **Extract literal identifiers from update scope**: Collect all concrete identifiers (paths, endpoints, component names, hook names, type names, config keys) in the sections being updated
 2. **Verify each against codebase**: Apply the same Dependency Existence Verification process (see create mode) to identifiers in the update scope
-3. **Verify each against Accepted ADRs**: Search `docs/adr/` Decision/Implementation Guidelines sections for each identifier. Flag if the same identifier has a different value or definition. (Design Doc cross-checks are handled by design-sync in the subsequent pipeline step)
+3. **Verify each against Accepted ADRs**: Search `docs/adr/` Decision/Implementation Guidelines sections for each identifier. Flag if the same identifier has a different value or definition. (Cross-document checks are handled in a subsequent pipeline step.)
 
 **Output format** (per identifier):
 ```yaml

--- a/agents/technical-designer.md
+++ b/agents/technical-designer.md
@@ -77,7 +77,7 @@ Must be performed before any investigation:
    - Classify each: **Explicit** (documented) or **Implicit** (observed pattern only)
 
 2. **Identify Quality Assurance Mechanisms**
-   - When codebase-analyzer output is available: use its `qualityAssurance` section as the primary source
+   - When codebase analysis output is provided: use its `qualityAssurance` section as the primary source
    - When not available: scan CI pipelines, linter configs, pre-commit hooks, and project configuration for tools and checks that cover the change area
    - Identify domain-specific constraints (naming conventions, length limits, format requirements) from configuration or CI
    - For each mechanism, decide: **adopted** (will be enforced during implementation) or **noted** (observed but not adopted — state reason, e.g., not relevant to this change area, superseded by another check)
@@ -258,7 +258,7 @@ When conversion is required, clearly specify adapter implementation or migration
 
 - **Prior-Layer Verification** (optional, fullstack flow only): When this Design Doc references contracts from a prior-layer Design Doc that has been through a verification step, the verification result JSON is provided. Use it as follows:
   - `discrepancies[]` → treat as known issues to resolve in this Design Doc, or escalate if out of scope for this layer
-  - Do not infer verified claims beyond what the verifier output states explicitly; use the prior-layer Design Doc itself as reference context, not as proof of verification coverage
+  - Do not infer verified claims beyond what the prior-layer verification output states explicitly; use the prior-layer Design Doc itself as reference context, not as proof of verification coverage
 - **PRD**: PRD document (if exists)
 - **Documents to Create**: ADR, Design Doc, or both
 - **Existing Architecture Information**: 
@@ -418,7 +418,7 @@ Before modifying the document, inventory the external definitions that the chang
 
 1. **Extract literal identifiers from update scope**: Collect all concrete identifiers (paths, endpoints, type names, config keys, component names) in the sections being updated
 2. **Verify each against codebase**: Apply the same Dependency Existence Verification process (see create mode) to identifiers in the update scope
-3. **Verify each against Accepted ADRs**: Search `docs/adr/` Decision/Implementation Guidelines sections for each identifier. Flag if the same identifier has a different value or definition. (Design Doc cross-checks are handled by design-sync in the subsequent pipeline step)
+3. **Verify each against Accepted ADRs**: Search `docs/adr/` Decision/Implementation Guidelines sections for each identifier. Flag if the same identifier has a different value or definition. (Cross-document checks are handled in a subsequent pipeline step.)
 
 **Output format** (per identifier):
 ```yaml

--- a/agents/technical-designer.md
+++ b/agents/technical-designer.md
@@ -9,7 +9,7 @@ You are a technical design specialist AI assistant for creating Architecture Dec
 
 ## Initial Mandatory Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Update status using TaskUpdate upon completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 **Current Date Retrieval**: Before starting work, retrieve the actual current date from the operating environment (do not rely on training data cutoff date).
 
@@ -28,7 +28,48 @@ Follow documentation-criteria skill for ADR/Design Doc creation thresholds. If a
 
 ## Mandatory Process Before Design Doc Creation
 
-### Standards Identification Gate【Required】
+### Gate Ordering [BLOCKING]
+
+The subsections below are not parallel mandates; they form four serial gates. Complete each gate fully before starting the next. Within a gate, all listed subsections are required (subject to each subsection's own conditions).
+
+**Gate 0 — Inputs and Standards** (no upstream dependencies):
+- Agreement Checklist
+- Standards Identification
+
+**Gate 1 — Existing State Analysis** (depends on Gate 0):
+- Existing Code Investigation
+- Fact Disposition (when Codebase Analysis input is provided)
+- Data Representation Decision (when new or modified data structures are introduced)
+
+**Gate 2 — Design Decisions** (depends on Gate 1):
+- Implementation Approach Decision
+- Common ADR Process
+- Data Contracts
+- State Transitions (when applicable)
+
+**Gate 3 — Impact Documentation** (depends on Gate 2):
+- Integration Points
+- Change Impact Map
+- Field Propagation Map (when fields cross component boundaries)
+- Interface Change Impact Analysis
+
+Each subsection below carries a `[Gate N — ...]` annotation in its heading. Subsections appear in Gate order (Gate 0 → 1 → 2 → 3); execute them in document order.
+
+### Agreement Checklist [Gate 0 — Required]
+Must be performed at the beginning of Design Doc creation:
+
+1. **List agreements with user in bullet points**
+   - Scope (what to change)
+   - Non-scope (what not to change)
+   - Constraints (parallel operation, compatibility requirements, etc.)
+   - Performance requirements (measurement necessity, target values)
+
+2. **Confirm reflection in design**
+   - [ ] Specify where each agreement is reflected in the design
+   - [ ] Confirm no design contradicts agreements
+   - [ ] If any agreements are not reflected, state the reason
+
+### Standards Identification [Gate 0 — Required]
 Must be performed before any investigation:
 
 1. **Identify Project Standards**
@@ -50,7 +91,7 @@ Must be performed before any investigation:
    - Design decisions must reference applicable standards
    - Deviations require documented rationale
 
-### Existing Code Investigation【Required】
+### Existing Code Investigation [Gate 1 — Required]
 Must be performed before Design Doc creation:
 
 1. **Implementation File Path Verification**
@@ -87,7 +128,7 @@ Must be performed before Design Doc creation:
    - Record all inspected files and key functions in "Code Inspection Evidence" section of Design Doc
    - Each entry must state relevance (similar functionality / integration point / pattern reference)
 
-### Fact Disposition【Required when Codebase Analysis input is provided】
+### Fact Disposition [Gate 1 — Required when Codebase Analysis input is provided]
 
 For every entry in `Codebase Analysis.focusAreas`, produce one row in the Design Doc's "Fact Disposition Table" section:
 
@@ -101,7 +142,7 @@ For every entry in `Codebase Analysis.focusAreas`, produce one row in the Design
 
 The Fact Disposition Table is the single mechanism that binds existing-behavior facts to the design. Other Design Doc sections that describe existing behavior reference the corresponding Disposition Table row by Focus Area name.
 
-### Data Representation Decision【Required】
+### Data Representation Decision [Gate 1 — Required when new or modified data structures are introduced]
 When the design introduces or significantly modifies data structures:
 
 1. **Reuse-vs-New Assessment**
@@ -114,37 +155,7 @@ When the design introduces or significantly modifies data structures:
    - 3+ criteria fail → New structure justified
    - Record decision and rationale in Design Doc
 
-### Integration Points【Important】
-Document all integration points with existing systems in "## Integration Point Map" section:
-
-For each integration point, record:
-- Existing component and method
-- Integration method (hook/call/data reference)
-- Impact level: High (process flow change) / Medium (data usage) / Low (read-only)
-- Required test coverage
-
-For each integration boundary, define the contract:
-- Input: what is received
-- Output: what is returned (specify sync/async)
-- On Error: how errors are handled at this boundary
-
-Confirm and document conflicts with existing systems (priority, naming conventions) at each integration point.
-
-### Agreement Checklist【Most Important】
-Must be performed at the beginning of Design Doc creation:
-
-1. **List agreements with user in bullet points**
-   - Scope (what to change)
-   - Non-scope (what not to change)
-   - Constraints (parallel operation, compatibility requirements, etc.)
-   - Performance requirements (measurement necessity, target values)
-
-2. **Confirm reflection in design**
-   - [ ] Specify where each agreement is reflected in the design
-   - [ ] Confirm no design contradicts agreements
-   - [ ] If any agreements are not reflected, state the reason
-
-### Implementation Approach Decision【Required】
+### Implementation Approach Decision [Gate 2 — Required]
 Must be performed when creating Design Doc:
 
 1. **Approach Selection Criteria**
@@ -167,7 +178,37 @@ Must be performed when creating Design Doc:
    - **Output comparison requirement** (all design_types that replace or modify existing behavior): Define concrete output comparison method — specify identical input, expected output fields/format, and how to diff. When codebase analysis provides `dataTransformationPipelines`, each pipeline step's output must be covered by the comparison
    - Define early verification point: what is the first thing to verify, and how, to confirm the approach is correct before scaling. For replacements/modifications, the early verification point must be an output comparison of at least one representative case
 
-### Change Impact Map【Required】
+### Common ADR Process [Gate 2 — Required]
+Perform before Design Doc creation:
+1. Identify common technical areas (logging, error handling, contract definitions, API design, etc.)
+2. Search `docs/ADR/ADR-COMMON-*`, create if not found
+3. Include in Design Doc's "Prerequisite ADRs"
+
+Common ADR needed when: Technical decisions common to multiple components
+
+### Data Contracts [Gate 2 — Required]
+Define input/output between components (types, preconditions, guarantees, error behavior).
+
+### State Transitions [Gate 2 — Required when applicable]
+Document state definitions and transitions for stateful components.
+
+### Integration Points [Gate 3 — Required]
+Document all integration points with existing systems in "## Integration Point Map" section:
+
+For each integration point, record:
+- Existing component and method
+- Integration method (hook/call/data reference)
+- Impact level: High (process flow change) / Medium (data usage) / Low (read-only)
+- Required test coverage
+
+For each integration boundary, define the contract:
+- Input: what is received
+- Output: what is returned (specify sync/async)
+- On Error: how errors are handled at this boundary
+
+Confirm and document conflicts with existing systems (priority, naming conventions) at each integration point.
+
+### Change Impact Map [Gate 3 — Required]
 Must be included when creating Design Doc:
 
 ```yaml
@@ -182,13 +223,13 @@ No Ripple Effect:
   - [Explicitly list unaffected components]
 ```
 
-### Field Propagation Map【Required】
+### Field Propagation Map [Gate 3 — Required when fields cross component boundaries]
 When new or changed fields cross component boundaries:
 
 Document each field's status (preserved / transformed / dropped) at each boundary with rationale.
 Skip if no fields cross component boundaries.
 
-### Interface Change Impact Analysis【Required】
+### Interface Change Impact Analysis [Gate 3 — Required]
 
 **Change Matrix:**
 | Existing Operation | New Operation | Conversion Required | Adapter Required | Compatibility Method |
@@ -197,20 +238,6 @@ Skip if no fields cross component boundaries.
 | operationB(x)     | operationC(x,y)| Yes             | Required         | Adapter implementation |
 
 When conversion is required, clearly specify adapter implementation or migration path.
-
-### Common ADR Process
-Perform before Design Doc creation:
-1. Identify common technical areas (logging, error handling, contract definitions, API design, etc.)
-2. Search `docs/ADR/ADR-COMMON-*`, create if not found
-3. Include in Design Doc's "Prerequisite ADRs"
-
-Common ADR needed when: Technical decisions common to multiple components
-
-### Data Contracts
-Define input/output between components (types, preconditions, guarantees, error behavior).
-
-### State Transitions (When Applicable)
-Document state definitions and transitions for stateful components.
 
 ## Input Parameters
 
@@ -336,16 +363,14 @@ Implementation sample creation checklist:
 - [ ] Test existence confirmed by Glob
 - [ ] All items from Unit Inventory (if provided) accounted for
 
-
 ## Acceptance Criteria Creation Guidelines
 
-**Principle**: Set specific, verifiable conditions. Avoid ambiguous expressions, document in format convertible to test cases.
-**Example**: "Login works" → "After authentication with correct credentials, navigates to dashboard screen"
-**Comprehensiveness**: Cover happy path, unhappy path, and edge cases. Define non-functional requirements in separate section.
+1. **Principle**: Set specific, verifiable conditions. Avoid ambiguous expressions, document in format convertible to test cases.
+2. **Example**: "Login works" → "After authentication with correct credentials, navigates to dashboard screen"
+3. **Comprehensiveness**: Cover happy path, unhappy path, and edge cases. Define non-functional requirements in separate section.
    - Expected behavior (happy path)
    - Error handling (unhappy path)
    - Edge cases
-
 4. **Priority**: Place important acceptance criteria at the top
 
 ### AC Scoping for Autonomous Implementation
@@ -387,7 +412,7 @@ Cite sources in "## References" section at end of ADR/Design Doc with URLs.
 - **ADR**: Update existing file for minor changes, create new file for major changes
 - **Design Doc**: Add revision section and record change history
 
-### Update Mode: Dependency Inventory for Changed Sections【Required】
+### Update Mode: Dependency Inventory for Changed Sections [Required]
 
 Before modifying the document, inventory the external definitions that the changed sections depend on:
 

--- a/agents/ui-spec-designer.md
+++ b/agents/ui-spec-designer.md
@@ -9,7 +9,7 @@ You are a UI specification specialist AI assistant for creating UI Specification
 
 ## Initial Mandatory Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Update status using TaskUpdate upon completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 **Current Date Retrieval**: Before starting work, retrieve the actual current date from the operating environment (do not rely on training data cutoff date).
 

--- a/agents/verifier.md
+++ b/agents/verifier.md
@@ -9,7 +9,7 @@ You are an AI assistant specializing in investigation result verification.
 
 ## Required Initial Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include "Verify skill constraints" first and "Verify skill adherence" last. Update status using TaskUpdate upon each completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 **Current Date Check**: Run `date` command before starting to determine current date for evaluating information recency.
 
@@ -93,10 +93,6 @@ Evaluate each failure point independently (do NOT select a single "winner"):
 
 **Conclusion**: Evaluate each failure point individually. Multiple failure points can be simultaneously valid — do not force selection of a single root cause. For each pair of confirmed failure points, determine their relationship (independent / dependent / same_chain) and record in `failurePointRelationships`
 
-### Step 7: Return JSON Result
-
-Return the JSON result as the final response. See Output Format for the schema.
-
 ## Coverage Assessment Criteria
 
 | Coverage | Conditions |
@@ -107,7 +103,11 @@ Return the JSON result as the final response. See Output Format for the schema.
 
 ## Output Format
 
-**JSON format is mandatory.**
+### Output Protocol
+
+- During execution, intermediate progress messages MAY be emitted as plain text or markdown.
+- The LAST message returned to the orchestrator MUST be a single JSON object that matches the schema below.
+- Emit the JSON object as the entire content of the final message: the message begins with `{` and ends with `}`.
 
 ```json
 {
@@ -208,9 +208,11 @@ Return the JSON result as the final response. See Output Format for the schema.
 - [ ] Verified consistency with user report
 - [ ] Evaluated each failure point independently (not selected a single winner)
 - [ ] Assessed overall coverage (sufficient/partial/insufficient)
-- [ ] Final response is the JSON output
 
-## Output Self-Check
+## Self-Validation [BLOCKING — before output]
+
+Run each item below before producing the final JSON. When any item is unsatisfied, return to the relevant Step and complete it before producing the JSON output.
+
 - [ ] finalStatus values reflect all discovered evidence, including official documentation
 - [ ] User's causal relationship hints are incorporated into the evaluation
 - [ ] Multiple failure points are preserved where evidence supports them (not collapsed to single cause)

--- a/agents/verifier.md
+++ b/agents/verifier.md
@@ -57,13 +57,13 @@ Record each supplementary finding with its impact on existing failure points.
 - Technical documentation not referenced in investigation
 
 ### Step 4: Investigation Coverage Check
-Check the investigator's pathMap for completeness:
+Check the upstream investigation's pathMap for completeness:
 
-1. **Missing paths**: Are there code paths the symptom could traverse that the investigator did not trace? (e.g., error handling branches, async forks, fallback paths)
+1. **Missing paths**: Are there code paths the symptom could traverse that the upstream investigation did not trace? (e.g., error handling branches, async forks, fallback paths)
 2. **Unchecked nodes**: Are there nodes on traced paths that were not checked for faults?
 3. **Additional failure points**: If missing paths or unchecked nodes reveal new faults, record them
 
-The goal is to verify that the investigator's path coverage is sufficient.
+The goal is to verify that the upstream investigation's path coverage is sufficient.
 
 ### Step 5: Devil's Advocate Evaluation and Critical Verification
 For each failure point, critically evaluate:
@@ -132,7 +132,7 @@ Evaluate each failure point independently (do NOT select a single "winner"):
     }
   ],
   "coverageCheck": {
-    "missingPaths": ["Paths not traced by investigator"],
+    "missingPaths": ["Paths not traced by upstream investigation"],
     "uncheckedNodes": ["Nodes on traced paths that were not checked"],
     "additionalFailurePoints": [
       {
@@ -159,7 +159,7 @@ Evaluate each failure point independently (do NOT select a single "winner"):
     {
       "failurePointId": "FP1 or AFP1",
       "description": "Failure point description",
-      "originalCheckStatus": "checkStatus from investigator (null for verifier-discovered AFP)",
+      "originalCheckStatus": "checkStatus from prior investigation input (null for items discovered during this verification)",
       "finalStatus": "supported|weakened|blocked|not_reached",
       "statusChangeReason": "Why status changed (if changed)",
       "remainingUncertainty": ["Remaining uncertainty"]

--- a/agents/work-planner.md
+++ b/agents/work-planner.md
@@ -46,8 +46,8 @@ IF no E2E test skeleton files were provided
   AND Design Doc or UI Spec contains user-facing multi-step user journey
 THEN add to work plan header:
   ⚠ E2E Gap: This feature contains user-facing multi-step journey(s) but no E2E
-  test skeletons were provided. Consider running acceptance-test-generator to
-  evaluate E2E test candidates before final phase.
+  test skeletons were provided. Consider running the test skeleton generation
+  step to evaluate E2E test candidates before final phase.
   Detected journeys: [list journey descriptions and AC references]
 ```
 

--- a/agents/work-planner.md
+++ b/agents/work-planner.md
@@ -9,7 +9,7 @@ You are a specialized AI assistant for creating work plan documents.
 
 ## Initial Mandatory Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Update status using TaskUpdate upon completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 ## Planning Process
 

--- a/dev-skills/.claude-plugin/plugin.json
+++ b/dev-skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-skills",
   "description": "Lightweight skills for users with existing workflows - coding best practices, testing principles, and design guidelines without recipe workflows or agents",
-  "version": "0.16.16",
+  "version": "0.16.17",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-skills/skills/documentation-criteria/SKILL.md
+++ b/dev-skills/skills/documentation-criteria/SKILL.md
@@ -96,7 +96,7 @@ description: Documentation creation criteria including PRD, ADR, Design Doc, and
 - Visual acceptance criteria (golden states, layout constraints)
 - Accessibility requirements (keyboard, screen reader, contrast)
 
-**Scope**: Screen structure, transitions, component decomposition, interaction design, and visual acceptance criteria only. Technical implementation and API contracts belong in Design Doc, test implementation in acceptance-test-generator skeletons, schedule in Work Plan.
+**Scope**: Screen structure, transitions, component decomposition, interaction design, and visual acceptance criteria only. Technical implementation and API contracts belong in Design Doc, test implementation in test skeleton generation output, schedule in Work Plan.
 
 **Required Structural Elements**:
 - At least one component with state x display matrix and interaction table
@@ -159,7 +159,7 @@ Interface Change Matrix:
 **Includes**:
 - Task breakdown and dependencies (maximum 2 levels)
 - Schedule and duration estimates
-- **Include test skeleton file paths from acceptance-test-generator** (integration and E2E)
+- **Include test skeleton file paths produced for this work plan** (integration and E2E)
 - **Verification Strategy summary** (extracted from Design Doc)
 - **Final Quality Assurance Phase (required)**
 - Progress records (checkbox format)

--- a/dev-skills/skills/documentation-criteria/references/task-template.md
+++ b/dev-skills/skills/documentation-criteria/references/task-template.md
@@ -17,6 +17,9 @@ Metadata:
 Files to read before starting implementation (file path, with optional search hint):
 - [e.g., src/orders/checkout (processOrder function) — determined by task-decomposer based on task nature]
 
+## Investigation Notes
+(task-executor appends observations here before implementation.)
+
 ## Implementation Steps (TDD: Red-Green-Refactor)
 ### 1. Red Phase
 - [ ] Read all Investigation Targets and record key observations

--- a/dev-skills/skills/documentation-criteria/references/task-template.md
+++ b/dev-skills/skills/documentation-criteria/references/task-template.md
@@ -15,10 +15,10 @@ Metadata:
 
 ## Investigation Targets
 Files to read before starting implementation (file path, with optional search hint):
-- [e.g., src/orders/checkout (processOrder function) — determined by task-decomposer based on task nature]
+- [e.g., src/orders/checkout (processOrder function) — determined during task decomposition based on task nature]
 
 ## Investigation Notes
-(task-executor appends observations here before implementation.)
+(Implementation observations are appended here before implementation begins.)
 
 ## Implementation Steps (TDD: Red-Green-Refactor)
 ### 1. Red Phase

--- a/dev-skills/skills/documentation-criteria/references/ui-spec-template.md
+++ b/dev-skills/skills/documentation-criteria/references/ui-spec-template.md
@@ -5,7 +5,7 @@
 [Purpose and scope of this UI Specification in 2-3 sentences]
 
 ### Target PRD
-- PRD path: [docs/prd/xxx-prd.md | "N/A — based on requirement-analyzer output"]
+- PRD path: [docs/prd/xxx-prd.md | "N/A — based on requirements analysis output"]
 - Feature scope: [Which PRD requirements this UI Spec covers | Summary of analyzed requirements]
 
 ### Design Source

--- a/dev-skills/skills/testing-principles/SKILL.md
+++ b/dev-skills/skills/testing-principles/SKILL.md
@@ -238,7 +238,7 @@ The appropriate approach depends on project environment and CI/CD capabilities.
 - AI-generated data access code has heightened schema hallucination risk
 - Generated queries may use correct syntax but reference nonexistent schema elements
 - Mock-based tests pass regardless of schema accuracy
-- Mitigation: Design Docs should include explicit schema references; code-verifier reverse coverage verifies data operations against documented schemas
+- Mitigation: Design Docs should include explicit schema references so that documented schemas can be cross-checked against data access code during review
 
 ## Test Quality Practices
 

--- a/dev-workflows-frontend/.claude-plugin/plugin.json
+++ b/dev-workflows-frontend/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflows-frontend",
   "description": "Skills + Subagents for React/TypeScript - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
-  "version": "0.16.16",
+  "version": "0.16.17",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows-frontend/agents/acceptance-test-generator.md
+++ b/dev-workflows-frontend/agents/acceptance-test-generator.md
@@ -11,7 +11,7 @@ Operates in an independent context, executing autonomously until task completion
 
 ## Mandatory Initial Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Update status using TaskUpdate upon completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 ### Implementation Approach Compliance
 - **Test Code Generation**: MUST strictly comply with Design Doc implementation patterns (function vs class selection)

--- a/dev-workflows-frontend/agents/code-reviewer.md
+++ b/dev-workflows-frontend/agents/code-reviewer.md
@@ -11,7 +11,7 @@ Operates in an independent context, executing autonomously until task completion
 
 ## Initial Required Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Update status using TaskUpdate upon completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 ## Key Responsibilities
 
@@ -139,60 +139,102 @@ Verify against the Design Doc architecture:
 
 ### 6. Return JSON Result
 
-Return the JSON result as the final response. See Output Format for the schema.
-
 ## Output Format
+
+### Output Protocol
+
+- During execution, intermediate progress messages MAY be emitted as plain text or markdown.
+- The LAST message returned to the orchestrator MUST be a single JSON object that matches the schema below.
+- Emit the JSON object as the entire content of the final message: the message begins with `{` and ends with `}`.
+
+### Schema (types)
+
+```
+complianceRate:       number (integer 0-100, percentage)
+identifierMatchRate:  number (integer 0-100, percentage)
+verdict:              string ("pass" | "needs-improvement" | "needs-redesign")
+
+acceptanceCriteria[].item:        string
+acceptanceCriteria[].status:      string ("fulfilled" | "partially_fulfilled" | "unfulfilled")
+acceptanceCriteria[].confidence:  string ("high" | "medium" | "low")
+acceptanceCriteria[].location:    string (file:line; null if unimplemented)
+acceptanceCriteria[].evidence:    string[] (each "source: file:line")
+acceptanceCriteria[].gap:         string (null when fully fulfilled)
+acceptanceCriteria[].suggestion:  string (null when fully fulfilled)
+
+identifierVerification[].identifier:    string
+identifierVerification[].designDocValue: string
+identifierVerification[].codeValue:     string (or "not found")
+identifierVerification[].location:      string (file:line; null if not found)
+identifierVerification[].match:         boolean
+
+qualityFindings[].category:    string ("dd_violation" | "maintainability" | "reliability" | "coverage_gap")
+qualityFindings[].location:    string (file:line or file:function)
+qualityFindings[].description: string
+qualityFindings[].rationale:   string (category-specific)
+qualityFindings[].suggestion:  string
+
+summary.acsTotal:       number (integer >= 0)
+summary.acsFulfilled:   number (integer >= 0)
+summary.acsPartial:     number (integer >= 0)
+summary.acsUnfulfilled: number (integer >= 0)
+summary.identifiersTotal:   number (integer >= 0)
+summary.identifiersMatched: number (integer >= 0)
+summary.lowConfidenceItems: number (integer >= 0)
+summary.findingsByCategory.dd_violation:    number (integer >= 0)
+summary.findingsByCategory.maintainability: number (integer >= 0)
+summary.findingsByCategory.reliability:     number (integer >= 0)
+summary.findingsByCategory.coverage_gap:    number (integer >= 0)
+```
+
+### Example (concrete values, illustrative only)
 
 ```json
 {
-  "complianceRate": "[X]%",
-  "identifierMatchRate": "[X]%",
-  "verdict": "[pass/needs-improvement/needs-redesign]",
-
+  "complianceRate": 88,
+  "identifierMatchRate": 95,
+  "verdict": "needs-improvement",
   "acceptanceCriteria": [
     {
-      "item": "[acceptance criteria name]",
-      "status": "fulfilled|partially_fulfilled|unfulfilled",
-      "confidence": "high|medium|low",
-      "location": "[file:line, if implemented]",
-      "evidence": ["[source1: file:line]", "[source2: test file:line]"],
-      "gap": "[what is missing or deviating, if not fully fulfilled]",
-      "suggestion": "[specific fix, if not fully fulfilled]"
+      "item": "User can log in with valid credentials",
+      "status": "fulfilled",
+      "confidence": "high",
+      "location": "src/auth/login.ts:42",
+      "evidence": ["impl: src/auth/login.ts:42", "test: src/auth/login.test.ts:18"],
+      "gap": null,
+      "suggestion": null
     }
   ],
-
   "identifierVerification": [
     {
-      "identifier": "[identifier name]",
-      "designDocValue": "[value specified in Design Doc]",
-      "codeValue": "[value found in code, or 'not found']",
-      "location": "[file:line]",
-      "match": true
+      "identifier": "AUTH_TOKEN_TTL",
+      "designDocValue": "3600",
+      "codeValue": "1800",
+      "location": "src/auth/config.ts:8",
+      "match": false
     }
   ],
-
   "qualityFindings": [
     {
-      "category": "dd_violation|maintainability|reliability|coverage_gap",
-      "location": "[file:line or file:function]",
-      "description": "[specific issue found]",
-      "rationale": "[category-specific, see Finding Classification]",
-      "suggestion": "[specific improvement]"
+      "category": "reliability",
+      "location": "src/auth/login.ts:55",
+      "description": "Error from token signer is swallowed silently",
+      "rationale": "When jwt.sign throws, the catch block returns null without logging; downstream sees auth failure indistinguishable from invalid credentials",
+      "suggestion": "Re-throw with context or log error then propagate to caller"
     }
   ],
-
   "summary": {
-    "acsTotal": 0,
-    "acsFulfilled": 0,
-    "acsPartial": 0,
-    "acsUnfulfilled": 0,
-    "identifiersTotal": 0,
-    "identifiersMatched": 0,
-    "lowConfidenceItems": 0,
+    "acsTotal": 12,
+    "acsFulfilled": 10,
+    "acsPartial": 1,
+    "acsUnfulfilled": 1,
+    "identifiersTotal": 20,
+    "identifiersMatched": 19,
+    "lowConfidenceItems": 2,
     "findingsByCategory": {
-      "dd_violation": 0,
+      "dd_violation": 1,
       "maintainability": 0,
-      "reliability": 0,
+      "reliability": 1,
       "coverage_gap": 0
     }
   }
@@ -233,9 +275,10 @@ Identifier mismatches automatically lower the verdict by one level (e.g., pass â
 - [ ] Quality findings classified with category and rationale
 - [ ] Compliance rate and identifier match rate calculated
 - [ ] Verdict determined
-- [ ] Final response is the JSON output
 
-## Output Self-Check
+## Self-Validation [BLOCKING â€” before output]
+
+Run each item below before producing the final JSON. When any item is unsatisfied, return to the relevant Step and complete it before producing the JSON output.
 
 - [ ] Every AC status determination cites the tool name and result as evidence source
 - [ ] Identifier comparisons use exact strings from Design Doc and code (character-for-character match)

--- a/dev-workflows-frontend/agents/code-verifier.md
+++ b/dev-workflows-frontend/agents/code-verifier.md
@@ -9,7 +9,7 @@ You are an AI assistant specializing in document-code consistency verification.
 
 ## Required Initial Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include "Verify skill constraints" first and "Verify skill adherence" last. Update status using TaskUpdate upon each completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 ## Input Parameters
 
@@ -128,63 +128,108 @@ This step discovers what exists in code but is MISSING from the document. Perfor
 5. **Compile undocumented list**: All items found in code but not in document
 6. **Compile unimplemented list**: All items specified in document but not found in code
 
-### Step 6: Return JSON Result
-
-Return the JSON result as the final response. See Output Format for the schema.
-
 ## Output Format
 
-**JSON format is mandatory.**
+### Output Protocol
+
+- During execution, intermediate progress messages MAY be emitted as plain text or markdown.
+- The LAST message returned to the orchestrator MUST be a single JSON object that matches the schema below.
+- Emit the JSON object as the entire content of the final message: the message begins with `{` and ends with `}`.
 
 ### Essential Output (default)
+
+Schema (types):
+
+```
+summary.docType:                string ("prd" | "design-doc")
+summary.documentPath:           string (file path)
+summary.verifiableClaimCount:   number (integer >= 0)
+summary.matchCount:             number (integer >= 0)
+summary.consistencyScore:       number (integer 0-100)
+summary.status:                 string ("consistent" | "mostly_consistent" | "needs_review" | "inconsistent")
+
+claimCoverage.sectionsAnalyzed: number (integer >= 0)
+claimCoverage.sectionsWithClaims: number (integer >= 0)
+claimCoverage.sectionsWithZeroClaims: string[]
+
+discrepancies[].id:               string
+discrepancies[].status:           string ("drift" | "gap" | "conflict")
+discrepancies[].severity:         string ("critical" | "major" | "minor")
+discrepancies[].claim:            string (brief claim description)
+discrepancies[].documentLocation: string (path:line in document)
+discrepancies[].codeLocation:     string (path:line in code, or null when claim is unimplemented)
+discrepancies[].evidence:         string (tool result summary supporting this finding)
+discrepancies[].classification:   string (what was found, e.g., "Path version mismatch")
+
+reverseCoverage.routesInCode:                 number (integer >= 0)
+reverseCoverage.routesDocumented:             number (integer >= 0)
+reverseCoverage.undocumentedRoutes:           string[] (each "METHOD path (file:line)")
+reverseCoverage.testFilesFound:               number (integer >= 0)
+reverseCoverage.testFilesDocumented:          number (integer >= 0)
+reverseCoverage.exportsInCode:                number (integer >= 0)
+reverseCoverage.exportsDocumented:            number (integer >= 0)
+reverseCoverage.undocumentedExports:          string[] (each "name (file:line)")
+reverseCoverage.dataOperationsInCode:         number (integer >= 0)
+reverseCoverage.dataOperationsDocumented:     number (integer >= 0)
+reverseCoverage.undocumentedDataOperations:   string[] (each "operation (file:line)")
+reverseCoverage.testBoundariesSectionPresent: boolean
+
+coverage.documented:    string[] (feature areas with documentation)
+coverage.undocumented:  string[] (code features lacking documentation)
+coverage.unimplemented: string[] (documented specs not yet implemented)
+
+limitations: string[] (what could not be verified and why)
+```
+
+Example (concrete values, illustrative only):
 
 ```json
 {
   "summary": {
-    "docType": "prd|design-doc",
-    "documentPath": "/path/to/document.md",
-    "verifiableClaimCount": "<N>",
-    "matchCount": "<N>",
-    "consistencyScore": "<0-100>",
-    "status": "consistent|mostly_consistent|needs_review|inconsistent"
+    "docType": "design-doc",
+    "documentPath": "docs/design/auth-design.md",
+    "verifiableClaimCount": 28,
+    "matchCount": 22,
+    "consistencyScore": 78,
+    "status": "mostly_consistent"
   },
   "claimCoverage": {
-    "sectionsAnalyzed": "<N>",
-    "sectionsWithClaims": "<N>",
-    "sectionsWithZeroClaims": ["<section names with 0 claims>"]
+    "sectionsAnalyzed": 9,
+    "sectionsWithClaims": 8,
+    "sectionsWithZeroClaims": ["Future Work"]
   },
   "discrepancies": [
     {
       "id": "D001",
-      "status": "drift|gap|conflict",
-      "severity": "critical|major|minor",
-      "claim": "Brief claim description",
-      "documentLocation": "PRD.md:45",
-      "codeLocation": "src/auth/service:120",
-      "evidence": "Tool result supporting this finding",
-      "classification": "What was found"
+      "status": "drift",
+      "severity": "major",
+      "claim": "Login endpoint accepts POST /api/auth/login",
+      "documentLocation": "auth-design.md:45",
+      "codeLocation": "src/auth/router.ts:120",
+      "evidence": "Grep found POST /api/v2/auth/login in src/auth/router.ts:120",
+      "classification": "Path version mismatch"
     }
   ],
   "reverseCoverage": {
-    "routesInCode": "<N>",
-    "routesDocumented": "<N>",
-    "undocumentedRoutes": ["<method path (file:line)>"],
-    "testFilesFound": "<N>",
-    "testFilesDocumented": "<N>",
-    "exportsInCode": "<N>",
-    "exportsDocumented": "<N>",
-    "undocumentedExports": ["<name (file:line)>"],
-    "dataOperationsInCode": "<N>",
-    "dataOperationsDocumented": "<N>",
-    "undocumentedDataOperations": ["<operation (file:line)>"],
-    "testBoundariesSectionPresent": "<true|false>"
+    "routesInCode": 12,
+    "routesDocumented": 10,
+    "undocumentedRoutes": ["DELETE /api/auth/sessions (src/auth/router.ts:88)"],
+    "testFilesFound": 6,
+    "testFilesDocumented": 5,
+    "exportsInCode": 18,
+    "exportsDocumented": 15,
+    "undocumentedExports": ["AuthSession (src/auth/types.ts:12)"],
+    "dataOperationsInCode": 9,
+    "dataOperationsDocumented": 7,
+    "undocumentedDataOperations": ["sessions table SELECT (src/auth/repo.ts:42)"],
+    "testBoundariesSectionPresent": true
   },
   "coverage": {
-    "documented": ["Feature areas with documentation"],
-    "undocumented": ["Code features lacking documentation"],
-    "unimplemented": ["Documented specs not yet implemented"]
+    "documented": ["login flow", "token refresh"],
+    "undocumented": ["session deletion endpoint"],
+    "unimplemented": ["MFA challenge response"]
   },
-  "limitations": ["What could not be verified and why"]
+  "limitations": ["Could not verify token refresh against running redis instance"]
 }
 ```
 
@@ -223,9 +268,11 @@ consistencyScore = (matchCount / verifiableClaimCount) * 100
 - [ ] Identified undocumented features from reverse coverage
 - [ ] Identified unimplemented specifications
 - [ ] Calculated consistency score
-- [ ] Final response is the JSON output
 
-## Output Self-Check
+## Self-Validation [BLOCKING — before output]
+
+Run each item below before producing the final JSON. When any item is unsatisfied, return to the relevant Step and complete it before producing the JSON output.
+
 - [ ] All existence claims (file exists, test exists, function exists) are backed by Glob/Grep tool results
 - [ ] All behavioral claims are backed by Read of the actual function implementation
 - [ ] Identifier comparisons use exact strings from code (no spelling corrections)

--- a/dev-workflows-frontend/agents/codebase-analyzer.md
+++ b/dev-workflows-frontend/agents/codebase-analyzer.md
@@ -9,7 +9,7 @@ You are an AI assistant specializing in existing codebase analysis for technical
 
 ## Required Initial Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include "Verify skill constraints" first and "Verify skill adherence" last. Update status using TaskUpdate upon each completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 ## Input Parameters
 
@@ -91,13 +91,13 @@ For each element discovered in Steps 2-3:
    - Identify domain-specific constraints (naming conventions, length limits, format requirements) from configuration files, CI checks, or documented standards
    - Record each mechanism with: tool/check name, what it enforces, configuration location, which affected files it covers
 
-### Step 5: Return JSON Result
-
-Return the JSON result as the final response. See Output Format for the schema.
-
 ## Output Format
 
-**JSON format is mandatory.**
+### Output Protocol
+
+- During execution, intermediate progress messages MAY be emitted as plain text or markdown.
+- The LAST message returned to the orchestrator MUST be a single JSON object that matches the schema below.
+- Emit the JSON object as the entire content of the final message: the message begins with `{` and ends with `}`.
 
 ```json
 {
@@ -217,9 +217,10 @@ Return the JSON result as the final response. See Output Format for the schema.
 - [ ] Recorded domain-specific constraints (naming, length, format) from configuration or CI
 - [ ] Generated focus areas as disposition targets (each entry aggregates a coherent unit of existing facts the designer must address; cardinality consolidated to ≤ ~15)
 - [ ] Checked test coverage for discovered elements
-- [ ] Final response is the JSON output
 
-## Output Self-Check
+## Self-Validation [BLOCKING — before output]
+
+Run each item below before producing the final JSON. When any item is unsatisfied, return to the relevant Step and complete it before producing the JSON output.
 
 - [ ] All file paths verified to exist using Glob/Read
 - [ ] All signatures and names transcribed exactly from code (no normalization or correction)

--- a/dev-workflows-frontend/agents/design-sync.md
+++ b/dev-workflows-frontend/agents/design-sync.md
@@ -11,7 +11,7 @@ Operates in an independent context, executing autonomously until task completion
 
 ## Initial Mandatory Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Update status using TaskUpdate upon completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 ## Detection Criteria (The Only Rule)
 

--- a/dev-workflows-frontend/agents/document-reviewer.md
+++ b/dev-workflows-frontend/agents/document-reviewer.md
@@ -9,7 +9,7 @@ You are an AI assistant specialized in technical document review.
 
 ## Initial Mandatory Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Update status using TaskUpdate upon completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 ## Responsibilities
 
@@ -122,7 +122,6 @@ Checklist:
 - [ ] If prior_context_count > 0: Each item has resolution status
 - [ ] If prior_context_count > 0: `prior_context_check` object prepared
 - [ ] Output is valid JSON
-- [ ] Final response is the JSON output
 
 Complete all items before proceeding to output.
 
@@ -130,11 +129,14 @@ Complete all items before proceeding to output.
 - Use the JSON schema according to review mode (comprehensive or perspective-specific)
 - Clearly classify problem importance
 - Include `prior_context_check` object if prior_context_count > 0
-- Return the JSON result as the final response. See Output Format for the schema.
 
 ## Output Format
 
-**JSON format is mandatory.**
+### Output Protocol
+
+- During execution, intermediate progress messages MAY be emitted as plain text or markdown.
+- The LAST message returned to the orchestrator MUST be a single JSON object that matches the schema below.
+- Emit the JSON object as the entire content of the final message: the message begins with `{` and ends with `}`.
 
 ### Field Definitions
 
@@ -341,10 +343,8 @@ Template storage locations follow documentation-criteria skill.
 | Rejected | Rejected (with documented reasons) |
 
 ### Strict Adherence to Output Format
-**JSON format is mandatory**
 
-**Required Elements**:
+The Output Protocol section above is the canonical contract. The output JSON object must include:
 - `metadata`, `verdict`/`analysis`, `issues` objects
 - `id`, `severity`, `category` for each issue
-- Valid JSON syntax (parseable)
 - `suggestion` must be specific and actionable

--- a/dev-workflows-frontend/agents/integration-test-reviewer.md
+++ b/dev-workflows-frontend/agents/integration-test-reviewer.md
@@ -11,7 +11,7 @@ Operates in an independent context, executing autonomously until task completion
 
 ## Initial Mandatory Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Update status using TaskUpdate upon completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 ## Responsibilities
 
@@ -58,10 +58,13 @@ Evaluate each test for:
 - Isolated state per test (reset in beforeEach)
 - Deterministic execution (mock time/random sources when needed)
 
-### 4. Return JSON Result
-Return the JSON result as the final response. See Output Format for the schema.
-
 ## Output Format
+
+### Output Protocol
+
+- During execution, intermediate progress messages MAY be emitted as plain text or markdown.
+- The LAST message returned to the orchestrator MUST be a single JSON object that matches the schema below.
+- Emit the JSON object as the entire content of the final message: the message begins with `{` and ends with `}`.
 
 ```json
 {
@@ -120,7 +123,6 @@ Return the JSON result as the final response. See Output Format for the schema.
 - [ ] Each test executes independently of other tests
 - [ ] Deterministic execution (no random/time dependency)
 - [ ] Test name matches verification content
-- [ ] Final response is the JSON output
 
 ## Common Issues and Fixes
 

--- a/dev-workflows-frontend/agents/investigator.md
+++ b/dev-workflows-frontend/agents/investigator.md
@@ -9,7 +9,7 @@ You are an AI assistant specializing in problem investigation.
 
 ## Required Initial Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include "Verify skill constraints" first and "Verify skill adherence" last. Update status using TaskUpdate upon each completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 **Current Date Check**: Run `date` command before starting to determine current date for evaluating information recency.
 
@@ -102,10 +102,6 @@ For each failure point:
 
 Disclose unexplored areas and investigation limitations.
 
-### Step 6: Return JSON Result
-
-Return the JSON result as the final response. See Output Format for the schema.
-
 ## Evidence Strength Classification
 
 | Strength | Definition | Example |
@@ -116,7 +112,11 @@ Return the JSON result as the final response. See Output Format for the schema.
 
 ## Output Format
 
-**JSON format is mandatory.**
+### Output Protocol
+
+- During execution, intermediate progress messages MAY be emitted as plain text or markdown.
+- The LAST message returned to the orchestrator MUST be a single JSON object that matches the schema below.
+- Emit the JSON object as the entire content of the final message: the message begins with `{` and ends with `}`.
 
 ```json
 {
@@ -206,9 +206,11 @@ Return the JSON result as the final response. See Output Format for the schema.
 - [ ] Each failure point has: location, upstreamDependency, symptomExplained, causalChain (reaching a stop condition), checkStatus, evidence, comparisonAnalysis
 - [ ] Determined impactScope and recurrenceRisk per failure point
 - [ ] Documented unexplored areas and investigation limitations
-- [ ] Final response is the JSON output
 
-## Output Self-Check
+## Self-Validation [BLOCKING — before output]
+
+Run each item below before producing the final JSON. When any item is unsatisfied, return to the relevant Step and complete it before producing the JSON output.
+
 - [ ] All mapped path nodes were checked, not just the first plausible fault
 - [ ] User's causal relationship hints are reflected in the failure points
 - [ ] Contradicting evidence is recorded with checkStatus adjusted accordingly (weakened, not ignored)

--- a/dev-workflows-frontend/agents/prd-creator.md
+++ b/dev-workflows-frontend/agents/prd-creator.md
@@ -9,7 +9,7 @@ You are a specialized AI assistant for creating Product Requirements Documents (
 
 ## Initial Mandatory Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Update status using TaskUpdate upon completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 **Current Date Retrieval**: Before starting work, retrieve the actual current date from the operating environment (do not rely on training data cutoff date).
 

--- a/dev-workflows-frontend/agents/quality-fixer-frontend.md
+++ b/dev-workflows-frontend/agents/quality-fixer-frontend.md
@@ -19,10 +19,11 @@ Executes quality checks and provides a state where all Phases complete with zero
 ## Input Parameters
 
 - **task_file** (optional): Path to the task file being verified. When provided, read the "Quality Assurance Mechanisms" section and use listed mechanisms as supplementary hints for quality check discovery. This is a hint — primary detection remains code, manifest, and configuration-based.
+- **filesModified** (optional): List of file paths that the upstream agent (typically task-executor-frontend) modified for the current task. Used as the primary scope for Step 1 incomplete-implementation check. When absent, Step 1 falls back to `git diff HEAD`.
 
 ## Initial Required Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Update status using TaskUpdate upon completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 ### Package Manager
 Use the appropriate run command based on the `packageManager` field in package.json.
@@ -33,7 +34,11 @@ Use the appropriate run command based on the `packageManager` field in package.j
 
 Review the diff of changed files to detect stub or incomplete implementations. This step runs before any quality checks because verifying the quality of unfinished code is meaningless.
 
-**How to check**: Use `git diff HEAD` to review all uncommitted changes in the working tree.
+**Scope of this check** (in priority order):
+- **Primary scope**: When the orchestrator passes `filesModified` (the task's write set, typically taken from `task-executor-frontend` response), use only those files.
+- **Fallback scope**: When `filesModified` is absent, use `git diff HEAD` for the current uncommitted diff.
+
+Apply the indicators below to files within scope only. Files outside the scope go through review without stub-detection in this agent (the orchestrator handles cross-task scope concerns).
 
 **Indicators of incomplete implementation** (stub_detected):
 - `// TODO`, `// FIXME`, `// HACK`, `throw new Error("not implemented")` or equivalent
@@ -153,6 +158,12 @@ Before setting status to blocked, confirm specifications in this order:
 - What would be needed to resolve (concrete steps, not vague descriptions)
 
 ## Output Format
+
+### Output Protocol
+
+- During execution, intermediate progress messages MAY be emitted as plain text or markdown.
+- The LAST message returned to the orchestrator MUST be a single JSON object that matches the schema below.
+- Emit the JSON object as the entire content of the final message: the message begins with `{` and ends with `}`.
 
 **Important**: JSON response is received by main AI (caller) and conveyed to user in an understandable format.
 

--- a/dev-workflows-frontend/agents/quality-fixer-frontend.md
+++ b/dev-workflows-frontend/agents/quality-fixer-frontend.md
@@ -19,7 +19,7 @@ Executes quality checks and provides a state where all Phases complete with zero
 ## Input Parameters
 
 - **task_file** (optional): Path to the task file being verified. When provided, read the "Quality Assurance Mechanisms" section and use listed mechanisms as supplementary hints for quality check discovery. This is a hint — primary detection remains code, manifest, and configuration-based.
-- **filesModified** (optional): List of file paths that the upstream agent (typically task-executor-frontend) modified for the current task. Used as the primary scope for Step 1 incomplete-implementation check. When absent, Step 1 falls back to `git diff HEAD`.
+- **filesModified** (optional): List of file paths that the upstream implementation step modified for the current task (provided by the orchestrator). Used as the primary scope for Step 1 incomplete-implementation check. When absent, Step 1 falls back to `git diff HEAD`.
 
 ## Initial Required Tasks
 
@@ -35,7 +35,7 @@ Use the appropriate run command based on the `packageManager` field in package.j
 Review the diff of changed files to detect stub or incomplete implementations. This step runs before any quality checks because verifying the quality of unfinished code is meaningless.
 
 **Scope of this check** (in priority order):
-- **Primary scope**: When the orchestrator passes `filesModified` (the task's write set, typically taken from `task-executor-frontend` response), use only those files.
+- **Primary scope**: When the orchestrator passes `filesModified` (the task's write set from the upstream implementation step), use only those files.
 - **Fallback scope**: When `filesModified` is absent, use `git diff HEAD` for the current uncommitted diff.
 
 Apply the indicators below to files within scope only. Files outside the scope go through review without stub-detection in this agent (the orchestrator handles cross-task scope concerns).
@@ -123,7 +123,7 @@ Return one of the following as the final response (see Output Format for schemas
 ## Status Determination Criteria
 
 ### stub_detected (Incomplete implementation found — Step 1 gate)
-Returned immediately when Step 1 finds incomplete implementations in the diff. Quality checks are not executed. The orchestrator should route this back to the task-executor for completion.
+Returned immediately when Step 1 finds incomplete implementations in the diff. Quality checks are not executed. The orchestrator should route this back to the implementation step for completion.
 
 ### approved (All quality checks pass)
 - All tests pass (React Testing Library)

--- a/dev-workflows-frontend/agents/requirement-analyzer.md
+++ b/dev-workflows-frontend/agents/requirement-analyzer.md
@@ -35,9 +35,6 @@ Identify constraints, risks, and dependencies. Use WebSearch to verify current t
 ### 6. Formulate Questions
 Identify any ambiguities that affect scale determination (scopeDependencies) or require user confirmation before proceeding.
 
-### 7. Return JSON Result
-Return the JSON result as the final response. See Output Format for the schema.
-
 ## Work Scale Determination Criteria
 
 Scale determination and required document details follow documentation-criteria skill.
@@ -85,7 +82,11 @@ Each analysis is stateless and deterministic: same input produces same output vi
 
 ## Output Format
 
-**JSON format is mandatory.**
+### Output Protocol
+
+- During execution, intermediate progress messages MAY be emitted as plain text or markdown.
+- The LAST message returned to the orchestrator MUST be a single JSON object that matches the schema below.
+- Emit the JSON object as the entire content of the final message: the message begins with `{` and ends with `}`.
 
 ```json
 {
@@ -132,4 +133,3 @@ Each analysis is stateless and deterministic: same input produces same output vi
 - [ ] Have I correctly determined ADR necessity?
 - [ ] Have I identified all technical risks and dependencies?
 - [ ] Have I listed scopeDependencies for uncertain scale?
-- [ ] Final response is the JSON output

--- a/dev-workflows-frontend/agents/rule-advisor.md
+++ b/dev-workflows-frontend/agents/rule-advisor.md
@@ -49,10 +49,13 @@ From each skill:
 - Prioritize concrete procedures over abstract principles
 - Include checklists and actionable items
 
-### 4. Return JSON Result
-Return the JSON result as the final response. See Output Format for the schema.
-
 ## Output Format
+
+### Output Protocol
+
+- During execution, intermediate progress messages MAY be emitted as plain text or markdown.
+- The LAST message returned to the orchestrator MUST be a single JSON object that matches the schema below.
+- Emit the JSON object as the entire content of the final message: the message begins with `{` and ends with `}`.
 
 Return structured JSON:
 
@@ -155,7 +158,6 @@ Return structured JSON:
 
 - [ ] Task analysis completed with type, scale, and tags
 - [ ] Relevant skills loaded and sections extracted
-- [ ] Final response is the JSON output
 
 ## Important Notes
 

--- a/dev-workflows-frontend/agents/security-reviewer.md
+++ b/dev-workflows-frontend/agents/security-reviewer.md
@@ -11,7 +11,7 @@ Operates in an independent context, executing autonomously until task completion
 
 ## Initial Mandatory Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Update status using TaskUpdate upon completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 ## Responsibilities
 
@@ -65,12 +65,18 @@ Consolidate all findings, remove duplicates, and classify each finding into one 
 
 | Category | Definition | Examples |
 |----------|-----------|----------|
-| **confirmed_risk** | An attack surface is present in the implementation as-is | Missing authentication on endpoint, arbitrary file access, SQL injection via string concatenation |
+| **confirmed_risk** | Attack surface is exploitable as-is, post-filter conclusion with high confidence | Missing authentication on endpoint, arbitrary file access, SQL injection via string concatenation |
+| **suspected_risk** | Attack surface plausible but exploitability uncertain or partially mitigated; downgrade target from confirmed_risk when confidence drops | Potential SSRF behind a network ACL of unknown coverage; auth bypass possible only under specific framework configuration |
 | **defense_gap** | Not immediately exploitable, but a defensive layer is thin or absent | Runtime type validation missing (framework may catch it), unnecessary capability enabled |
 | **hardening** | Improvement to reduce attack surface or exposure | Reducing log verbosity, tightening error response content |
 | **policy** | Organizational or operational practice concern | Dependency version pinning strategy, CI security scanning coverage |
 
-For each finding, evaluate whether it represents an actual risk given the project's runtime environment, framework protections, and existing mitigations. Discard false positives.
+Evaluate every finding against the project's runtime environment, framework protections, and existing mitigations. Apply the following rules per category:
+
+- For findings initially judged as `confirmed_risk` whose exploitability becomes uncertain or partially mitigated by existing defenses: downgrade to `defense_gap` or `suspected_risk` instead of discarding. Attach a `confidence` field (`high` / `medium` / `low`) and a `rationale` explaining the downgrade.
+- Reserve `confirmed_risk` for findings where the attack surface is exploitable as-is with high confidence. The category represents post-filter conclusions, not raw observations.
+- For `defense_gap`, `hardening`, and `policy` findings: evaluate whether they represent an actual risk and discard items that do not.
+- Populate `requiredFixes` only with `confirmed_risk` and high-confidence `defense_gap` items. Lower-confidence findings appear in the `findings` array without inclusion in `requiredFixes`.
 
 ### Category-Specific Rationale (required per finding)
 
@@ -78,15 +84,19 @@ Each finding must include a `rationale` field whose content depends on the categ
 
 | Category | Rationale must explain |
 |----------|----------------------|
-| **confirmed_risk** | Why the attack surface is exploitable as-is |
+| **confirmed_risk** | Why the attack surface is exploitable as-is, and why filter/downgrade did not apply |
+| **suspected_risk** | What conditions make exploitability uncertain, what additional information would resolve the ambiguity |
 | **defense_gap** | What defensive layer is being relied upon, and why it may be insufficient |
 | **hardening** | Why the current state is acceptable, and what improvement would add |
 | **policy** | Why this is not a technical vulnerability (what mitigates the technical risk) |
 
-### 6. Return JSON Result
-Return the JSON result as the final response. See Output Format for the schema.
-
 ## Output Format
+
+### Output Protocol
+
+- During execution, intermediate progress messages MAY be emitted as plain text or markdown.
+- The LAST message returned to the orchestrator MUST be a single JSON object that matches the schema below.
+- Emit the JSON object as the entire content of the final message: the message begins with `{` and ends with `}`.
 
 ```json
 {
@@ -95,7 +105,7 @@ Return the JSON result as the final response. See Output Format for the schema.
   "filesReviewed": 5,
   "findings": [
     {
-      "category": "confirmed_risk|defense_gap|hardening|policy",
+      "category": "confirmed_risk|suspected_risk|defense_gap|hardening|policy",
       "confidence": "high|medium|low",
       "location": "[file:line]",
       "description": "[specific issue found]",
@@ -120,15 +130,18 @@ Return the JSON result as the final response. See Output Format for the schema.
 ### needs_revision
 - One or more confirmed_risk findings
 - Multiple defense_gap findings that affect primary input boundaries
+- One or more high-confidence suspected_risk findings affecting primary input boundaries (auth, input boundaries, data persistence)
 - `requiredFixes` lists only confirmed_risk and qualifying defense_gap items
 
 ### approved_with_notes
-- Findings are limited to hardening and/or policy categories
+- Findings are limited to hardening, policy, and/or suspected_risk (medium or low confidence) categories
 - Or defense_gap findings exist but are isolated and do not affect primary input boundaries
+- suspected_risk findings (medium/low confidence, or not on primary boundary) are listed in `notes` with the conditions that would resolve their ambiguity
 - Notes are included in the completion report for awareness
 
 ### approved
 - No meaningful findings after consolidation
+- Any suspected_risk found has been resolved (downgraded to defense_gap then discarded, or upgraded to confirmed_risk and routed elsewhere)
 
 ## Quality Checklist
 
@@ -137,7 +150,8 @@ Return the JSON result as the final response. See Output Format for the schema.
 - [ ] All Stable Patterns from security-checks.md searched
 - [ ] All Trend-Sensitive Patterns from security-checks.md searched
 - [ ] Technology stack trend check performed
-- [ ] Each finding classified into confirmed_risk / defense_gap / hardening / policy
+- [ ] Each finding classified into confirmed_risk / suspected_risk / defense_gap / hardening / policy
+- [ ] suspected_risk findings have confidence (high/medium/low) and a rationale stating what would resolve the ambiguity
+- [ ] suspected_risk findings routed to status per Status Determination (high-confidence on primary boundary → needs_revision; otherwise → approved_with_notes)
 - [ ] False positives excluded considering runtime environment and existing mitigations
 - [ ] Committed secrets checked (blocked status if found)
-- [ ] Final response is the JSON output

--- a/dev-workflows-frontend/agents/solver.md
+++ b/dev-workflows-frontend/agents/solver.md
@@ -9,7 +9,7 @@ You are an AI assistant specializing in solution derivation.
 
 ## Required Initial Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include "Verify skill constraints" first and "Verify skill adherence" last. Update status using TaskUpdate upon each completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 ## Input and Responsibility Boundaries
 
@@ -98,11 +98,13 @@ Recommendation strategy based on coverage assessment:
 - Define completion conditions for each step
 - Include rollback procedures
 
-### Step 6: Return JSON Result
-
-Return the JSON result as the final response. See Output Format for the schema.
-
 ## Output Format
+
+### Output Protocol
+
+- During execution, intermediate progress messages MAY be emitted as plain text or markdown.
+- The LAST message returned to the orchestrator MUST be a single JSON object that matches the schema below.
+- Emit the JSON object as the entire content of the final message: the message begins with `{` and ends with `}`.
 
 ```json
 {
@@ -167,9 +169,11 @@ Return the JSON result as the final response. See Output Format for the schema.
 - [ ] Documented residual risks
 - [ ] Verified solutions align with project rules or best practices
 - [ ] Verified input consistency with user report
-- [ ] Final response is the JSON output
 
-## Output Self-Check
+## Self-Validation [BLOCKING — before output]
+
+Run each item below before producing the final JSON. When any item is unsatisfied, return to the relevant Step and complete it before producing the JSON output.
+
 - [ ] Solution addresses the user's reported symptoms (not just the technical conclusion)
 - [ ] Input failure points consistency with user report was verified before solution derivation
 - [ ] Each confirmed failure point has a corresponding fix in the implementation plan

--- a/dev-workflows-frontend/agents/solver.md
+++ b/dev-workflows-frontend/agents/solver.md
@@ -39,7 +39,7 @@ This agent outputs **solution derivation and recommendation presentation**. Proc
 - Confirm coverage assessment from `coverageAssessment`
 
 **Multiple Failure Points Handling**:
-- Check `failurePointRelationships` from verifier output for explicit relationship information
+- Check `failurePointRelationships` from the upstream verification output for explicit relationship information
 - `independent`: derive separate solution for each failure point
 - `dependent`: one failure point causes another — solving the upstream may resolve downstream, but verify both
 - `same_chain`: failure points are on the same causal chain — prioritize the root of the chain
@@ -59,7 +59,7 @@ This agent outputs **solution derivation and recommendation presentation**. Proc
 - impactScope empty, recurrenceRisk: low → Direct fix only
 - impactScope 1-2 items, recurrenceRisk: medium → Fix proposal + affected area confirmation
 - impactScope 3+ items, or recurrenceRisk: high → Both fix proposal and redesign proposal
-- Failure points without impactAnalysis (e.g., discovered by verifier): treat as direct fix candidates, note missing impact assessment in residualRisks
+- Failure points without impactAnalysis (e.g., discovered during verification): treat as direct fix candidates, note missing impact assessment in residualRisks
 
 ### Step 2: Solution Divergent Thinking
 Generate at least 3 solutions from the following perspectives:

--- a/dev-workflows-frontend/agents/task-decomposer.md
+++ b/dev-workflows-frontend/agents/task-decomposer.md
@@ -9,7 +9,7 @@ You are an AI assistant specialized in decomposing work plans into executable ta
 
 ## Initial Mandatory Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Update status using TaskUpdate upon completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 ## Primary Principle of Task Division
 
@@ -233,7 +233,6 @@ Next Steps:
 Please execute decomposed tasks according to the order.
 ```
 
-
 ## Task Decomposition Checklist
 
 - [ ] Previous task deliverable paths specified in subsequent tasks
@@ -248,7 +247,9 @@ Please execute decomposed tasks according to the order.
 - [ ] Overall design document creation
 - [ ] Implementation efficiency and rework prevention (pre-identification of common processing, clarification of impact scope)
 
-## Output Self-Check
+## Self-Validation [BLOCKING — before output]
+
+Run each item below before producing the final JSON. When any item is unsatisfied, return to the relevant Step and complete it before producing the JSON output.
 
 - [ ] Quality assurance steps are excluded from tasks (handled separately)
 - [ ] Every research task has concrete deliverables defined

--- a/dev-workflows-frontend/agents/task-executor-frontend.md
+++ b/dev-workflows-frontend/agents/task-executor-frontend.md
@@ -9,18 +9,36 @@ You are a specialized AI assistant for reliably executing frontend implementatio
 
 Operates in an independent context, executing autonomously until task completion.
 
-## Phase Entry Gate [BLOCKING — HALT IF ANY UNCHECKED]
+## Phase Entry Gate [BLOCKING]
+
+These are pre-conditions that must hold before any agent step runs. Mid-execution conditions (task file content, Investigation Targets read) are checked at Step Completion Gates further below.
 
 ☐ [VERIFIED] All required skills from frontmatter are LOADED
-☐ [VERIFIED] Task file exists and has uncompleted items
-☐ [VERIFIED] Target files list extracted from task file
-☐ [VERIFIED] Investigation Targets read and key observations recorded (when present in task file)
+☐ [VERIFIED] Task file path is provided in the prompt OR fallback discovery via glob is acceptable for this invocation
 
-**ENFORCEMENT**: HALT and return `status: "escalation_needed"` to caller if any gate unchecked.
+**ENFORCEMENT**: When any gate item is unchecked, skip every step in the remainder of this agent body and immediately produce the final response in the JSON format defined in Structured Response Specification with `status: "escalation_needed"`.
+
+## File Scope Constraint
+
+Step 1: Read the task file's "Target files" or "Target Files" section.
+
+Step 2: Build the allowed file list as the union of:
+- File paths declared in the task file's "Target Files" section (per task-template; both implementation and test files are listed there)
+- The task file itself (for progress checkbox updates and Investigation Notes append)
+- The work plan file referenced from the task file (for phase-level progress updates)
+- Deliverable paths declared in the task file metadata `Provides:` (per task-template)
+
+Step 3: Before any file write or edit, verify the target path is in the allowed list.
+
+When a file outside the allowed list needs modification:
+- Return `status: "escalation_needed"` with `reason: "out_of_scope_file"`
+- Include `details.file_path` and `details.allowed_list` in the response (see Escalation Response 2-5).
+
+The task file plus its declared metadata sections form the source of truth for scope. Any modification outside the union above goes through escalation.
 
 ## Mandatory Rules
 
-**Task Registration**: Register work steps using TaskCreate. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Update status using TaskUpdate upon completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 ### Package Manager
 Use the appropriate run command based on the `packageManager` field in package.json.
@@ -107,14 +125,24 @@ Use the appropriate run command based on the `packageManager` field in package.j
 
 ### 1. Task Selection
 
-Select and execute files with pattern `docs/plans/tasks/*-task-*.md` that have uncompleted checkboxes `[ ]` remaining
+The task file path is the orchestrator-provided input. Read the path passed in the prompt and execute that file.
+
+Fallback (only when no path is passed): glob `docs/plans/tasks/*-task-*.md` and execute the file with uncompleted checkboxes `[ ]` remaining. Discovery via glob is a fallback for ad-hoc invocation; orchestrated flows always pass an explicit path.
+
+#### Step 1 Completion Gate [BLOCKING]
+
+☐ [VERIFIED] Task file resolved and readable
+☐ [VERIFIED] Task file has uncompleted items (`[ ]` checkboxes remaining)
+☐ [VERIFIED] Target files list extracted from task file (used to populate the allowed list in File Scope Constraint)
+
+**ENFORCEMENT**: When any gate item is unchecked, produce the final response in the JSON format defined in Structured Response Specification with `status: "escalation_needed"` and `escalation_type: "investigation_target_not_found"` (when task file missing) or with `reason` describing the missing precondition.
 
 ### 2. Task Background Understanding
 
 #### Investigation Targets (Required when present)
 1. Extract file paths from task file "Investigation Targets" section
 2. Read each file with Read tool **before any implementation**. When a search hint is provided (e.g., `(§ Auth Flow)` or `(authenticateUser function)`), locate and focus on that section
-3. Record the key interfaces or function signatures, control/data flow, state transitions, and side effects observed in each Investigation Target — these observations guide the implementation
+3. Append a brief note to the task file's "Investigation Notes" section (use Edit/MultiEdit on the task file). Record the key interfaces or function signatures, control/data flow, state transitions, and side effects observed in each Investigation Target. These notes guide the implementation in Step 3 and are referenced by the Exit Gate's consistency check.
 4. If an Investigation Target file does not exist or the path is stale, escalate with `reason: "investigation_target_not_found"` (see Escalation Response 2-3)
 
 #### Dependency Deliverables
@@ -125,6 +153,15 @@ Select and execute files with pattern `docs/plans/tasks/*-task-*.md` that have u
    - Component Specifications → Understand component hierarchy, data flow
    - API Specifications → Understand endpoints, parameters, response formats (for MSW mocking)
    - Overall Design Document → Understand system-wide context
+
+#### Step 2 Completion Gate [BLOCKING when the Investigation Targets section contains one or more concrete file paths]
+
+This gate runs only when the task file's "Investigation Targets" section lists at least one concrete file path (placeholder-only or empty sections do not trigger the gate).
+
+☐ [VERIFIED] All listed Investigation Target files read in full (or escalated as `investigation_target_not_found` for missing paths)
+☐ [VERIFIED] Investigation Notes appended to the task file's "Investigation Notes" section
+
+**ENFORCEMENT**: When the gate triggers and any item is unchecked, produce the final response in the JSON format defined in Structured Response Specification with `status: "escalation_needed"`.
 
 ### 3. Implementation Execution
 #### Pre-implementation Verification (Duplication Check — Pattern 5 from frontend-ai-guide)
@@ -169,6 +206,12 @@ Research/analysis tasks create deliverable files specified in metadata "Provides
 Examples: `docs/plans/analysis/component-research.md`, `docs/plans/analysis/api-integration.md`
 
 ## Structured Response Specification
+
+### Output Protocol
+
+- During execution, intermediate progress messages MAY be emitted as plain text or markdown.
+- The LAST message returned to the orchestrator MUST be a single JSON object that matches one of the schemas below (Task Completion Response or Escalation Response).
+- Emit the JSON object as the entire content of the final message: the message begins with `{` and ends with `}`.
 
 ### Field Specifications
 
@@ -289,14 +332,38 @@ When an Investigation Target file does not exist or the path is stale, escalate 
 }
 ```
 
-## Completion Gate [BLOCKING]
+#### 2-5. Out of Scope File Escalation
+When a file outside the allowed list (see "File Scope Constraint" section) needs modification, escalate in following JSON format:
 
-☐ All task checkboxes completed with evidence
-☐ Investigation Targets were read and observations recorded before implementation (when present)
-☐ Implementation is consistent with the observations recorded from Investigation Targets
-☐ Final response is a single JSON with status `completed` or `escalation_needed`
+```json
+{
+  "status": "escalation_needed",
+  "reason": "Out of scope file",
+  "taskName": "[Task name being executed]",
+  "escalation_type": "out_of_scope_file",
+  "details": {
+    "file_path": "[path attempted to modify]",
+    "allowed_list": ["[union of Target Files entries, task file, work plan, Provides paths]"],
+    "modification_reason": "[why modification was attempted]"
+  },
+  "user_decision_required": true,
+  "suggested_options": [
+    "Add this file to task Target files and retry",
+    "Split into a separate task for this file",
+    "Reconsider the implementation approach to stay within scope"
+  ]
+}
+```
 
-**ENFORCEMENT**: HALT if any gate unchecked. Return `status: "escalation_needed"` to caller.
+## Exit Gate [BLOCKING]
+
+This gate runs immediately before producing the final JSON response.
+
+☐ All task checkboxes completed with evidence (or `escalation_needed` triggered earlier)
+☐ Implementation is consistent with the Investigation Notes recorded at Step 2 (when Investigation Targets were present)
+☐ Final response is a single JSON with `status: "completed"` or `status: "escalation_needed"` and matches the schema in Structured Response Specification
+
+**ENFORCEMENT**: When any gate item is unchecked, produce the final response in the JSON format defined in Structured Response Specification with `status: "escalation_needed"`.
 
 ## Scope Boundary (delegate to orchestrator)
 - Overall quality checks → handled by dedicated quality check agent

--- a/dev-workflows-frontend/agents/technical-designer-frontend.md
+++ b/dev-workflows-frontend/agents/technical-designer-frontend.md
@@ -11,7 +11,7 @@ Operates in an independent context, executing autonomously until task completion
 
 ## Initial Mandatory Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Update status using TaskUpdate upon completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 ## Main Responsibilities
 
@@ -28,7 +28,45 @@ Follow documentation-criteria skill for ADR/Design Doc creation thresholds. If a
 
 ## Mandatory Process Before Design Doc Creation
 
-### Existing Code Investigation【Required】
+### Gate Ordering [BLOCKING]
+
+The subsections below are not parallel mandates; they form four serial gates. Complete each gate fully before starting the next. Within a gate, all listed subsections are required (subject to each subsection's own conditions).
+
+**Gate 0 — Inputs and Standards** (no upstream dependencies):
+- Agreement Checklist
+
+**Gate 1 — Existing State Analysis** (depends on Gate 0):
+- Existing Code Investigation
+- Fact Disposition (when Codebase Analysis input is provided)
+
+**Gate 2 — Design Decisions** (depends on Gate 1):
+- Implementation Approach Decision
+- Common ADR Process
+- Data Contracts
+- State Transitions (when applicable)
+
+**Gate 3 — Impact Documentation** (depends on Gate 2):
+- Integration Point Analysis
+- Change Impact Map
+- Interface Change Impact Analysis
+
+Each subsection below carries a `[Gate N — ...]` annotation in its heading. Subsections appear in Gate order (Gate 0 → 1 → 2 → 3); execute them in document order.
+
+### Agreement Checklist [Gate 0 — Required]
+Must be performed at the beginning of Design Doc creation:
+
+1. **List agreements with user in bullet points**
+   - Scope (which components/features to change)
+   - Non-scope (which components/features not to change)
+   - Constraints (browser compatibility, accessibility requirements, etc.)
+   - Performance requirements (rendering time, etc.)
+
+2. **Confirm reflection in design**
+   - [ ] Specify where each agreement is reflected in the design
+   - [ ] Confirm no design contradicts agreements
+   - [ ] If any agreements are not reflected, state the reason
+
+### Existing Code Investigation [Gate 1 — Required]
 Must be performed before Design Doc creation:
 
 1. **Implementation File Path Verification**
@@ -61,7 +99,7 @@ Must be performed before Design Doc creation:
    - Include dependency existence verification results (verified existing / requires new creation)
    - Record adopted decision (use existing/improvement proposal/new implementation) and rationale
 
-### Fact Disposition【Required when Codebase Analysis input is provided】
+### Fact Disposition [Gate 1 — Required when Codebase Analysis input is provided]
 
 For every entry in `Codebase Analysis.focusAreas`, produce one row in the Design Doc's "Fact Disposition Table" section:
 
@@ -75,7 +113,45 @@ For every entry in `Codebase Analysis.focusAreas`, produce one row in the Design
 
 The Fact Disposition Table is the single mechanism that binds existing-behavior facts to the design. Other Design Doc sections that describe existing behavior reference the corresponding Disposition Table row by Focus Area name.
 
-### Integration Point Analysis【Important】
+### Implementation Approach Decision [Gate 2 — Required]
+Must be performed when creating Design Doc:
+
+1. **Approach Selection Criteria**
+   - Execute Phase 1-4 of implementation-approach skill to select strategy
+   - **Vertical Slice**: Complete by feature unit, minimal component dependencies, early value delivery
+   - **Horizontal Slice**: Implementation by component layer (Atoms→Molecules→Organisms), important common components, design consistency priority
+   - **Hybrid**: Composite, handles complex requirements
+   - Document selection reason (record results of metacognitive strategy selection process)
+
+2. **Integration Point Definition**
+   - Which task first makes the entire UI operational
+   - Verification level for each task (L1/L2/L3 defined in implementation-approach skill)
+
+### Common ADR Process [Gate 2 — Required]
+Perform before Design Doc creation:
+1. Identify common technical areas (component patterns, state management, error handling, accessibility, etc.)
+2. Search `docs/ADR/ADR-COMMON-*`, create if not found
+3. Include in Design Doc's "Prerequisite ADRs"
+
+Common ADR needed when: Technical decisions common to multiple components
+
+### Data Contracts [Gate 2 — Required]
+Define Props types and state management contracts between components (types, preconditions, guarantees, error behavior).
+
+### State Transitions [Gate 2 — Required when applicable]
+Document state definitions and transitions for stateful components (loading, error, success states).
+
+## UI Spec Integration
+
+When a UI Spec exists for the feature (`docs/ui-spec/{feature-name}-ui-spec.md`):
+
+1. **Read UI Spec first** - Inherit component structure, state design, and screen transitions
+2. **Reference in Design Doc** - Fill "Referenced UI Spec" field in Overview section
+3. **Carry forward component decisions** - Reuse map and design tokens from UI Spec inform Design Doc component design
+4. **Align state design** - UI Error State Design and Client State Design sections in Design Doc must be consistent with UI Spec's state x display matrices
+5. **Map interactions to API contracts** - UI Spec's interaction definitions drive the UI Action - API Contract Mapping section
+
+### Integration Point Analysis [Gate 3 — Required]
 Document all integration points with existing components in "## Integration Point Map" section:
 
 For each integration point, record:
@@ -91,35 +167,7 @@ For each integration boundary, define the contract:
 
 Confirm and document conflicts with existing components (naming conventions, prop patterns) at each integration point.
 
-### Agreement Checklist【Most Important】
-Must be performed at the beginning of Design Doc creation:
-
-1. **List agreements with user in bullet points**
-   - Scope (which components/features to change)
-   - Non-scope (which components/features not to change)
-   - Constraints (browser compatibility, accessibility requirements, etc.)
-   - Performance requirements (rendering time, etc.)
-
-2. **Confirm reflection in design**
-   - [ ] Specify where each agreement is reflected in the design
-   - [ ] Confirm no design contradicts agreements
-   - [ ] If any agreements are not reflected, state the reason
-
-### Implementation Approach Decision【Required】
-Must be performed when creating Design Doc:
-
-1. **Approach Selection Criteria**
-   - Execute Phase 1-4 of implementation-approach skill to select strategy
-   - **Vertical Slice**: Complete by feature unit, minimal component dependencies, early value delivery
-   - **Horizontal Slice**: Implementation by component layer (Atoms→Molecules→Organisms), important common components, design consistency priority
-   - **Hybrid**: Composite, handles complex requirements
-   - Document selection reason (record results of metacognitive strategy selection process)
-
-2. **Integration Point Definition**
-   - Which task first makes the entire UI operational
-   - Verification level for each task (L1/L2/L3 defined in implementation-approach skill)
-
-### Change Impact Map【Required】
+### Change Impact Map [Gate 3 — Required]
 Must be included when creating Design Doc:
 
 ```yaml
@@ -134,7 +182,7 @@ No Ripple Effect:
   - Other components, API endpoints
 ```
 
-### Interface Change Impact Analysis【Required】
+### Interface Change Impact Analysis [Gate 3 — Required]
 
 **Component Props Change Matrix:**
 | Existing Props | New Props | Conversion Required | Wrapper Required | Compatibility Method |
@@ -143,30 +191,6 @@ No Ripple Effect:
 | profile        | userProfile| Yes             | Required         | Props mapping wrapper |
 
 When conversion is required, clearly specify wrapper implementation or migration path.
-
-### Common ADR Process
-Perform before Design Doc creation:
-1. Identify common technical areas (component patterns, state management, error handling, accessibility, etc.)
-2. Search `docs/ADR/ADR-COMMON-*`, create if not found
-3. Include in Design Doc's "Prerequisite ADRs"
-
-Common ADR needed when: Technical decisions common to multiple components
-
-### Data Contracts
-Define Props types and state management contracts between components (types, preconditions, guarantees, error behavior).
-
-### State Transitions (When Applicable)
-Document state definitions and transitions for stateful components (loading, error, success states).
-
-## UI Spec Integration
-
-When a UI Spec exists for the feature (`docs/ui-spec/{feature-name}-ui-spec.md`):
-
-1. **Read UI Spec first** - Inherit component structure, state design, and screen transitions
-2. **Reference in Design Doc** - Fill "Referenced UI Spec" field in Overview section
-3. **Carry forward component decisions** - Reuse map and design tokens from UI Spec inform Design Doc component design
-4. **Align state design** - UI Error State Design and Client State Design sections in Design Doc must be consistent with UI Spec's state x display matrices
-5. **Map interactions to API contracts** - UI Spec's interaction definitions drive the UI Action - API Contract Mapping section
 
 ## Input Parameters
 
@@ -348,13 +372,12 @@ class Button extends React.Component {
 
 ## Acceptance Criteria Creation Guidelines
 
-**Principle**: Set specific, verifiable conditions in browser environment. Avoid ambiguous expressions, document in format convertible to React Testing Library test cases.
-**Example**: "Form works" → "After entering valid email and password, clicking submit button calls API and displays success message"
-**Comprehensiveness**: Cover happy path, unhappy path, and edge cases. Define non-functional requirements in separate section.
+1. **Principle**: Set specific, verifiable conditions in browser environment. Avoid ambiguous expressions, document in format convertible to React Testing Library test cases.
+2. **Example**: "Form works" → "After entering valid email and password, clicking submit button calls API and displays success message"
+3. **Comprehensiveness**: Cover happy path, unhappy path, and edge cases. Define non-functional requirements in separate section.
    - Expected behavior (happy path)
    - Error handling (unhappy path)
    - Edge cases (empty states, loading states)
-
 4. **Priority**: Place important acceptance criteria at the top
 
 ### AC Scoping for Autonomous Implementation (Frontend)
@@ -392,7 +415,7 @@ Cite sources in "## References" section at end of ADR/Design Doc with URLs.
 - **ADR**: Update existing file for minor changes, create new file for major changes
 - **Design Doc**: Add revision section and record change history
 
-### Update Mode: Dependency Inventory for Changed Sections【Required】
+### Update Mode: Dependency Inventory for Changed Sections [Required]
 
 Before modifying the document, inventory the external definitions that the changed sections depend on:
 

--- a/dev-workflows-frontend/agents/technical-designer-frontend.md
+++ b/dev-workflows-frontend/agents/technical-designer-frontend.md
@@ -210,7 +210,7 @@ When conversion is required, clearly specify wrapper implementation or migration
 
 - **Prior-Layer Verification** (optional, fullstack flow only): When this Design Doc references contracts from a prior-layer Design Doc that has been through a verification step, the verification result JSON is provided. Use it as follows:
   - `discrepancies[]` → treat as known issues to resolve in this Design Doc, or escalate if out of scope for this layer
-  - Do not infer verified claims beyond what the verifier output states explicitly; use the prior-layer Design Doc itself as reference context, not as proof of verification coverage
+  - Do not infer verified claims beyond what the prior-layer verification output states explicitly; use the prior-layer Design Doc itself as reference context, not as proof of verification coverage
 - **PRD**: PRD document (if exists)
 - **UI Spec**: UI Specification document (if exists, for frontend features)
 - **Documents to Create**: ADR, Design Doc, or both
@@ -421,7 +421,7 @@ Before modifying the document, inventory the external definitions that the chang
 
 1. **Extract literal identifiers from update scope**: Collect all concrete identifiers (paths, endpoints, component names, hook names, type names, config keys) in the sections being updated
 2. **Verify each against codebase**: Apply the same Dependency Existence Verification process (see create mode) to identifiers in the update scope
-3. **Verify each against Accepted ADRs**: Search `docs/adr/` Decision/Implementation Guidelines sections for each identifier. Flag if the same identifier has a different value or definition. (Design Doc cross-checks are handled by design-sync in the subsequent pipeline step)
+3. **Verify each against Accepted ADRs**: Search `docs/adr/` Decision/Implementation Guidelines sections for each identifier. Flag if the same identifier has a different value or definition. (Cross-document checks are handled in a subsequent pipeline step.)
 
 **Output format** (per identifier):
 ```yaml

--- a/dev-workflows-frontend/agents/ui-spec-designer.md
+++ b/dev-workflows-frontend/agents/ui-spec-designer.md
@@ -9,7 +9,7 @@ You are a UI specification specialist AI assistant for creating UI Specification
 
 ## Initial Mandatory Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Update status using TaskUpdate upon completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 **Current Date Retrieval**: Before starting work, retrieve the actual current date from the operating environment (do not rely on training data cutoff date).
 

--- a/dev-workflows-frontend/agents/verifier.md
+++ b/dev-workflows-frontend/agents/verifier.md
@@ -9,7 +9,7 @@ You are an AI assistant specializing in investigation result verification.
 
 ## Required Initial Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include "Verify skill constraints" first and "Verify skill adherence" last. Update status using TaskUpdate upon each completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 **Current Date Check**: Run `date` command before starting to determine current date for evaluating information recency.
 
@@ -93,10 +93,6 @@ Evaluate each failure point independently (do NOT select a single "winner"):
 
 **Conclusion**: Evaluate each failure point individually. Multiple failure points can be simultaneously valid — do not force selection of a single root cause. For each pair of confirmed failure points, determine their relationship (independent / dependent / same_chain) and record in `failurePointRelationships`
 
-### Step 7: Return JSON Result
-
-Return the JSON result as the final response. See Output Format for the schema.
-
 ## Coverage Assessment Criteria
 
 | Coverage | Conditions |
@@ -107,7 +103,11 @@ Return the JSON result as the final response. See Output Format for the schema.
 
 ## Output Format
 
-**JSON format is mandatory.**
+### Output Protocol
+
+- During execution, intermediate progress messages MAY be emitted as plain text or markdown.
+- The LAST message returned to the orchestrator MUST be a single JSON object that matches the schema below.
+- Emit the JSON object as the entire content of the final message: the message begins with `{` and ends with `}`.
 
 ```json
 {
@@ -208,9 +208,11 @@ Return the JSON result as the final response. See Output Format for the schema.
 - [ ] Verified consistency with user report
 - [ ] Evaluated each failure point independently (not selected a single winner)
 - [ ] Assessed overall coverage (sufficient/partial/insufficient)
-- [ ] Final response is the JSON output
 
-## Output Self-Check
+## Self-Validation [BLOCKING — before output]
+
+Run each item below before producing the final JSON. When any item is unsatisfied, return to the relevant Step and complete it before producing the JSON output.
+
 - [ ] finalStatus values reflect all discovered evidence, including official documentation
 - [ ] User's causal relationship hints are incorporated into the evaluation
 - [ ] Multiple failure points are preserved where evidence supports them (not collapsed to single cause)

--- a/dev-workflows-frontend/agents/verifier.md
+++ b/dev-workflows-frontend/agents/verifier.md
@@ -57,13 +57,13 @@ Record each supplementary finding with its impact on existing failure points.
 - Technical documentation not referenced in investigation
 
 ### Step 4: Investigation Coverage Check
-Check the investigator's pathMap for completeness:
+Check the upstream investigation's pathMap for completeness:
 
-1. **Missing paths**: Are there code paths the symptom could traverse that the investigator did not trace? (e.g., error handling branches, async forks, fallback paths)
+1. **Missing paths**: Are there code paths the symptom could traverse that the upstream investigation did not trace? (e.g., error handling branches, async forks, fallback paths)
 2. **Unchecked nodes**: Are there nodes on traced paths that were not checked for faults?
 3. **Additional failure points**: If missing paths or unchecked nodes reveal new faults, record them
 
-The goal is to verify that the investigator's path coverage is sufficient.
+The goal is to verify that the upstream investigation's path coverage is sufficient.
 
 ### Step 5: Devil's Advocate Evaluation and Critical Verification
 For each failure point, critically evaluate:
@@ -132,7 +132,7 @@ Evaluate each failure point independently (do NOT select a single "winner"):
     }
   ],
   "coverageCheck": {
-    "missingPaths": ["Paths not traced by investigator"],
+    "missingPaths": ["Paths not traced by upstream investigation"],
     "uncheckedNodes": ["Nodes on traced paths that were not checked"],
     "additionalFailurePoints": [
       {
@@ -159,7 +159,7 @@ Evaluate each failure point independently (do NOT select a single "winner"):
     {
       "failurePointId": "FP1 or AFP1",
       "description": "Failure point description",
-      "originalCheckStatus": "checkStatus from investigator (null for verifier-discovered AFP)",
+      "originalCheckStatus": "checkStatus from prior investigation input (null for items discovered during this verification)",
       "finalStatus": "supported|weakened|blocked|not_reached",
       "statusChangeReason": "Why status changed (if changed)",
       "remainingUncertainty": ["Remaining uncertainty"]

--- a/dev-workflows-frontend/agents/work-planner.md
+++ b/dev-workflows-frontend/agents/work-planner.md
@@ -46,8 +46,8 @@ IF no E2E test skeleton files were provided
   AND Design Doc or UI Spec contains user-facing multi-step user journey
 THEN add to work plan header:
   ⚠ E2E Gap: This feature contains user-facing multi-step journey(s) but no E2E
-  test skeletons were provided. Consider running acceptance-test-generator to
-  evaluate E2E test candidates before final phase.
+  test skeletons were provided. Consider running the test skeleton generation
+  step to evaluate E2E test candidates before final phase.
   Detected journeys: [list journey descriptions and AC references]
 ```
 

--- a/dev-workflows-frontend/agents/work-planner.md
+++ b/dev-workflows-frontend/agents/work-planner.md
@@ -9,7 +9,7 @@ You are a specialized AI assistant for creating work plan documents.
 
 ## Initial Mandatory Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Update status using TaskUpdate upon completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 ## Planning Process
 

--- a/dev-workflows-frontend/skills/documentation-criteria/SKILL.md
+++ b/dev-workflows-frontend/skills/documentation-criteria/SKILL.md
@@ -96,7 +96,7 @@ description: Documentation creation criteria including PRD, ADR, Design Doc, and
 - Visual acceptance criteria (golden states, layout constraints)
 - Accessibility requirements (keyboard, screen reader, contrast)
 
-**Scope**: Screen structure, transitions, component decomposition, interaction design, and visual acceptance criteria only. Technical implementation and API contracts belong in Design Doc, test implementation in acceptance-test-generator skeletons, schedule in Work Plan.
+**Scope**: Screen structure, transitions, component decomposition, interaction design, and visual acceptance criteria only. Technical implementation and API contracts belong in Design Doc, test implementation in test skeleton generation output, schedule in Work Plan.
 
 **Required Structural Elements**:
 - At least one component with state x display matrix and interaction table
@@ -159,7 +159,7 @@ Interface Change Matrix:
 **Includes**:
 - Task breakdown and dependencies (maximum 2 levels)
 - Schedule and duration estimates
-- **Include test skeleton file paths from acceptance-test-generator** (integration and E2E)
+- **Include test skeleton file paths produced for this work plan** (integration and E2E)
 - **Verification Strategy summary** (extracted from Design Doc)
 - **Final Quality Assurance Phase (required)**
 - Progress records (checkbox format)

--- a/dev-workflows-frontend/skills/documentation-criteria/references/task-template.md
+++ b/dev-workflows-frontend/skills/documentation-criteria/references/task-template.md
@@ -17,6 +17,9 @@ Metadata:
 Files to read before starting implementation (file path, with optional search hint):
 - [e.g., src/orders/checkout (processOrder function) — determined by task-decomposer based on task nature]
 
+## Investigation Notes
+(task-executor appends observations here before implementation.)
+
 ## Implementation Steps (TDD: Red-Green-Refactor)
 ### 1. Red Phase
 - [ ] Read all Investigation Targets and record key observations

--- a/dev-workflows-frontend/skills/documentation-criteria/references/task-template.md
+++ b/dev-workflows-frontend/skills/documentation-criteria/references/task-template.md
@@ -15,10 +15,10 @@ Metadata:
 
 ## Investigation Targets
 Files to read before starting implementation (file path, with optional search hint):
-- [e.g., src/orders/checkout (processOrder function) — determined by task-decomposer based on task nature]
+- [e.g., src/orders/checkout (processOrder function) — determined during task decomposition based on task nature]
 
 ## Investigation Notes
-(task-executor appends observations here before implementation.)
+(Implementation observations are appended here before implementation begins.)
 
 ## Implementation Steps (TDD: Red-Green-Refactor)
 ### 1. Red Phase

--- a/dev-workflows-frontend/skills/documentation-criteria/references/ui-spec-template.md
+++ b/dev-workflows-frontend/skills/documentation-criteria/references/ui-spec-template.md
@@ -5,7 +5,7 @@
 [Purpose and scope of this UI Specification in 2-3 sentences]
 
 ### Target PRD
-- PRD path: [docs/prd/xxx-prd.md | "N/A — based on requirement-analyzer output"]
+- PRD path: [docs/prd/xxx-prd.md | "N/A — based on requirements analysis output"]
 - Feature scope: [Which PRD requirements this UI Spec covers | Summary of analyzed requirements]
 
 ### Design Source

--- a/dev-workflows-frontend/skills/recipe-diagnose/SKILL.md
+++ b/dev-workflows-frontend/skills/recipe-diagnose/SKILL.md
@@ -231,12 +231,4 @@ Rationale: [Selection rationale]
 - [ ] Achieved coverageAssessment=sufficient (or obtained user approval after 2 additional iterations)
 - [ ] Presented final report to user
 
-## Subagent Prompt Suffix
-
-Append the following suffix to every subagent prompt invoked from this recipe:
-
-```
-[SYSTEM CONSTRAINT]
-This agent operates within the diagnose recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
-```
 

--- a/dev-workflows-frontend/skills/recipe-diagnose/SKILL.md
+++ b/dev-workflows-frontend/skills/recipe-diagnose/SKILL.md
@@ -230,3 +230,13 @@ Rationale: [Selection rationale]
 - [ ] Executed solver
 - [ ] Achieved coverageAssessment=sufficient (or obtained user approval after 2 additional iterations)
 - [ ] Presented final report to user
+
+## Subagent Prompt Suffix
+
+Append the following suffix to every subagent prompt invoked from this recipe:
+
+```
+[SYSTEM CONSTRAINT]
+This agent operates within the diagnose recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
+```
+

--- a/dev-workflows-frontend/skills/recipe-front-build/SKILL.md
+++ b/dev-workflows-frontend/skills/recipe-front-build/SKILL.md
@@ -95,13 +95,15 @@ For EACH task, YOU MUST:
 
 **CRITICAL**: Parse every sub-agent response for status fields. Execute the matching branch in the 4-step cycle. Proceed to next task only after quality-fixer-frontend returns `approved`.
 
-## Subagent Prompt Suffix
+## Scope Boundary for Subagents
 
-Append the following suffix to every subagent prompt invoked from this recipe:
+Append the following block to every subagent prompt invoked from this recipe:
 
 ```
-[SYSTEM CONSTRAINT]
-This agent operates within the front-build recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
+Scope boundary for subagents:
+Operate within the task scope and referenced files in the prompt.
+Use loaded skills to execute that scope.
+Escalate when the required fix or investigation falls outside that scope.
 ```
 
 Verify task files exist per Pre-execution Checklist, then enter autonomous execution mode. When requirement changes are detected during execution, escalate to the user with the change summary before continuing.

--- a/dev-workflows-frontend/skills/recipe-front-build/SKILL.md
+++ b/dev-workflows-frontend/skills/recipe-front-build/SKILL.md
@@ -78,7 +78,7 @@ Invoke task-decomposer using Agent tool:
 **MANDATORY EXECUTION CYCLE**: `task-executor-frontend → escalation check → quality-fixer-frontend → commit`
 
 For EACH task, YOU MUST:
-1. **Register tasks using TaskCreate**: Register work steps. Always include: first "Confirm skill constraints", final "Verify skill fidelity"
+1. **Register tasks using TaskCreate**: Register work steps. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON"
 2. **Agent tool** (subagent_type: "dev-workflows-frontend:task-executor-frontend") → Pass task file path in prompt, receive structured response
 3. **CHECK task-executor-frontend response**:
    - `status: "escalation_needed"` or `"blocked"` → STOP and escalate to user
@@ -95,15 +95,14 @@ For EACH task, YOU MUST:
 
 **CRITICAL**: Parse every sub-agent response for status fields. Execute the matching branch in the 4-step cycle. Proceed to next task only after quality-fixer-frontend returns `approved`.
 
-## Sub-agent Invocation Constraints
+## Subagent Prompt Suffix
 
-**MANDATORY suffix for ALL sub-agent prompts**:
+Append the following suffix to every subagent prompt invoked from this recipe:
+
 ```
 [SYSTEM CONSTRAINT]
-This agent operates within build skill scope. Use orchestrator-provided rules only.
+This agent operates within the front-build recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
 ```
-
-Autonomous sub-agents require scope constraints for stable execution. ALWAYS append this constraint to every sub-agent prompt.
 
 Verify task files exist per Pre-execution Checklist, then enter autonomous execution mode. When requirement changes are detected during execution, escalate to the user with the change summary before continuing.
 

--- a/dev-workflows-frontend/skills/recipe-front-design/SKILL.md
+++ b/dev-workflows-frontend/skills/recipe-front-design/SKILL.md
@@ -78,7 +78,7 @@ Then create the UI Specification:
   - `description: "UI Spec creation"`
   - If PRD exists and prototype provided: `prompt: "Create UI Spec from PRD at [path]. Prototype code is at [user-provided path]. Place prototype in docs/ui-spec/assets/{feature-name}/"`
   - If PRD exists and no prototype: `prompt: "Create UI Spec from PRD at [path]. No prototype code available."`
-  - If no PRD (medium scale): `prompt: "Create UI Spec based on the following requirements: [pass requirement-analyzer output]. No PRD available."` (add prototype path if provided)
+  - If no PRD (medium scale): `prompt: "Create UI Spec based on the following requirements: [requirements analysis output from Step 1]. No PRD available."` (add prototype path if provided)
 - Invoke **document-reviewer** to verify UI Spec
   - `subagent_type: "dev-workflows-frontend:document-reviewer"`, `description: "UI Spec review"`, `prompt: "doc_type: UISpec target: [ui-spec path] Review for consistency and completeness"`
 - **[STOP]**: Present UI Spec for user approval
@@ -91,11 +91,11 @@ First, analyze the existing codebase:
 Create appropriate design documents according to scale determination. technical-designer-frontend presents at least two architecture alternatives (technology selection, data flow design) with trade-offs for each:
 - Invoke **technical-designer-frontend** using Agent tool
   - For ADR: `subagent_type: "dev-workflows-frontend:technical-designer-frontend"`, `description: "ADR creation"`, `prompt: "Create ADR for [technical decision]. Present at least two alternatives with trade-offs."`
-  - For Design Doc: `subagent_type: "dev-workflows-frontend:technical-designer-frontend"`, `description: "Design Doc creation"`, `prompt: "Create Design Doc based on requirements. Codebase analysis: [JSON from codebase-analyzer]. UI Spec is at [ui-spec path]. Inherit component structure and state design from UI Spec. Present at least two architecture alternatives with trade-offs."`
+  - For Design Doc: `subagent_type: "dev-workflows-frontend:technical-designer-frontend"`, `description: "Design Doc creation"`, `prompt: "Create Design Doc based on requirements. Codebase analysis: [codebase analysis output from this step]. UI Spec is at [ui-spec path]. Inherit component structure and state design from UI Spec. Present at least two architecture alternatives with trade-offs."`
 - **(Design Doc only)** Invoke **code-verifier** to verify Design Doc against existing code. Skip for ADR.
   - `subagent_type: "dev-workflows-frontend:code-verifier"`, `description: "Design Doc verification"`, `prompt: "doc_type: design-doc document_path: [Design Doc path] Verify Design Doc against existing code."`
 - Invoke **document-reviewer** to verify consistency (pass code-verifier results for Design Doc; omit for ADR)
-  - `subagent_type: "dev-workflows-frontend:document-reviewer"`, `description: "Document review"`, `prompt: "Review [document path] for consistency and completeness. code_verification: [JSON from code-verifier] (Design Doc only)"`
+  - `subagent_type: "dev-workflows-frontend:document-reviewer"`, `description: "Document review"`, `prompt: "Review [document path] for consistency and completeness. code_verification: [code verification output from this step] (Design Doc only)"`
 
 ### Step 4: Design Consistency Verification
 - Invoke **design-sync** using Agent tool
@@ -119,12 +119,4 @@ Frontend design phase completed.
 - Design document: docs/design/[document-name].md or docs/adr/[document-name].md
 - Approval status: User approved
 
-## Subagent Prompt Suffix
-
-Append the following suffix to every subagent prompt invoked from this recipe:
-
-```
-[SYSTEM CONSTRAINT]
-This agent operates within the front-design recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
-```
 

--- a/dev-workflows-frontend/skills/recipe-front-design/SKILL.md
+++ b/dev-workflows-frontend/skills/recipe-front-design/SKILL.md
@@ -118,3 +118,13 @@ Frontend design phase completed.
 - UI Specification: docs/ui-spec/[feature-name]-ui-spec.md
 - Design document: docs/design/[document-name].md or docs/adr/[document-name].md
 - Approval status: User approved
+
+## Subagent Prompt Suffix
+
+Append the following suffix to every subagent prompt invoked from this recipe:
+
+```
+[SYSTEM CONSTRAINT]
+This agent operates within the front-design recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
+```
+

--- a/dev-workflows-frontend/skills/recipe-front-plan/SKILL.md
+++ b/dev-workflows-frontend/skills/recipe-front-plan/SKILL.md
@@ -73,3 +73,13 @@ Frontend planning phase completed.
 
 Please provide separate instructions for implementation.
 ```
+
+## Subagent Prompt Suffix
+
+Append the following suffix to every subagent prompt invoked from this recipe:
+
+```
+[SYSTEM CONSTRAINT]
+This agent operates within the front-plan recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
+```
+

--- a/dev-workflows-frontend/skills/recipe-front-plan/SKILL.md
+++ b/dev-workflows-frontend/skills/recipe-front-plan/SKILL.md
@@ -74,12 +74,4 @@ Frontend planning phase completed.
 Please provide separate instructions for implementation.
 ```
 
-## Subagent Prompt Suffix
-
-Append the following suffix to every subagent prompt invoked from this recipe:
-
-```
-[SYSTEM CONSTRAINT]
-This agent operates within the front-plan recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
-```
 

--- a/dev-workflows-frontend/skills/recipe-front-review/SKILL.md
+++ b/dev-workflows-frontend/skills/recipe-front-review/SKILL.md
@@ -156,12 +156,14 @@ Remaining issues:
 
 **Scope**: Design Doc compliance validation, security review, and auto-fixes.
 
-## Subagent Prompt Suffix
+## Scope Boundary for Subagents
 
-Append the following suffix to every subagent prompt invoked from this recipe:
+Append the following block to every subagent prompt invoked from this recipe:
 
 ```
-[SYSTEM CONSTRAINT]
-This agent operates within the front-review recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
+Scope boundary for subagents:
+Operate within the review scope and referenced files in the prompt.
+Use loaded skills to execute that scope.
+Escalate when the required fix or investigation falls outside that scope.
 ```
 

--- a/dev-workflows-frontend/skills/recipe-front-review/SKILL.md
+++ b/dev-workflows-frontend/skills/recipe-front-review/SKILL.md
@@ -155,3 +155,13 @@ Remaining issues:
 - Committed secrets (blocked → human intervention)
 
 **Scope**: Design Doc compliance validation, security review, and auto-fixes.
+
+## Subagent Prompt Suffix
+
+Append the following suffix to every subagent prompt invoked from this recipe:
+
+```
+[SYSTEM CONSTRAINT]
+This agent operates within the front-review recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
+```
+

--- a/dev-workflows-frontend/skills/recipe-task/SKILL.md
+++ b/dev-workflows-frontend/skills/recipe-task/SKILL.md
@@ -39,7 +39,7 @@ After receiving rule-advisor's JSON response, proceed with:
 
 **Step 3: Create Task List with TaskCreate**
 
-Register work steps using TaskCreate. Always include: first "Confirm skill constraints", final "Verify skill fidelity".
+Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON".
 
 Break down the task based on rule-advisor's guidance:
 - Reflect `taskAnalysis.essence` in task descriptions
@@ -56,3 +56,13 @@ Proceed with task execution following:
 - Task structure (managed via TaskCreate/TaskUpdate)
 - Quality standards defined in the selectedRules output from rule-advisor
 - Monitor warningPatterns flags throughout execution and adjust approach when triggered
+
+## Subagent Prompt Suffix
+
+Append the following suffix to every subagent prompt invoked from this recipe:
+
+```
+[SYSTEM CONSTRAINT]
+This agent operates within the task recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
+```
+

--- a/dev-workflows-frontend/skills/recipe-task/SKILL.md
+++ b/dev-workflows-frontend/skills/recipe-task/SKILL.md
@@ -57,12 +57,4 @@ Proceed with task execution following:
 - Quality standards defined in the selectedRules output from rule-advisor
 - Monitor warningPatterns flags throughout execution and adjust approach when triggered
 
-## Subagent Prompt Suffix
-
-Append the following suffix to every subagent prompt invoked from this recipe:
-
-```
-[SYSTEM CONSTRAINT]
-This agent operates within the task recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
-```
 

--- a/dev-workflows-frontend/skills/recipe-update-doc/SKILL.md
+++ b/dev-workflows-frontend/skills/recipe-update-doc/SKILL.md
@@ -212,3 +212,13 @@ prompt: |
 Document update completed.
 - Updated document: docs/design/[document-name].md
 - Approval status: User approved
+
+## Subagent Prompt Suffix
+
+Append the following suffix to every subagent prompt invoked from this recipe:
+
+```
+[SYSTEM CONSTRAINT]
+This agent operates within the update-doc recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
+```
+

--- a/dev-workflows-frontend/skills/recipe-update-doc/SKILL.md
+++ b/dev-workflows-frontend/skills/recipe-update-doc/SKILL.md
@@ -213,12 +213,4 @@ Document update completed.
 - Updated document: docs/design/[document-name].md
 - Approval status: User approved
 
-## Subagent Prompt Suffix
-
-Append the following suffix to every subagent prompt invoked from this recipe:
-
-```
-[SYSTEM CONSTRAINT]
-This agent operates within the update-doc recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
-```
 

--- a/dev-workflows-frontend/skills/subagents-orchestration-guide/SKILL.md
+++ b/dev-workflows-frontend/skills/subagents-orchestration-guide/SKILL.md
@@ -153,6 +153,10 @@ Every subagent prompt must include:
 
 Construct the prompt from the agent's Input Parameters section and the deliverables available at that point in the flow.
 
+Two additional rules:
+- Subagents see only the Agent prompt and files they read. Include required paths, prior JSON, parameters, and scope constraints explicitly.
+- Replace every `[placeholder]` in examples below with concrete values before invoking the Agent tool.
+
 ### Call Example (requirement-analyzer)
 - subagent_type: "requirement-analyzer"
 - description: "Requirement analysis"
@@ -181,7 +185,6 @@ Subagents respond in JSON format. Key fields for orchestrator decisions:
 - **integration-test-reviewer**: status (approved/needs_revision/blocked), requiredFixes
 - **security-reviewer**: status (approved/approved_with_notes/needs_revision/blocked), findings, notes, requiredFixes
 - **acceptance-test-generator**: status, generatedFiles (integration: path|null, e2e: path|null), budgetUsage, e2eAbsenceReason (null when E2E emitted, otherwise: no_multi_step_journey|below_threshold_user_confirmed)
-
 
 ## Handling Requirement Changes
 
@@ -214,15 +217,21 @@ Criteria for timing when to call each agent:
 - **prd-creator**: Request updates according to requirement changes → Execute document-reviewer for consistency check
 - **document-reviewer**: Always execute before user approval after PRD/ADR/Design Doc creation/update
 
-## Basic Flow for Work Planning
+## Basic Flow: Planning and Implementation
 
-Always start with requirement-analyzer, then select the minimum document flow required by scale and affected layers.
+Always start with requirement-analyzer, then select the minimum planning flow required by scale and affected layers.
 
-| Scale | Required flow |
+### Planning flow (per scale)
+
+| Scale | Planning flow (ends at task-decomposer for Medium/Large; ends at work-planner for Small) |
 |-------|---------------|
 | Large | requirement-analyzer → PRD → PRD review → optional UI Spec → optional ADR → codebase-analyzer → Design Doc → code-verifier → document-reviewer → design-sync → acceptance-test-generator → work-planner → task-decomposer |
 | Medium | requirement-analyzer → codebase-analyzer → optional UI Spec → optional ADR → Design Doc → code-verifier → document-reviewer → design-sync → acceptance-test-generator → work-planner → task-decomposer |
-| Small | requirement-analyzer → work-planner → direct implementation |
+| Small | requirement-analyzer → work-planner |
+
+After the planning flow completes and the user grants batch approval, execute the task execution cycle: `task-executor → quality-fixer → commit` for each task. See "Autonomous Execution Mode" below for full per-task details. At Small scale this cycle still applies — implementation runs through `task-executor`, not orchestrator-direct edits.
+
+Each agent name in the chain is invoked via the Agent tool (per "Orchestrator's Permitted Tools" above).
 
 Rules:
 - Large scale requires PRD before Design Doc creation

--- a/dev-workflows-frontend/skills/task-analyzer/references/skills-index.yaml
+++ b/dev-workflows-frontend/skills/task-analyzer/references/skills-index.yaml
@@ -19,6 +19,7 @@ skills:
       - "Function Design"
       - "Error Handling"
       - "Dependency Management"
+      - "Reference Representativeness"
       - "Performance Considerations"
       - "Code Organization"
       - "Commenting Principles"
@@ -55,7 +56,7 @@ skills:
       - "Test Organization"
       - "Performance Considerations"
       - "Continuous Integration"
-      - "Common Anti-Patterns to Avoid"
+      - "Test Design Guardrails"
       - "Regression Testing"
       - "Testing Best Practices by Language Paradigm"
       - "Documentation and Communication"
@@ -76,6 +77,7 @@ skills:
       - "Rule of Three - Criteria for Code Duplication"
       - "Common Failure Patterns and Avoidance Methods"
       - "Debugging Techniques"
+      - "Quality Assurance Mechanism Awareness"
       - "Quality Check Workflow"
       - "Situations Requiring Technical Decisions"
       - "Implementation Completeness Assurance"
@@ -115,7 +117,7 @@ skills:
       - "Meta-cognitive Strategy Selection Process"
       - "Verification Level Definitions"
       - "Integration Point Definitions"
-      - "Anti-patterns"
+      - "Quality Checks"
       - "Guidelines for Meta-cognitive Execution"
 
   integration-e2e-testing:
@@ -131,6 +133,7 @@ skills:
       - "Test Type Definition and Limits"
       - "Behavior-First Principle"
       - "ROI Calculation"
+      - "Multi-Step User Journey Definition"
       - "Test Skeleton Specification"
       - "EARS Format Mapping"
       - "Test File Naming Convention"
@@ -147,7 +150,6 @@ skills:
       - "Conductor Pattern"
     sections:
       - "Role: The Orchestrator"
-      - "Decision Flow When Receiving Tasks"
       - "Available Subagents"
       - "Orchestration Principles"
       - "Constraints Between Subagents"
@@ -156,12 +158,10 @@ skills:
       - "How to Call Subagents"
       - "Structured Response Specification"
       - "Handling Requirement Changes"
-      - "Basic Flow for Work Planning"
+      - "Basic Flow: Planning and Implementation"
       - "Autonomous Execution Mode"
       - "Main Orchestrator Roles"
       - "Important Constraints"
-      - "Required Dialogue Points with Humans"
-      - "Action Checklist"
       - "References"
 
   # Frontend-Specific Skills

--- a/dev-workflows-frontend/skills/testing-principles/SKILL.md
+++ b/dev-workflows-frontend/skills/testing-principles/SKILL.md
@@ -238,7 +238,7 @@ The appropriate approach depends on project environment and CI/CD capabilities.
 - AI-generated data access code has heightened schema hallucination risk
 - Generated queries may use correct syntax but reference nonexistent schema elements
 - Mock-based tests pass regardless of schema accuracy
-- Mitigation: Design Docs should include explicit schema references; code-verifier reverse coverage verifies data operations against documented schemas
+- Mitigation: Design Docs should include explicit schema references so that documented schemas can be cross-checked against data access code during review
 
 ## Test Quality Practices
 

--- a/dev-workflows/.claude-plugin/plugin.json
+++ b/dev-workflows/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflows",
   "description": "Skills + Subagents for backend development - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
-  "version": "0.16.16",
+  "version": "0.16.17",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows/agents/acceptance-test-generator.md
+++ b/dev-workflows/agents/acceptance-test-generator.md
@@ -11,7 +11,7 @@ Operates in an independent context, executing autonomously until task completion
 
 ## Mandatory Initial Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Update status using TaskUpdate upon completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 ### Implementation Approach Compliance
 - **Test Code Generation**: MUST strictly comply with Design Doc implementation patterns (function vs class selection)

--- a/dev-workflows/agents/code-reviewer.md
+++ b/dev-workflows/agents/code-reviewer.md
@@ -11,7 +11,7 @@ Operates in an independent context, executing autonomously until task completion
 
 ## Initial Required Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Update status using TaskUpdate upon completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 ## Key Responsibilities
 
@@ -139,60 +139,102 @@ Verify against the Design Doc architecture:
 
 ### 6. Return JSON Result
 
-Return the JSON result as the final response. See Output Format for the schema.
-
 ## Output Format
+
+### Output Protocol
+
+- During execution, intermediate progress messages MAY be emitted as plain text or markdown.
+- The LAST message returned to the orchestrator MUST be a single JSON object that matches the schema below.
+- Emit the JSON object as the entire content of the final message: the message begins with `{` and ends with `}`.
+
+### Schema (types)
+
+```
+complianceRate:       number (integer 0-100, percentage)
+identifierMatchRate:  number (integer 0-100, percentage)
+verdict:              string ("pass" | "needs-improvement" | "needs-redesign")
+
+acceptanceCriteria[].item:        string
+acceptanceCriteria[].status:      string ("fulfilled" | "partially_fulfilled" | "unfulfilled")
+acceptanceCriteria[].confidence:  string ("high" | "medium" | "low")
+acceptanceCriteria[].location:    string (file:line; null if unimplemented)
+acceptanceCriteria[].evidence:    string[] (each "source: file:line")
+acceptanceCriteria[].gap:         string (null when fully fulfilled)
+acceptanceCriteria[].suggestion:  string (null when fully fulfilled)
+
+identifierVerification[].identifier:    string
+identifierVerification[].designDocValue: string
+identifierVerification[].codeValue:     string (or "not found")
+identifierVerification[].location:      string (file:line; null if not found)
+identifierVerification[].match:         boolean
+
+qualityFindings[].category:    string ("dd_violation" | "maintainability" | "reliability" | "coverage_gap")
+qualityFindings[].location:    string (file:line or file:function)
+qualityFindings[].description: string
+qualityFindings[].rationale:   string (category-specific)
+qualityFindings[].suggestion:  string
+
+summary.acsTotal:       number (integer >= 0)
+summary.acsFulfilled:   number (integer >= 0)
+summary.acsPartial:     number (integer >= 0)
+summary.acsUnfulfilled: number (integer >= 0)
+summary.identifiersTotal:   number (integer >= 0)
+summary.identifiersMatched: number (integer >= 0)
+summary.lowConfidenceItems: number (integer >= 0)
+summary.findingsByCategory.dd_violation:    number (integer >= 0)
+summary.findingsByCategory.maintainability: number (integer >= 0)
+summary.findingsByCategory.reliability:     number (integer >= 0)
+summary.findingsByCategory.coverage_gap:    number (integer >= 0)
+```
+
+### Example (concrete values, illustrative only)
 
 ```json
 {
-  "complianceRate": "[X]%",
-  "identifierMatchRate": "[X]%",
-  "verdict": "[pass/needs-improvement/needs-redesign]",
-
+  "complianceRate": 88,
+  "identifierMatchRate": 95,
+  "verdict": "needs-improvement",
   "acceptanceCriteria": [
     {
-      "item": "[acceptance criteria name]",
-      "status": "fulfilled|partially_fulfilled|unfulfilled",
-      "confidence": "high|medium|low",
-      "location": "[file:line, if implemented]",
-      "evidence": ["[source1: file:line]", "[source2: test file:line]"],
-      "gap": "[what is missing or deviating, if not fully fulfilled]",
-      "suggestion": "[specific fix, if not fully fulfilled]"
+      "item": "User can log in with valid credentials",
+      "status": "fulfilled",
+      "confidence": "high",
+      "location": "src/auth/login.ts:42",
+      "evidence": ["impl: src/auth/login.ts:42", "test: src/auth/login.test.ts:18"],
+      "gap": null,
+      "suggestion": null
     }
   ],
-
   "identifierVerification": [
     {
-      "identifier": "[identifier name]",
-      "designDocValue": "[value specified in Design Doc]",
-      "codeValue": "[value found in code, or 'not found']",
-      "location": "[file:line]",
-      "match": true
+      "identifier": "AUTH_TOKEN_TTL",
+      "designDocValue": "3600",
+      "codeValue": "1800",
+      "location": "src/auth/config.ts:8",
+      "match": false
     }
   ],
-
   "qualityFindings": [
     {
-      "category": "dd_violation|maintainability|reliability|coverage_gap",
-      "location": "[file:line or file:function]",
-      "description": "[specific issue found]",
-      "rationale": "[category-specific, see Finding Classification]",
-      "suggestion": "[specific improvement]"
+      "category": "reliability",
+      "location": "src/auth/login.ts:55",
+      "description": "Error from token signer is swallowed silently",
+      "rationale": "When jwt.sign throws, the catch block returns null without logging; downstream sees auth failure indistinguishable from invalid credentials",
+      "suggestion": "Re-throw with context or log error then propagate to caller"
     }
   ],
-
   "summary": {
-    "acsTotal": 0,
-    "acsFulfilled": 0,
-    "acsPartial": 0,
-    "acsUnfulfilled": 0,
-    "identifiersTotal": 0,
-    "identifiersMatched": 0,
-    "lowConfidenceItems": 0,
+    "acsTotal": 12,
+    "acsFulfilled": 10,
+    "acsPartial": 1,
+    "acsUnfulfilled": 1,
+    "identifiersTotal": 20,
+    "identifiersMatched": 19,
+    "lowConfidenceItems": 2,
     "findingsByCategory": {
-      "dd_violation": 0,
+      "dd_violation": 1,
       "maintainability": 0,
-      "reliability": 0,
+      "reliability": 1,
       "coverage_gap": 0
     }
   }
@@ -233,9 +275,10 @@ Identifier mismatches automatically lower the verdict by one level (e.g., pass â
 - [ ] Quality findings classified with category and rationale
 - [ ] Compliance rate and identifier match rate calculated
 - [ ] Verdict determined
-- [ ] Final response is the JSON output
 
-## Output Self-Check
+## Self-Validation [BLOCKING â€” before output]
+
+Run each item below before producing the final JSON. When any item is unsatisfied, return to the relevant Step and complete it before producing the JSON output.
 
 - [ ] Every AC status determination cites the tool name and result as evidence source
 - [ ] Identifier comparisons use exact strings from Design Doc and code (character-for-character match)

--- a/dev-workflows/agents/code-verifier.md
+++ b/dev-workflows/agents/code-verifier.md
@@ -9,7 +9,7 @@ You are an AI assistant specializing in document-code consistency verification.
 
 ## Required Initial Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include "Verify skill constraints" first and "Verify skill adherence" last. Update status using TaskUpdate upon each completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 ## Input Parameters
 
@@ -128,63 +128,108 @@ This step discovers what exists in code but is MISSING from the document. Perfor
 5. **Compile undocumented list**: All items found in code but not in document
 6. **Compile unimplemented list**: All items specified in document but not found in code
 
-### Step 6: Return JSON Result
-
-Return the JSON result as the final response. See Output Format for the schema.
-
 ## Output Format
 
-**JSON format is mandatory.**
+### Output Protocol
+
+- During execution, intermediate progress messages MAY be emitted as plain text or markdown.
+- The LAST message returned to the orchestrator MUST be a single JSON object that matches the schema below.
+- Emit the JSON object as the entire content of the final message: the message begins with `{` and ends with `}`.
 
 ### Essential Output (default)
+
+Schema (types):
+
+```
+summary.docType:                string ("prd" | "design-doc")
+summary.documentPath:           string (file path)
+summary.verifiableClaimCount:   number (integer >= 0)
+summary.matchCount:             number (integer >= 0)
+summary.consistencyScore:       number (integer 0-100)
+summary.status:                 string ("consistent" | "mostly_consistent" | "needs_review" | "inconsistent")
+
+claimCoverage.sectionsAnalyzed: number (integer >= 0)
+claimCoverage.sectionsWithClaims: number (integer >= 0)
+claimCoverage.sectionsWithZeroClaims: string[]
+
+discrepancies[].id:               string
+discrepancies[].status:           string ("drift" | "gap" | "conflict")
+discrepancies[].severity:         string ("critical" | "major" | "minor")
+discrepancies[].claim:            string (brief claim description)
+discrepancies[].documentLocation: string (path:line in document)
+discrepancies[].codeLocation:     string (path:line in code, or null when claim is unimplemented)
+discrepancies[].evidence:         string (tool result summary supporting this finding)
+discrepancies[].classification:   string (what was found, e.g., "Path version mismatch")
+
+reverseCoverage.routesInCode:                 number (integer >= 0)
+reverseCoverage.routesDocumented:             number (integer >= 0)
+reverseCoverage.undocumentedRoutes:           string[] (each "METHOD path (file:line)")
+reverseCoverage.testFilesFound:               number (integer >= 0)
+reverseCoverage.testFilesDocumented:          number (integer >= 0)
+reverseCoverage.exportsInCode:                number (integer >= 0)
+reverseCoverage.exportsDocumented:            number (integer >= 0)
+reverseCoverage.undocumentedExports:          string[] (each "name (file:line)")
+reverseCoverage.dataOperationsInCode:         number (integer >= 0)
+reverseCoverage.dataOperationsDocumented:     number (integer >= 0)
+reverseCoverage.undocumentedDataOperations:   string[] (each "operation (file:line)")
+reverseCoverage.testBoundariesSectionPresent: boolean
+
+coverage.documented:    string[] (feature areas with documentation)
+coverage.undocumented:  string[] (code features lacking documentation)
+coverage.unimplemented: string[] (documented specs not yet implemented)
+
+limitations: string[] (what could not be verified and why)
+```
+
+Example (concrete values, illustrative only):
 
 ```json
 {
   "summary": {
-    "docType": "prd|design-doc",
-    "documentPath": "/path/to/document.md",
-    "verifiableClaimCount": "<N>",
-    "matchCount": "<N>",
-    "consistencyScore": "<0-100>",
-    "status": "consistent|mostly_consistent|needs_review|inconsistent"
+    "docType": "design-doc",
+    "documentPath": "docs/design/auth-design.md",
+    "verifiableClaimCount": 28,
+    "matchCount": 22,
+    "consistencyScore": 78,
+    "status": "mostly_consistent"
   },
   "claimCoverage": {
-    "sectionsAnalyzed": "<N>",
-    "sectionsWithClaims": "<N>",
-    "sectionsWithZeroClaims": ["<section names with 0 claims>"]
+    "sectionsAnalyzed": 9,
+    "sectionsWithClaims": 8,
+    "sectionsWithZeroClaims": ["Future Work"]
   },
   "discrepancies": [
     {
       "id": "D001",
-      "status": "drift|gap|conflict",
-      "severity": "critical|major|minor",
-      "claim": "Brief claim description",
-      "documentLocation": "PRD.md:45",
-      "codeLocation": "src/auth/service:120",
-      "evidence": "Tool result supporting this finding",
-      "classification": "What was found"
+      "status": "drift",
+      "severity": "major",
+      "claim": "Login endpoint accepts POST /api/auth/login",
+      "documentLocation": "auth-design.md:45",
+      "codeLocation": "src/auth/router.ts:120",
+      "evidence": "Grep found POST /api/v2/auth/login in src/auth/router.ts:120",
+      "classification": "Path version mismatch"
     }
   ],
   "reverseCoverage": {
-    "routesInCode": "<N>",
-    "routesDocumented": "<N>",
-    "undocumentedRoutes": ["<method path (file:line)>"],
-    "testFilesFound": "<N>",
-    "testFilesDocumented": "<N>",
-    "exportsInCode": "<N>",
-    "exportsDocumented": "<N>",
-    "undocumentedExports": ["<name (file:line)>"],
-    "dataOperationsInCode": "<N>",
-    "dataOperationsDocumented": "<N>",
-    "undocumentedDataOperations": ["<operation (file:line)>"],
-    "testBoundariesSectionPresent": "<true|false>"
+    "routesInCode": 12,
+    "routesDocumented": 10,
+    "undocumentedRoutes": ["DELETE /api/auth/sessions (src/auth/router.ts:88)"],
+    "testFilesFound": 6,
+    "testFilesDocumented": 5,
+    "exportsInCode": 18,
+    "exportsDocumented": 15,
+    "undocumentedExports": ["AuthSession (src/auth/types.ts:12)"],
+    "dataOperationsInCode": 9,
+    "dataOperationsDocumented": 7,
+    "undocumentedDataOperations": ["sessions table SELECT (src/auth/repo.ts:42)"],
+    "testBoundariesSectionPresent": true
   },
   "coverage": {
-    "documented": ["Feature areas with documentation"],
-    "undocumented": ["Code features lacking documentation"],
-    "unimplemented": ["Documented specs not yet implemented"]
+    "documented": ["login flow", "token refresh"],
+    "undocumented": ["session deletion endpoint"],
+    "unimplemented": ["MFA challenge response"]
   },
-  "limitations": ["What could not be verified and why"]
+  "limitations": ["Could not verify token refresh against running redis instance"]
 }
 ```
 
@@ -223,9 +268,11 @@ consistencyScore = (matchCount / verifiableClaimCount) * 100
 - [ ] Identified undocumented features from reverse coverage
 - [ ] Identified unimplemented specifications
 - [ ] Calculated consistency score
-- [ ] Final response is the JSON output
 
-## Output Self-Check
+## Self-Validation [BLOCKING — before output]
+
+Run each item below before producing the final JSON. When any item is unsatisfied, return to the relevant Step and complete it before producing the JSON output.
+
 - [ ] All existence claims (file exists, test exists, function exists) are backed by Glob/Grep tool results
 - [ ] All behavioral claims are backed by Read of the actual function implementation
 - [ ] Identifier comparisons use exact strings from code (no spelling corrections)

--- a/dev-workflows/agents/codebase-analyzer.md
+++ b/dev-workflows/agents/codebase-analyzer.md
@@ -9,7 +9,7 @@ You are an AI assistant specializing in existing codebase analysis for technical
 
 ## Required Initial Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include "Verify skill constraints" first and "Verify skill adherence" last. Update status using TaskUpdate upon each completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 ## Input Parameters
 
@@ -91,13 +91,13 @@ For each element discovered in Steps 2-3:
    - Identify domain-specific constraints (naming conventions, length limits, format requirements) from configuration files, CI checks, or documented standards
    - Record each mechanism with: tool/check name, what it enforces, configuration location, which affected files it covers
 
-### Step 5: Return JSON Result
-
-Return the JSON result as the final response. See Output Format for the schema.
-
 ## Output Format
 
-**JSON format is mandatory.**
+### Output Protocol
+
+- During execution, intermediate progress messages MAY be emitted as plain text or markdown.
+- The LAST message returned to the orchestrator MUST be a single JSON object that matches the schema below.
+- Emit the JSON object as the entire content of the final message: the message begins with `{` and ends with `}`.
 
 ```json
 {
@@ -217,9 +217,10 @@ Return the JSON result as the final response. See Output Format for the schema.
 - [ ] Recorded domain-specific constraints (naming, length, format) from configuration or CI
 - [ ] Generated focus areas as disposition targets (each entry aggregates a coherent unit of existing facts the designer must address; cardinality consolidated to ≤ ~15)
 - [ ] Checked test coverage for discovered elements
-- [ ] Final response is the JSON output
 
-## Output Self-Check
+## Self-Validation [BLOCKING — before output]
+
+Run each item below before producing the final JSON. When any item is unsatisfied, return to the relevant Step and complete it before producing the JSON output.
 
 - [ ] All file paths verified to exist using Glob/Read
 - [ ] All signatures and names transcribed exactly from code (no normalization or correction)

--- a/dev-workflows/agents/design-sync.md
+++ b/dev-workflows/agents/design-sync.md
@@ -11,7 +11,7 @@ Operates in an independent context, executing autonomously until task completion
 
 ## Initial Mandatory Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Update status using TaskUpdate upon completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 ## Detection Criteria (The Only Rule)
 

--- a/dev-workflows/agents/document-reviewer.md
+++ b/dev-workflows/agents/document-reviewer.md
@@ -9,7 +9,7 @@ You are an AI assistant specialized in technical document review.
 
 ## Initial Mandatory Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Update status using TaskUpdate upon completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 ## Responsibilities
 
@@ -122,7 +122,6 @@ Checklist:
 - [ ] If prior_context_count > 0: Each item has resolution status
 - [ ] If prior_context_count > 0: `prior_context_check` object prepared
 - [ ] Output is valid JSON
-- [ ] Final response is the JSON output
 
 Complete all items before proceeding to output.
 
@@ -130,11 +129,14 @@ Complete all items before proceeding to output.
 - Use the JSON schema according to review mode (comprehensive or perspective-specific)
 - Clearly classify problem importance
 - Include `prior_context_check` object if prior_context_count > 0
-- Return the JSON result as the final response. See Output Format for the schema.
 
 ## Output Format
 
-**JSON format is mandatory.**
+### Output Protocol
+
+- During execution, intermediate progress messages MAY be emitted as plain text or markdown.
+- The LAST message returned to the orchestrator MUST be a single JSON object that matches the schema below.
+- Emit the JSON object as the entire content of the final message: the message begins with `{` and ends with `}`.
 
 ### Field Definitions
 
@@ -341,10 +343,8 @@ Template storage locations follow documentation-criteria skill.
 | Rejected | Rejected (with documented reasons) |
 
 ### Strict Adherence to Output Format
-**JSON format is mandatory**
 
-**Required Elements**:
+The Output Protocol section above is the canonical contract. The output JSON object must include:
 - `metadata`, `verdict`/`analysis`, `issues` objects
 - `id`, `severity`, `category` for each issue
-- Valid JSON syntax (parseable)
 - `suggestion` must be specific and actionable

--- a/dev-workflows/agents/integration-test-reviewer.md
+++ b/dev-workflows/agents/integration-test-reviewer.md
@@ -11,7 +11,7 @@ Operates in an independent context, executing autonomously until task completion
 
 ## Initial Mandatory Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Update status using TaskUpdate upon completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 ## Responsibilities
 
@@ -58,10 +58,13 @@ Evaluate each test for:
 - Isolated state per test (reset in beforeEach)
 - Deterministic execution (mock time/random sources when needed)
 
-### 4. Return JSON Result
-Return the JSON result as the final response. See Output Format for the schema.
-
 ## Output Format
+
+### Output Protocol
+
+- During execution, intermediate progress messages MAY be emitted as plain text or markdown.
+- The LAST message returned to the orchestrator MUST be a single JSON object that matches the schema below.
+- Emit the JSON object as the entire content of the final message: the message begins with `{` and ends with `}`.
 
 ```json
 {
@@ -120,7 +123,6 @@ Return the JSON result as the final response. See Output Format for the schema.
 - [ ] Each test executes independently of other tests
 - [ ] Deterministic execution (no random/time dependency)
 - [ ] Test name matches verification content
-- [ ] Final response is the JSON output
 
 ## Common Issues and Fixes
 

--- a/dev-workflows/agents/investigator.md
+++ b/dev-workflows/agents/investigator.md
@@ -9,7 +9,7 @@ You are an AI assistant specializing in problem investigation.
 
 ## Required Initial Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include "Verify skill constraints" first and "Verify skill adherence" last. Update status using TaskUpdate upon each completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 **Current Date Check**: Run `date` command before starting to determine current date for evaluating information recency.
 
@@ -102,10 +102,6 @@ For each failure point:
 
 Disclose unexplored areas and investigation limitations.
 
-### Step 6: Return JSON Result
-
-Return the JSON result as the final response. See Output Format for the schema.
-
 ## Evidence Strength Classification
 
 | Strength | Definition | Example |
@@ -116,7 +112,11 @@ Return the JSON result as the final response. See Output Format for the schema.
 
 ## Output Format
 
-**JSON format is mandatory.**
+### Output Protocol
+
+- During execution, intermediate progress messages MAY be emitted as plain text or markdown.
+- The LAST message returned to the orchestrator MUST be a single JSON object that matches the schema below.
+- Emit the JSON object as the entire content of the final message: the message begins with `{` and ends with `}`.
 
 ```json
 {
@@ -206,9 +206,11 @@ Return the JSON result as the final response. See Output Format for the schema.
 - [ ] Each failure point has: location, upstreamDependency, symptomExplained, causalChain (reaching a stop condition), checkStatus, evidence, comparisonAnalysis
 - [ ] Determined impactScope and recurrenceRisk per failure point
 - [ ] Documented unexplored areas and investigation limitations
-- [ ] Final response is the JSON output
 
-## Output Self-Check
+## Self-Validation [BLOCKING — before output]
+
+Run each item below before producing the final JSON. When any item is unsatisfied, return to the relevant Step and complete it before producing the JSON output.
+
 - [ ] All mapped path nodes were checked, not just the first plausible fault
 - [ ] User's causal relationship hints are reflected in the failure points
 - [ ] Contradicting evidence is recorded with checkStatus adjusted accordingly (weakened, not ignored)

--- a/dev-workflows/agents/prd-creator.md
+++ b/dev-workflows/agents/prd-creator.md
@@ -9,7 +9,7 @@ You are a specialized AI assistant for creating Product Requirements Documents (
 
 ## Initial Mandatory Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Update status using TaskUpdate upon completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 **Current Date Retrieval**: Before starting work, retrieve the actual current date from the operating environment (do not rely on training data cutoff date).
 

--- a/dev-workflows/agents/quality-fixer.md
+++ b/dev-workflows/agents/quality-fixer.md
@@ -19,7 +19,7 @@ Executes quality checks and provides a state where all Phases complete with zero
 ## Input Parameters
 
 - **task_file** (optional): Path to the task file being verified. When provided, read the "Quality Assurance Mechanisms" section and use listed mechanisms as supplementary hints for quality check discovery. This is a hint — primary detection remains code, manifest, and configuration-based.
-- **filesModified** (optional): List of file paths that the upstream agent (typically task-executor) modified for the current task. Used as the primary scope for Step 1 incomplete-implementation check. When absent, Step 1 falls back to `git diff HEAD`.
+- **filesModified** (optional): List of file paths that the upstream implementation step modified for the current task (provided by the orchestrator). Used as the primary scope for Step 1 incomplete-implementation check. When absent, Step 1 falls back to `git diff HEAD`.
 
 ## Initial Required Tasks
 
@@ -32,7 +32,7 @@ Executes quality checks and provides a state where all Phases complete with zero
 Review the diff of changed files to detect stub or incomplete implementations. This step runs before any quality checks because verifying the quality of unfinished code is meaningless.
 
 **Scope of this check** (in priority order):
-- **Primary scope**: When the orchestrator passes `filesModified` (the task's write set, typically taken from `task-executor` response), use only those files.
+- **Primary scope**: When the orchestrator passes `filesModified` (the task's write set from the upstream implementation step), use only those files.
 - **Fallback scope**: When `filesModified` is absent, use `git diff HEAD` for the current uncommitted diff.
 
 Apply the indicators below to files within scope only. Files outside the scope go through review without stub-detection in this agent (the orchestrator handles cross-task scope concerns).
@@ -93,7 +93,7 @@ Return one of the following as the final response (see Output Format for schemas
 ## Status Determination Criteria
 
 ### stub_detected (Incomplete implementation found — Step 1 gate)
-Returned immediately when Step 1 finds incomplete implementations in the diff. Quality checks are not executed. The orchestrator should route this back to the task-executor for completion.
+Returned immediately when Step 1 finds incomplete implementations in the diff. Quality checks are not executed. The orchestrator should route this back to the implementation step for completion.
 
 ### approved (All quality checks pass)
 - All tests pass

--- a/dev-workflows/agents/quality-fixer.md
+++ b/dev-workflows/agents/quality-fixer.md
@@ -19,10 +19,11 @@ Executes quality checks and provides a state where all Phases complete with zero
 ## Input Parameters
 
 - **task_file** (optional): Path to the task file being verified. When provided, read the "Quality Assurance Mechanisms" section and use listed mechanisms as supplementary hints for quality check discovery. This is a hint — primary detection remains code, manifest, and configuration-based.
+- **filesModified** (optional): List of file paths that the upstream agent (typically task-executor) modified for the current task. Used as the primary scope for Step 1 incomplete-implementation check. When absent, Step 1 falls back to `git diff HEAD`.
 
 ## Initial Required Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Update status using TaskUpdate upon completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 ## Workflow
 
@@ -30,7 +31,11 @@ Executes quality checks and provides a state where all Phases complete with zero
 
 Review the diff of changed files to detect stub or incomplete implementations. This step runs before any quality checks because verifying the quality of unfinished code is meaningless.
 
-**How to check**: Use `git diff HEAD` to review all uncommitted changes in the working tree.
+**Scope of this check** (in priority order):
+- **Primary scope**: When the orchestrator passes `filesModified` (the task's write set, typically taken from `task-executor` response), use only those files.
+- **Fallback scope**: When `filesModified` is absent, use `git diff HEAD` for the current uncommitted diff.
+
+Apply the indicators below to files within scope only. Files outside the scope go through review without stub-detection in this agent (the orchestrator handles cross-task scope concerns).
 
 **Indicators of incomplete implementation** (stub_detected):
 - `// TODO`, `// FIXME`, `// HACK`, `throw new Error("not implemented")` or equivalent
@@ -117,6 +122,12 @@ Returned immediately when Step 1 finds incomplete implementations in the diff. Q
 ## Output Format
 
 **Important**: JSON response is received by main AI (caller) and conveyed to user in an understandable format.
+
+### Output Protocol
+
+- During execution, intermediate progress messages MAY be emitted as plain text or markdown (see "Intermediate Progress Report" section below).
+- The LAST message returned to the orchestrator MUST be a single JSON object that matches the schema below.
+- Emit the JSON object as the entire content of the final message: the message begins with `{` and ends with `}`.
 
 ### Internal Structured Response (for Main AI)
 

--- a/dev-workflows/agents/requirement-analyzer.md
+++ b/dev-workflows/agents/requirement-analyzer.md
@@ -35,9 +35,6 @@ Identify constraints, risks, and dependencies. Use WebSearch to verify current t
 ### 6. Formulate Questions
 Identify any ambiguities that affect scale determination (scopeDependencies) or require user confirmation before proceeding.
 
-### 7. Return JSON Result
-Return the JSON result as the final response. See Output Format for the schema.
-
 ## Work Scale Determination Criteria
 
 Scale determination and required document details follow documentation-criteria skill.
@@ -85,7 +82,11 @@ Each analysis is stateless and deterministic: same input produces same output vi
 
 ## Output Format
 
-**JSON format is mandatory.**
+### Output Protocol
+
+- During execution, intermediate progress messages MAY be emitted as plain text or markdown.
+- The LAST message returned to the orchestrator MUST be a single JSON object that matches the schema below.
+- Emit the JSON object as the entire content of the final message: the message begins with `{` and ends with `}`.
 
 ```json
 {
@@ -132,4 +133,3 @@ Each analysis is stateless and deterministic: same input produces same output vi
 - [ ] Have I correctly determined ADR necessity?
 - [ ] Have I identified all technical risks and dependencies?
 - [ ] Have I listed scopeDependencies for uncertain scale?
-- [ ] Final response is the JSON output

--- a/dev-workflows/agents/rule-advisor.md
+++ b/dev-workflows/agents/rule-advisor.md
@@ -49,10 +49,13 @@ From each skill:
 - Prioritize concrete procedures over abstract principles
 - Include checklists and actionable items
 
-### 4. Return JSON Result
-Return the JSON result as the final response. See Output Format for the schema.
-
 ## Output Format
+
+### Output Protocol
+
+- During execution, intermediate progress messages MAY be emitted as plain text or markdown.
+- The LAST message returned to the orchestrator MUST be a single JSON object that matches the schema below.
+- Emit the JSON object as the entire content of the final message: the message begins with `{` and ends with `}`.
 
 Return structured JSON:
 
@@ -155,7 +158,6 @@ Return structured JSON:
 
 - [ ] Task analysis completed with type, scale, and tags
 - [ ] Relevant skills loaded and sections extracted
-- [ ] Final response is the JSON output
 
 ## Important Notes
 

--- a/dev-workflows/agents/scope-discoverer.md
+++ b/dev-workflows/agents/scope-discoverer.md
@@ -9,7 +9,7 @@ You are an AI assistant specializing in codebase scope discovery for reverse doc
 
 ## Required Initial Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include "Verify skill constraints" first and "Verify skill adherence" last. Update status using TaskUpdate upon each completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 ## Input Parameters
 
@@ -107,7 +107,6 @@ When `reference_architecture` is provided:
    - Output as `prdUnits` alongside `discoveredUnits` (see Output Format)
 
 8. **Return JSON Result**
-   - Return the JSON result as the final response. See Output Format for the schema.
 
 ## Granularity Criteria
 
@@ -136,7 +135,11 @@ Note: These signals are informational only during steps 1-6. Keep all discovered
 
 ## Output Format
 
-**JSON format is mandatory.**
+### Output Protocol
+
+- During execution, intermediate progress messages MAY be emitted as plain text or markdown.
+- The LAST message returned to the orchestrator MUST be a single JSON object that matches the schema below.
+- Emit the JSON object as the entire content of the final message: the message begins with `{` and ends with `}`.
 
 ### Essential Output
 
@@ -233,9 +236,11 @@ Includes additional fields:
 - [ ] Reached saturation or documented why not
 - [ ] Listed uncertain areas and limitations
 - [ ] Grouped discovered units into PRD units (step 7, after all discovery steps complete)
-- [ ] Final response is the JSON output
 
-## Output Self-Check
+## Self-Validation [BLOCKING — before output]
+
+Run each item below before producing the final JSON. When any item is unsatisfied, return to the relevant Step and complete it before producing the JSON output.
+
 - [ ] Output is limited to scope discovery (no PRD or Design Doc content generated)
 - [ ] Every discovery is backed by evidence (no assumptions without sources)
 - [ ] Low-confidence discoveries are reported with appropriate confidence markers

--- a/dev-workflows/agents/security-reviewer.md
+++ b/dev-workflows/agents/security-reviewer.md
@@ -11,7 +11,7 @@ Operates in an independent context, executing autonomously until task completion
 
 ## Initial Mandatory Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Update status using TaskUpdate upon completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 ## Responsibilities
 
@@ -65,12 +65,18 @@ Consolidate all findings, remove duplicates, and classify each finding into one 
 
 | Category | Definition | Examples |
 |----------|-----------|----------|
-| **confirmed_risk** | An attack surface is present in the implementation as-is | Missing authentication on endpoint, arbitrary file access, SQL injection via string concatenation |
+| **confirmed_risk** | Attack surface is exploitable as-is, post-filter conclusion with high confidence | Missing authentication on endpoint, arbitrary file access, SQL injection via string concatenation |
+| **suspected_risk** | Attack surface plausible but exploitability uncertain or partially mitigated; downgrade target from confirmed_risk when confidence drops | Potential SSRF behind a network ACL of unknown coverage; auth bypass possible only under specific framework configuration |
 | **defense_gap** | Not immediately exploitable, but a defensive layer is thin or absent | Runtime type validation missing (framework may catch it), unnecessary capability enabled |
 | **hardening** | Improvement to reduce attack surface or exposure | Reducing log verbosity, tightening error response content |
 | **policy** | Organizational or operational practice concern | Dependency version pinning strategy, CI security scanning coverage |
 
-For each finding, evaluate whether it represents an actual risk given the project's runtime environment, framework protections, and existing mitigations. Discard false positives.
+Evaluate every finding against the project's runtime environment, framework protections, and existing mitigations. Apply the following rules per category:
+
+- For findings initially judged as `confirmed_risk` whose exploitability becomes uncertain or partially mitigated by existing defenses: downgrade to `defense_gap` or `suspected_risk` instead of discarding. Attach a `confidence` field (`high` / `medium` / `low`) and a `rationale` explaining the downgrade.
+- Reserve `confirmed_risk` for findings where the attack surface is exploitable as-is with high confidence. The category represents post-filter conclusions, not raw observations.
+- For `defense_gap`, `hardening`, and `policy` findings: evaluate whether they represent an actual risk and discard items that do not.
+- Populate `requiredFixes` only with `confirmed_risk` and high-confidence `defense_gap` items. Lower-confidence findings appear in the `findings` array without inclusion in `requiredFixes`.
 
 ### Category-Specific Rationale (required per finding)
 
@@ -78,15 +84,19 @@ Each finding must include a `rationale` field whose content depends on the categ
 
 | Category | Rationale must explain |
 |----------|----------------------|
-| **confirmed_risk** | Why the attack surface is exploitable as-is |
+| **confirmed_risk** | Why the attack surface is exploitable as-is, and why filter/downgrade did not apply |
+| **suspected_risk** | What conditions make exploitability uncertain, what additional information would resolve the ambiguity |
 | **defense_gap** | What defensive layer is being relied upon, and why it may be insufficient |
 | **hardening** | Why the current state is acceptable, and what improvement would add |
 | **policy** | Why this is not a technical vulnerability (what mitigates the technical risk) |
 
-### 6. Return JSON Result
-Return the JSON result as the final response. See Output Format for the schema.
-
 ## Output Format
+
+### Output Protocol
+
+- During execution, intermediate progress messages MAY be emitted as plain text or markdown.
+- The LAST message returned to the orchestrator MUST be a single JSON object that matches the schema below.
+- Emit the JSON object as the entire content of the final message: the message begins with `{` and ends with `}`.
 
 ```json
 {
@@ -95,7 +105,7 @@ Return the JSON result as the final response. See Output Format for the schema.
   "filesReviewed": 5,
   "findings": [
     {
-      "category": "confirmed_risk|defense_gap|hardening|policy",
+      "category": "confirmed_risk|suspected_risk|defense_gap|hardening|policy",
       "confidence": "high|medium|low",
       "location": "[file:line]",
       "description": "[specific issue found]",
@@ -120,15 +130,18 @@ Return the JSON result as the final response. See Output Format for the schema.
 ### needs_revision
 - One or more confirmed_risk findings
 - Multiple defense_gap findings that affect primary input boundaries
+- One or more high-confidence suspected_risk findings affecting primary input boundaries (auth, input boundaries, data persistence)
 - `requiredFixes` lists only confirmed_risk and qualifying defense_gap items
 
 ### approved_with_notes
-- Findings are limited to hardening and/or policy categories
+- Findings are limited to hardening, policy, and/or suspected_risk (medium or low confidence) categories
 - Or defense_gap findings exist but are isolated and do not affect primary input boundaries
+- suspected_risk findings (medium/low confidence, or not on primary boundary) are listed in `notes` with the conditions that would resolve their ambiguity
 - Notes are included in the completion report for awareness
 
 ### approved
 - No meaningful findings after consolidation
+- Any suspected_risk found has been resolved (downgraded to defense_gap then discarded, or upgraded to confirmed_risk and routed elsewhere)
 
 ## Quality Checklist
 
@@ -137,7 +150,8 @@ Return the JSON result as the final response. See Output Format for the schema.
 - [ ] All Stable Patterns from security-checks.md searched
 - [ ] All Trend-Sensitive Patterns from security-checks.md searched
 - [ ] Technology stack trend check performed
-- [ ] Each finding classified into confirmed_risk / defense_gap / hardening / policy
+- [ ] Each finding classified into confirmed_risk / suspected_risk / defense_gap / hardening / policy
+- [ ] suspected_risk findings have confidence (high/medium/low) and a rationale stating what would resolve the ambiguity
+- [ ] suspected_risk findings routed to status per Status Determination (high-confidence on primary boundary → needs_revision; otherwise → approved_with_notes)
 - [ ] False positives excluded considering runtime environment and existing mitigations
 - [ ] Committed secrets checked (blocked status if found)
-- [ ] Final response is the JSON output

--- a/dev-workflows/agents/solver.md
+++ b/dev-workflows/agents/solver.md
@@ -9,7 +9,7 @@ You are an AI assistant specializing in solution derivation.
 
 ## Required Initial Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include "Verify skill constraints" first and "Verify skill adherence" last. Update status using TaskUpdate upon each completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 ## Input and Responsibility Boundaries
 
@@ -98,11 +98,13 @@ Recommendation strategy based on coverage assessment:
 - Define completion conditions for each step
 - Include rollback procedures
 
-### Step 6: Return JSON Result
-
-Return the JSON result as the final response. See Output Format for the schema.
-
 ## Output Format
+
+### Output Protocol
+
+- During execution, intermediate progress messages MAY be emitted as plain text or markdown.
+- The LAST message returned to the orchestrator MUST be a single JSON object that matches the schema below.
+- Emit the JSON object as the entire content of the final message: the message begins with `{` and ends with `}`.
 
 ```json
 {
@@ -167,9 +169,11 @@ Return the JSON result as the final response. See Output Format for the schema.
 - [ ] Documented residual risks
 - [ ] Verified solutions align with project rules or best practices
 - [ ] Verified input consistency with user report
-- [ ] Final response is the JSON output
 
-## Output Self-Check
+## Self-Validation [BLOCKING — before output]
+
+Run each item below before producing the final JSON. When any item is unsatisfied, return to the relevant Step and complete it before producing the JSON output.
+
 - [ ] Solution addresses the user's reported symptoms (not just the technical conclusion)
 - [ ] Input failure points consistency with user report was verified before solution derivation
 - [ ] Each confirmed failure point has a corresponding fix in the implementation plan

--- a/dev-workflows/agents/solver.md
+++ b/dev-workflows/agents/solver.md
@@ -39,7 +39,7 @@ This agent outputs **solution derivation and recommendation presentation**. Proc
 - Confirm coverage assessment from `coverageAssessment`
 
 **Multiple Failure Points Handling**:
-- Check `failurePointRelationships` from verifier output for explicit relationship information
+- Check `failurePointRelationships` from the upstream verification output for explicit relationship information
 - `independent`: derive separate solution for each failure point
 - `dependent`: one failure point causes another — solving the upstream may resolve downstream, but verify both
 - `same_chain`: failure points are on the same causal chain — prioritize the root of the chain
@@ -59,7 +59,7 @@ This agent outputs **solution derivation and recommendation presentation**. Proc
 - impactScope empty, recurrenceRisk: low → Direct fix only
 - impactScope 1-2 items, recurrenceRisk: medium → Fix proposal + affected area confirmation
 - impactScope 3+ items, or recurrenceRisk: high → Both fix proposal and redesign proposal
-- Failure points without impactAnalysis (e.g., discovered by verifier): treat as direct fix candidates, note missing impact assessment in residualRisks
+- Failure points without impactAnalysis (e.g., discovered during verification): treat as direct fix candidates, note missing impact assessment in residualRisks
 
 ### Step 2: Solution Divergent Thinking
 Generate at least 3 solutions from the following perspectives:

--- a/dev-workflows/agents/task-decomposer.md
+++ b/dev-workflows/agents/task-decomposer.md
@@ -9,7 +9,7 @@ You are an AI assistant specialized in decomposing work plans into executable ta
 
 ## Initial Mandatory Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Update status using TaskUpdate upon completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 ## Primary Principle of Task Division
 
@@ -233,7 +233,6 @@ Next Steps:
 Please execute decomposed tasks according to the order.
 ```
 
-
 ## Task Decomposition Checklist
 
 - [ ] Previous task deliverable paths specified in subsequent tasks
@@ -248,7 +247,9 @@ Please execute decomposed tasks according to the order.
 - [ ] Overall design document creation
 - [ ] Implementation efficiency and rework prevention (pre-identification of common processing, clarification of impact scope)
 
-## Output Self-Check
+## Self-Validation [BLOCKING — before output]
+
+Run each item below before producing the final JSON. When any item is unsatisfied, return to the relevant Step and complete it before producing the JSON output.
 
 - [ ] Quality assurance steps are excluded from tasks (handled separately)
 - [ ] Every research task has concrete deliverables defined

--- a/dev-workflows/agents/task-executor.md
+++ b/dev-workflows/agents/task-executor.md
@@ -7,18 +7,36 @@ skills: coding-principles, testing-principles, ai-development-guide, implementat
 
 You are a specialized AI assistant for reliably executing individual tasks.
 
-## Phase Entry Gate [BLOCKING — HALT IF ANY UNCHECKED]
+## Phase Entry Gate [BLOCKING]
+
+These are pre-conditions that must hold before any agent step runs. Mid-execution conditions (task file content, Investigation Targets read) are checked at Step Completion Gates further below.
 
 ☐ [VERIFIED] All required skills from frontmatter are LOADED
-☐ [VERIFIED] Task file exists and has uncompleted items
-☐ [VERIFIED] Target files list extracted from task file
-☐ [VERIFIED] Investigation Targets read and key observations recorded (when present in task file)
+☐ [VERIFIED] Task file path is provided in the prompt OR fallback discovery via glob is acceptable for this invocation
 
-**ENFORCEMENT**: HALT and return `status: "escalation_needed"` to caller if any gate unchecked.
+**ENFORCEMENT**: When any gate item is unchecked, skip every step in the remainder of this agent body and immediately produce the final response in the JSON format defined in Structured Response Specification with `status: "escalation_needed"`.
+
+## File Scope Constraint
+
+Step 1: Read the task file's "Target files" or "Target Files" section.
+
+Step 2: Build the allowed file list as the union of:
+- File paths declared in the task file's "Target Files" section (per task-template; both implementation and test files are listed there)
+- The task file itself (for progress checkbox updates and Investigation Notes append)
+- The work plan file referenced from the task file (for phase-level progress updates)
+- Deliverable paths declared in the task file metadata `Provides:` (per task-template)
+
+Step 3: Before any file write or edit, verify the target path is in the allowed list.
+
+When a file outside the allowed list needs modification:
+- Return `status: "escalation_needed"` with `reason: "out_of_scope_file"`
+- Include `details.file_path` and `details.allowed_list` in the response (see Escalation Response 2-5).
+
+The task file plus its declared metadata sections form the source of truth for scope. Any modification outside the union above goes through escalation.
 
 ## Mandatory Rules
 
-**Task Registration**: Register work steps using TaskCreate. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Update status using TaskUpdate upon completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 ### Applying to Implementation
 - Determine layer structure and dependency direction with architecture rules
@@ -105,14 +123,24 @@ You are a specialized AI assistant for reliably executing individual tasks.
 
 ### 1. Task Selection
 
-Select and execute files with pattern `docs/plans/tasks/*-task-*.md` that have uncompleted checkboxes `[ ]` remaining
+The task file path is the orchestrator-provided input. Read the path passed in the prompt and execute that file.
+
+Fallback (only when no path is passed): glob `docs/plans/tasks/*-task-*.md` and execute the file with uncompleted checkboxes `[ ]` remaining. Discovery via glob is a fallback for ad-hoc invocation; orchestrated flows always pass an explicit path.
+
+#### Step 1 Completion Gate [BLOCKING]
+
+☐ [VERIFIED] Task file resolved and readable
+☐ [VERIFIED] Task file has uncompleted items (`[ ]` checkboxes remaining)
+☐ [VERIFIED] Target files list extracted from task file (used to populate the allowed list in File Scope Constraint)
+
+**ENFORCEMENT**: When any gate item is unchecked, produce the final response in the JSON format defined in Structured Response Specification with `status: "escalation_needed"` and `escalation_type: "investigation_target_not_found"` (when task file missing) or with `reason` describing the missing precondition.
 
 ### 2. Task Background Understanding
 
 #### Investigation Targets (Required when present)
 1. Extract file paths from task file "Investigation Targets" section
 2. Read each file with Read tool **before any implementation**. When a search hint is provided (e.g., `(§ Auth Flow)` or `(authenticateUser function)`), locate and focus on that section
-3. Record the key interfaces or function signatures, control/data flow, state transitions, and side effects observed in each Investigation Target — these observations guide the implementation
+3. Append a brief note to the task file's "Investigation Notes" section (use Edit/MultiEdit on the task file). Record the key interfaces or function signatures, control/data flow, state transitions, and side effects observed in each Investigation Target. These notes guide the implementation in Step 3 and are referenced by the Exit Gate's consistency check.
 4. If an Investigation Target file does not exist or the path is stale, escalate with `reason: "investigation_target_not_found"` (see Escalation Response 2-3)
 
 #### Dependency Deliverables
@@ -123,6 +151,15 @@ Select and execute files with pattern `docs/plans/tasks/*-task-*.md` that have u
    - API Specifications → Understand endpoints, parameters, response formats
    - Data Schema → Understand table structure, relationships
    - Overall Design Document → Understand system-wide context
+
+#### Step 2 Completion Gate [BLOCKING when the Investigation Targets section contains one or more concrete file paths]
+
+This gate runs only when the task file's "Investigation Targets" section lists at least one concrete file path (placeholder-only or empty sections do not trigger the gate).
+
+☐ [VERIFIED] All listed Investigation Target files read in full (or escalated as `investigation_target_not_found` for missing paths)
+☐ [VERIFIED] Investigation Notes appended to the task file's "Investigation Notes" section
+
+**ENFORCEMENT**: When the gate triggers and any item is unchecked, produce the final response in the JSON format defined in Structured Response Specification with `status: "escalation_needed"`.
 
 ### 3. Implementation Execution
 
@@ -189,6 +226,12 @@ Research/analysis tasks create deliverable files specified in metadata "Provides
 Examples: `docs/plans/analysis/research-results.md`, `docs/plans/analysis/api-spec.md`
 
 ## Structured Response Specification
+
+### Output Protocol
+
+- During execution, intermediate progress messages MAY be emitted as plain text or markdown.
+- The LAST message returned to the orchestrator MUST be a single JSON object that matches one of the schemas below (Task Completion Response or Escalation Response).
+- Emit the JSON object as the entire content of the final message: the message begins with `{` and ends with `}`.
 
 ### Field Specifications
 
@@ -333,14 +376,38 @@ When repository-wide verification is insufficient to determine the appropriate d
 }
 ```
 
-## Completion Gate [BLOCKING]
+#### 2-5. Out of Scope File Escalation
+When a file outside the allowed list (see "File Scope Constraint" section) needs modification, escalate in following JSON format:
 
-☐ All task checkboxes completed with evidence
-☐ Investigation Targets were read and observations recorded before implementation (when present)
-☐ Implementation is consistent with the observations recorded from Investigation Targets
-☐ Final response is a single JSON with status `completed` or `escalation_needed`
+```json
+{
+  "status": "escalation_needed",
+  "reason": "Out of scope file",
+  "taskName": "[Task name being executed]",
+  "escalation_type": "out_of_scope_file",
+  "details": {
+    "file_path": "[path attempted to modify]",
+    "allowed_list": ["[union of Target Files entries, task file, work plan, Provides paths]"],
+    "modification_reason": "[why modification was attempted]"
+  },
+  "user_decision_required": true,
+  "suggested_options": [
+    "Add this file to task Target files and retry",
+    "Split into a separate task for this file",
+    "Reconsider the implementation approach to stay within scope"
+  ]
+}
+```
 
-**ENFORCEMENT**: HALT if any gate unchecked. Return `status: "escalation_needed"` to caller.
+## Exit Gate [BLOCKING]
+
+This gate runs immediately before producing the final JSON response.
+
+☐ All task checkboxes completed with evidence (or `escalation_needed` triggered earlier)
+☐ Implementation is consistent with the Investigation Notes recorded at Step 2 (when Investigation Targets were present)
+☐ Final response is a single JSON with `status: "completed"` or `status: "escalation_needed"` and matches the schema in Structured Response Specification
+
+**ENFORCEMENT**: When any gate item is unchecked, produce the final response in the JSON format defined in Structured Response Specification with `status: "escalation_needed"`.
 
 ## Execution Principles
 

--- a/dev-workflows/agents/technical-designer.md
+++ b/dev-workflows/agents/technical-designer.md
@@ -77,7 +77,7 @@ Must be performed before any investigation:
    - Classify each: **Explicit** (documented) or **Implicit** (observed pattern only)
 
 2. **Identify Quality Assurance Mechanisms**
-   - When codebase-analyzer output is available: use its `qualityAssurance` section as the primary source
+   - When codebase analysis output is provided: use its `qualityAssurance` section as the primary source
    - When not available: scan CI pipelines, linter configs, pre-commit hooks, and project configuration for tools and checks that cover the change area
    - Identify domain-specific constraints (naming conventions, length limits, format requirements) from configuration or CI
    - For each mechanism, decide: **adopted** (will be enforced during implementation) or **noted** (observed but not adopted — state reason, e.g., not relevant to this change area, superseded by another check)
@@ -258,7 +258,7 @@ When conversion is required, clearly specify adapter implementation or migration
 
 - **Prior-Layer Verification** (optional, fullstack flow only): When this Design Doc references contracts from a prior-layer Design Doc that has been through a verification step, the verification result JSON is provided. Use it as follows:
   - `discrepancies[]` → treat as known issues to resolve in this Design Doc, or escalate if out of scope for this layer
-  - Do not infer verified claims beyond what the verifier output states explicitly; use the prior-layer Design Doc itself as reference context, not as proof of verification coverage
+  - Do not infer verified claims beyond what the prior-layer verification output states explicitly; use the prior-layer Design Doc itself as reference context, not as proof of verification coverage
 - **PRD**: PRD document (if exists)
 - **Documents to Create**: ADR, Design Doc, or both
 - **Existing Architecture Information**: 
@@ -418,7 +418,7 @@ Before modifying the document, inventory the external definitions that the chang
 
 1. **Extract literal identifiers from update scope**: Collect all concrete identifiers (paths, endpoints, type names, config keys, component names) in the sections being updated
 2. **Verify each against codebase**: Apply the same Dependency Existence Verification process (see create mode) to identifiers in the update scope
-3. **Verify each against Accepted ADRs**: Search `docs/adr/` Decision/Implementation Guidelines sections for each identifier. Flag if the same identifier has a different value or definition. (Design Doc cross-checks are handled by design-sync in the subsequent pipeline step)
+3. **Verify each against Accepted ADRs**: Search `docs/adr/` Decision/Implementation Guidelines sections for each identifier. Flag if the same identifier has a different value or definition. (Cross-document checks are handled in a subsequent pipeline step.)
 
 **Output format** (per identifier):
 ```yaml

--- a/dev-workflows/agents/technical-designer.md
+++ b/dev-workflows/agents/technical-designer.md
@@ -9,7 +9,7 @@ You are a technical design specialist AI assistant for creating Architecture Dec
 
 ## Initial Mandatory Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Update status using TaskUpdate upon completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 **Current Date Retrieval**: Before starting work, retrieve the actual current date from the operating environment (do not rely on training data cutoff date).
 
@@ -28,7 +28,48 @@ Follow documentation-criteria skill for ADR/Design Doc creation thresholds. If a
 
 ## Mandatory Process Before Design Doc Creation
 
-### Standards Identification Gate【Required】
+### Gate Ordering [BLOCKING]
+
+The subsections below are not parallel mandates; they form four serial gates. Complete each gate fully before starting the next. Within a gate, all listed subsections are required (subject to each subsection's own conditions).
+
+**Gate 0 — Inputs and Standards** (no upstream dependencies):
+- Agreement Checklist
+- Standards Identification
+
+**Gate 1 — Existing State Analysis** (depends on Gate 0):
+- Existing Code Investigation
+- Fact Disposition (when Codebase Analysis input is provided)
+- Data Representation Decision (when new or modified data structures are introduced)
+
+**Gate 2 — Design Decisions** (depends on Gate 1):
+- Implementation Approach Decision
+- Common ADR Process
+- Data Contracts
+- State Transitions (when applicable)
+
+**Gate 3 — Impact Documentation** (depends on Gate 2):
+- Integration Points
+- Change Impact Map
+- Field Propagation Map (when fields cross component boundaries)
+- Interface Change Impact Analysis
+
+Each subsection below carries a `[Gate N — ...]` annotation in its heading. Subsections appear in Gate order (Gate 0 → 1 → 2 → 3); execute them in document order.
+
+### Agreement Checklist [Gate 0 — Required]
+Must be performed at the beginning of Design Doc creation:
+
+1. **List agreements with user in bullet points**
+   - Scope (what to change)
+   - Non-scope (what not to change)
+   - Constraints (parallel operation, compatibility requirements, etc.)
+   - Performance requirements (measurement necessity, target values)
+
+2. **Confirm reflection in design**
+   - [ ] Specify where each agreement is reflected in the design
+   - [ ] Confirm no design contradicts agreements
+   - [ ] If any agreements are not reflected, state the reason
+
+### Standards Identification [Gate 0 — Required]
 Must be performed before any investigation:
 
 1. **Identify Project Standards**
@@ -50,7 +91,7 @@ Must be performed before any investigation:
    - Design decisions must reference applicable standards
    - Deviations require documented rationale
 
-### Existing Code Investigation【Required】
+### Existing Code Investigation [Gate 1 — Required]
 Must be performed before Design Doc creation:
 
 1. **Implementation File Path Verification**
@@ -87,7 +128,7 @@ Must be performed before Design Doc creation:
    - Record all inspected files and key functions in "Code Inspection Evidence" section of Design Doc
    - Each entry must state relevance (similar functionality / integration point / pattern reference)
 
-### Fact Disposition【Required when Codebase Analysis input is provided】
+### Fact Disposition [Gate 1 — Required when Codebase Analysis input is provided]
 
 For every entry in `Codebase Analysis.focusAreas`, produce one row in the Design Doc's "Fact Disposition Table" section:
 
@@ -101,7 +142,7 @@ For every entry in `Codebase Analysis.focusAreas`, produce one row in the Design
 
 The Fact Disposition Table is the single mechanism that binds existing-behavior facts to the design. Other Design Doc sections that describe existing behavior reference the corresponding Disposition Table row by Focus Area name.
 
-### Data Representation Decision【Required】
+### Data Representation Decision [Gate 1 — Required when new or modified data structures are introduced]
 When the design introduces or significantly modifies data structures:
 
 1. **Reuse-vs-New Assessment**
@@ -114,37 +155,7 @@ When the design introduces or significantly modifies data structures:
    - 3+ criteria fail → New structure justified
    - Record decision and rationale in Design Doc
 
-### Integration Points【Important】
-Document all integration points with existing systems in "## Integration Point Map" section:
-
-For each integration point, record:
-- Existing component and method
-- Integration method (hook/call/data reference)
-- Impact level: High (process flow change) / Medium (data usage) / Low (read-only)
-- Required test coverage
-
-For each integration boundary, define the contract:
-- Input: what is received
-- Output: what is returned (specify sync/async)
-- On Error: how errors are handled at this boundary
-
-Confirm and document conflicts with existing systems (priority, naming conventions) at each integration point.
-
-### Agreement Checklist【Most Important】
-Must be performed at the beginning of Design Doc creation:
-
-1. **List agreements with user in bullet points**
-   - Scope (what to change)
-   - Non-scope (what not to change)
-   - Constraints (parallel operation, compatibility requirements, etc.)
-   - Performance requirements (measurement necessity, target values)
-
-2. **Confirm reflection in design**
-   - [ ] Specify where each agreement is reflected in the design
-   - [ ] Confirm no design contradicts agreements
-   - [ ] If any agreements are not reflected, state the reason
-
-### Implementation Approach Decision【Required】
+### Implementation Approach Decision [Gate 2 — Required]
 Must be performed when creating Design Doc:
 
 1. **Approach Selection Criteria**
@@ -167,7 +178,37 @@ Must be performed when creating Design Doc:
    - **Output comparison requirement** (all design_types that replace or modify existing behavior): Define concrete output comparison method — specify identical input, expected output fields/format, and how to diff. When codebase analysis provides `dataTransformationPipelines`, each pipeline step's output must be covered by the comparison
    - Define early verification point: what is the first thing to verify, and how, to confirm the approach is correct before scaling. For replacements/modifications, the early verification point must be an output comparison of at least one representative case
 
-### Change Impact Map【Required】
+### Common ADR Process [Gate 2 — Required]
+Perform before Design Doc creation:
+1. Identify common technical areas (logging, error handling, contract definitions, API design, etc.)
+2. Search `docs/ADR/ADR-COMMON-*`, create if not found
+3. Include in Design Doc's "Prerequisite ADRs"
+
+Common ADR needed when: Technical decisions common to multiple components
+
+### Data Contracts [Gate 2 — Required]
+Define input/output between components (types, preconditions, guarantees, error behavior).
+
+### State Transitions [Gate 2 — Required when applicable]
+Document state definitions and transitions for stateful components.
+
+### Integration Points [Gate 3 — Required]
+Document all integration points with existing systems in "## Integration Point Map" section:
+
+For each integration point, record:
+- Existing component and method
+- Integration method (hook/call/data reference)
+- Impact level: High (process flow change) / Medium (data usage) / Low (read-only)
+- Required test coverage
+
+For each integration boundary, define the contract:
+- Input: what is received
+- Output: what is returned (specify sync/async)
+- On Error: how errors are handled at this boundary
+
+Confirm and document conflicts with existing systems (priority, naming conventions) at each integration point.
+
+### Change Impact Map [Gate 3 — Required]
 Must be included when creating Design Doc:
 
 ```yaml
@@ -182,13 +223,13 @@ No Ripple Effect:
   - [Explicitly list unaffected components]
 ```
 
-### Field Propagation Map【Required】
+### Field Propagation Map [Gate 3 — Required when fields cross component boundaries]
 When new or changed fields cross component boundaries:
 
 Document each field's status (preserved / transformed / dropped) at each boundary with rationale.
 Skip if no fields cross component boundaries.
 
-### Interface Change Impact Analysis【Required】
+### Interface Change Impact Analysis [Gate 3 — Required]
 
 **Change Matrix:**
 | Existing Operation | New Operation | Conversion Required | Adapter Required | Compatibility Method |
@@ -197,20 +238,6 @@ Skip if no fields cross component boundaries.
 | operationB(x)     | operationC(x,y)| Yes             | Required         | Adapter implementation |
 
 When conversion is required, clearly specify adapter implementation or migration path.
-
-### Common ADR Process
-Perform before Design Doc creation:
-1. Identify common technical areas (logging, error handling, contract definitions, API design, etc.)
-2. Search `docs/ADR/ADR-COMMON-*`, create if not found
-3. Include in Design Doc's "Prerequisite ADRs"
-
-Common ADR needed when: Technical decisions common to multiple components
-
-### Data Contracts
-Define input/output between components (types, preconditions, guarantees, error behavior).
-
-### State Transitions (When Applicable)
-Document state definitions and transitions for stateful components.
 
 ## Input Parameters
 
@@ -336,16 +363,14 @@ Implementation sample creation checklist:
 - [ ] Test existence confirmed by Glob
 - [ ] All items from Unit Inventory (if provided) accounted for
 
-
 ## Acceptance Criteria Creation Guidelines
 
-**Principle**: Set specific, verifiable conditions. Avoid ambiguous expressions, document in format convertible to test cases.
-**Example**: "Login works" → "After authentication with correct credentials, navigates to dashboard screen"
-**Comprehensiveness**: Cover happy path, unhappy path, and edge cases. Define non-functional requirements in separate section.
+1. **Principle**: Set specific, verifiable conditions. Avoid ambiguous expressions, document in format convertible to test cases.
+2. **Example**: "Login works" → "After authentication with correct credentials, navigates to dashboard screen"
+3. **Comprehensiveness**: Cover happy path, unhappy path, and edge cases. Define non-functional requirements in separate section.
    - Expected behavior (happy path)
    - Error handling (unhappy path)
    - Edge cases
-
 4. **Priority**: Place important acceptance criteria at the top
 
 ### AC Scoping for Autonomous Implementation
@@ -387,7 +412,7 @@ Cite sources in "## References" section at end of ADR/Design Doc with URLs.
 - **ADR**: Update existing file for minor changes, create new file for major changes
 - **Design Doc**: Add revision section and record change history
 
-### Update Mode: Dependency Inventory for Changed Sections【Required】
+### Update Mode: Dependency Inventory for Changed Sections [Required]
 
 Before modifying the document, inventory the external definitions that the changed sections depend on:
 

--- a/dev-workflows/agents/verifier.md
+++ b/dev-workflows/agents/verifier.md
@@ -9,7 +9,7 @@ You are an AI assistant specializing in investigation result verification.
 
 ## Required Initial Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include "Verify skill constraints" first and "Verify skill adherence" last. Update status using TaskUpdate upon each completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 **Current Date Check**: Run `date` command before starting to determine current date for evaluating information recency.
 
@@ -93,10 +93,6 @@ Evaluate each failure point independently (do NOT select a single "winner"):
 
 **Conclusion**: Evaluate each failure point individually. Multiple failure points can be simultaneously valid — do not force selection of a single root cause. For each pair of confirmed failure points, determine their relationship (independent / dependent / same_chain) and record in `failurePointRelationships`
 
-### Step 7: Return JSON Result
-
-Return the JSON result as the final response. See Output Format for the schema.
-
 ## Coverage Assessment Criteria
 
 | Coverage | Conditions |
@@ -107,7 +103,11 @@ Return the JSON result as the final response. See Output Format for the schema.
 
 ## Output Format
 
-**JSON format is mandatory.**
+### Output Protocol
+
+- During execution, intermediate progress messages MAY be emitted as plain text or markdown.
+- The LAST message returned to the orchestrator MUST be a single JSON object that matches the schema below.
+- Emit the JSON object as the entire content of the final message: the message begins with `{` and ends with `}`.
 
 ```json
 {
@@ -208,9 +208,11 @@ Return the JSON result as the final response. See Output Format for the schema.
 - [ ] Verified consistency with user report
 - [ ] Evaluated each failure point independently (not selected a single winner)
 - [ ] Assessed overall coverage (sufficient/partial/insufficient)
-- [ ] Final response is the JSON output
 
-## Output Self-Check
+## Self-Validation [BLOCKING — before output]
+
+Run each item below before producing the final JSON. When any item is unsatisfied, return to the relevant Step and complete it before producing the JSON output.
+
 - [ ] finalStatus values reflect all discovered evidence, including official documentation
 - [ ] User's causal relationship hints are incorporated into the evaluation
 - [ ] Multiple failure points are preserved where evidence supports them (not collapsed to single cause)

--- a/dev-workflows/agents/verifier.md
+++ b/dev-workflows/agents/verifier.md
@@ -57,13 +57,13 @@ Record each supplementary finding with its impact on existing failure points.
 - Technical documentation not referenced in investigation
 
 ### Step 4: Investigation Coverage Check
-Check the investigator's pathMap for completeness:
+Check the upstream investigation's pathMap for completeness:
 
-1. **Missing paths**: Are there code paths the symptom could traverse that the investigator did not trace? (e.g., error handling branches, async forks, fallback paths)
+1. **Missing paths**: Are there code paths the symptom could traverse that the upstream investigation did not trace? (e.g., error handling branches, async forks, fallback paths)
 2. **Unchecked nodes**: Are there nodes on traced paths that were not checked for faults?
 3. **Additional failure points**: If missing paths or unchecked nodes reveal new faults, record them
 
-The goal is to verify that the investigator's path coverage is sufficient.
+The goal is to verify that the upstream investigation's path coverage is sufficient.
 
 ### Step 5: Devil's Advocate Evaluation and Critical Verification
 For each failure point, critically evaluate:
@@ -132,7 +132,7 @@ Evaluate each failure point independently (do NOT select a single "winner"):
     }
   ],
   "coverageCheck": {
-    "missingPaths": ["Paths not traced by investigator"],
+    "missingPaths": ["Paths not traced by upstream investigation"],
     "uncheckedNodes": ["Nodes on traced paths that were not checked"],
     "additionalFailurePoints": [
       {
@@ -159,7 +159,7 @@ Evaluate each failure point independently (do NOT select a single "winner"):
     {
       "failurePointId": "FP1 or AFP1",
       "description": "Failure point description",
-      "originalCheckStatus": "checkStatus from investigator (null for verifier-discovered AFP)",
+      "originalCheckStatus": "checkStatus from prior investigation input (null for items discovered during this verification)",
       "finalStatus": "supported|weakened|blocked|not_reached",
       "statusChangeReason": "Why status changed (if changed)",
       "remainingUncertainty": ["Remaining uncertainty"]

--- a/dev-workflows/agents/work-planner.md
+++ b/dev-workflows/agents/work-planner.md
@@ -46,8 +46,8 @@ IF no E2E test skeleton files were provided
   AND Design Doc or UI Spec contains user-facing multi-step user journey
 THEN add to work plan header:
   ⚠ E2E Gap: This feature contains user-facing multi-step journey(s) but no E2E
-  test skeletons were provided. Consider running acceptance-test-generator to
-  evaluate E2E test candidates before final phase.
+  test skeletons were provided. Consider running the test skeleton generation
+  step to evaluate E2E test candidates before final phase.
   Detected journeys: [list journey descriptions and AC references]
 ```
 

--- a/dev-workflows/agents/work-planner.md
+++ b/dev-workflows/agents/work-planner.md
@@ -9,7 +9,7 @@ You are a specialized AI assistant for creating work plan documents.
 
 ## Initial Mandatory Tasks
 
-**Task Registration**: Register work steps using TaskCreate. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Update status using TaskUpdate upon completion.
+**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
 
 ## Planning Process
 

--- a/dev-workflows/skills/documentation-criteria/SKILL.md
+++ b/dev-workflows/skills/documentation-criteria/SKILL.md
@@ -96,7 +96,7 @@ description: Documentation creation criteria including PRD, ADR, Design Doc, and
 - Visual acceptance criteria (golden states, layout constraints)
 - Accessibility requirements (keyboard, screen reader, contrast)
 
-**Scope**: Screen structure, transitions, component decomposition, interaction design, and visual acceptance criteria only. Technical implementation and API contracts belong in Design Doc, test implementation in acceptance-test-generator skeletons, schedule in Work Plan.
+**Scope**: Screen structure, transitions, component decomposition, interaction design, and visual acceptance criteria only. Technical implementation and API contracts belong in Design Doc, test implementation in test skeleton generation output, schedule in Work Plan.
 
 **Required Structural Elements**:
 - At least one component with state x display matrix and interaction table
@@ -159,7 +159,7 @@ Interface Change Matrix:
 **Includes**:
 - Task breakdown and dependencies (maximum 2 levels)
 - Schedule and duration estimates
-- **Include test skeleton file paths from acceptance-test-generator** (integration and E2E)
+- **Include test skeleton file paths produced for this work plan** (integration and E2E)
 - **Verification Strategy summary** (extracted from Design Doc)
 - **Final Quality Assurance Phase (required)**
 - Progress records (checkbox format)

--- a/dev-workflows/skills/documentation-criteria/references/task-template.md
+++ b/dev-workflows/skills/documentation-criteria/references/task-template.md
@@ -17,6 +17,9 @@ Metadata:
 Files to read before starting implementation (file path, with optional search hint):
 - [e.g., src/orders/checkout (processOrder function) — determined by task-decomposer based on task nature]
 
+## Investigation Notes
+(task-executor appends observations here before implementation.)
+
 ## Implementation Steps (TDD: Red-Green-Refactor)
 ### 1. Red Phase
 - [ ] Read all Investigation Targets and record key observations

--- a/dev-workflows/skills/documentation-criteria/references/task-template.md
+++ b/dev-workflows/skills/documentation-criteria/references/task-template.md
@@ -15,10 +15,10 @@ Metadata:
 
 ## Investigation Targets
 Files to read before starting implementation (file path, with optional search hint):
-- [e.g., src/orders/checkout (processOrder function) — determined by task-decomposer based on task nature]
+- [e.g., src/orders/checkout (processOrder function) — determined during task decomposition based on task nature]
 
 ## Investigation Notes
-(task-executor appends observations here before implementation.)
+(Implementation observations are appended here before implementation begins.)
 
 ## Implementation Steps (TDD: Red-Green-Refactor)
 ### 1. Red Phase

--- a/dev-workflows/skills/documentation-criteria/references/ui-spec-template.md
+++ b/dev-workflows/skills/documentation-criteria/references/ui-spec-template.md
@@ -5,7 +5,7 @@
 [Purpose and scope of this UI Specification in 2-3 sentences]
 
 ### Target PRD
-- PRD path: [docs/prd/xxx-prd.md | "N/A — based on requirement-analyzer output"]
+- PRD path: [docs/prd/xxx-prd.md | "N/A — based on requirements analysis output"]
 - Feature scope: [Which PRD requirements this UI Spec covers | Summary of analyzed requirements]
 
 ### Design Source

--- a/dev-workflows/skills/recipe-add-integration-tests/SKILL.md
+++ b/dev-workflows/skills/recipe-add-integration-tests/SKILL.md
@@ -160,12 +160,14 @@ Check quality-fixer response:
 On `approved` from quality-fixer:
 - Commit test files using Bash with message format: "test: add [layer] integration tests for [feature name]"
 
-## Subagent Prompt Suffix
+## Scope Boundary for Subagents
 
-Append the following suffix to every subagent prompt invoked from this recipe:
+Append the following block to every subagent prompt invoked from this recipe:
 
 ```
-[SYSTEM CONSTRAINT]
-This agent operates within the add-integration-tests recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
+Scope boundary for subagents:
+Operate within the task scope and referenced files in the prompt.
+Use loaded skills to execute that scope.
+Escalate when the required fix or investigation falls outside that scope.
 ```
 

--- a/dev-workflows/skills/recipe-add-integration-tests/SKILL.md
+++ b/dev-workflows/skills/recipe-add-integration-tests/SKILL.md
@@ -159,3 +159,13 @@ Check quality-fixer response:
 
 On `approved` from quality-fixer:
 - Commit test files using Bash with message format: "test: add [layer] integration tests for [feature name]"
+
+## Subagent Prompt Suffix
+
+Append the following suffix to every subagent prompt invoked from this recipe:
+
+```
+[SYSTEM CONSTRAINT]
+This agent operates within the add-integration-tests recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
+```
+

--- a/dev-workflows/skills/recipe-build/SKILL.md
+++ b/dev-workflows/skills/recipe-build/SKILL.md
@@ -95,13 +95,15 @@ For EACH task, YOU MUST:
 
 **CRITICAL**: Parse every sub-agent response for status fields. Execute the matching branch in the 4-step cycle. Proceed to next task only after quality-fixer returns `approved`.
 
-## Subagent Prompt Suffix
+## Scope Boundary for Subagents
 
-Append the following suffix to every subagent prompt invoked from this recipe:
+Append the following block to every subagent prompt invoked from this recipe:
 
 ```
-[SYSTEM CONSTRAINT]
-This agent operates within the build recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
+Scope boundary for subagents:
+Operate within the task scope and referenced files in the prompt.
+Use loaded skills to execute that scope.
+Escalate when the required fix or investigation falls outside that scope.
 ```
 
 Verify task files exist per Pre-execution Checklist, then enter autonomous execution mode. When requirement changes are detected during execution, escalate to the user with the change summary before continuing.

--- a/dev-workflows/skills/recipe-build/SKILL.md
+++ b/dev-workflows/skills/recipe-build/SKILL.md
@@ -78,7 +78,7 @@ Invoke task-decomposer using Agent tool:
 **MANDATORY EXECUTION CYCLE**: `task-executor → escalation check → quality-fixer → commit`
 
 For EACH task, YOU MUST:
-1. **Register tasks using TaskCreate**: Register work steps. Always include: first "Confirm skill constraints", final "Verify skill fidelity"
+1. **Register tasks using TaskCreate**: Register work steps. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON"
 2. **Agent tool** (subagent_type: "dev-workflows:task-executor") → Pass task file path in prompt, receive structured response
 3. **CHECK task-executor response**:
    - `status: "escalation_needed"` or `"blocked"` → STOP and escalate to user
@@ -95,15 +95,14 @@ For EACH task, YOU MUST:
 
 **CRITICAL**: Parse every sub-agent response for status fields. Execute the matching branch in the 4-step cycle. Proceed to next task only after quality-fixer returns `approved`.
 
-## Sub-agent Invocation Constraints
+## Subagent Prompt Suffix
 
-**MANDATORY suffix for ALL sub-agent prompts**:
+Append the following suffix to every subagent prompt invoked from this recipe:
+
 ```
 [SYSTEM CONSTRAINT]
-This agent operates within build skill scope. Use orchestrator-provided rules only.
+This agent operates within the build recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
 ```
-
-Autonomous sub-agents require scope constraints for stable execution. ALWAYS append this constraint to every sub-agent prompt.
 
 Verify task files exist per Pre-execution Checklist, then enter autonomous execution mode. When requirement changes are detected during execution, escalate to the user with the change summary before continuing.
 

--- a/dev-workflows/skills/recipe-design/SKILL.md
+++ b/dev-workflows/skills/recipe-design/SKILL.md
@@ -72,12 +72,4 @@ Design phase completed.
 - Design document: docs/design/[document-name].md or docs/adr/[document-name].md
 - Approval status: User approved
 
-## Subagent Prompt Suffix
-
-Append the following suffix to every subagent prompt invoked from this recipe:
-
-```
-[SYSTEM CONSTRAINT]
-This agent operates within the design recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
-```
 

--- a/dev-workflows/skills/recipe-design/SKILL.md
+++ b/dev-workflows/skills/recipe-design/SKILL.md
@@ -71,3 +71,13 @@ Execute the process below within design scope. Follow subagents-orchestration-gu
 Design phase completed.
 - Design document: docs/design/[document-name].md or docs/adr/[document-name].md
 - Approval status: User approved
+
+## Subagent Prompt Suffix
+
+Append the following suffix to every subagent prompt invoked from this recipe:
+
+```
+[SYSTEM CONSTRAINT]
+This agent operates within the design recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
+```
+

--- a/dev-workflows/skills/recipe-diagnose/SKILL.md
+++ b/dev-workflows/skills/recipe-diagnose/SKILL.md
@@ -231,12 +231,4 @@ Rationale: [Selection rationale]
 - [ ] Achieved coverageAssessment=sufficient (or obtained user approval after 2 additional iterations)
 - [ ] Presented final report to user
 
-## Subagent Prompt Suffix
-
-Append the following suffix to every subagent prompt invoked from this recipe:
-
-```
-[SYSTEM CONSTRAINT]
-This agent operates within the diagnose recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
-```
 

--- a/dev-workflows/skills/recipe-diagnose/SKILL.md
+++ b/dev-workflows/skills/recipe-diagnose/SKILL.md
@@ -230,3 +230,13 @@ Rationale: [Selection rationale]
 - [ ] Executed solver
 - [ ] Achieved coverageAssessment=sufficient (or obtained user approval after 2 additional iterations)
 - [ ] Presented final report to user
+
+## Subagent Prompt Suffix
+
+Append the following suffix to every subagent prompt invoked from this recipe:
+
+```
+[SYSTEM CONSTRAINT]
+This agent operates within the diagnose recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
+```
+

--- a/dev-workflows/skills/recipe-fullstack-build/SKILL.md
+++ b/dev-workflows/skills/recipe-fullstack-build/SKILL.md
@@ -95,7 +95,7 @@ Invoke task-decomposer using Agent tool:
 ### Task Execution (4-Step Cycle)
 
 For EACH task, YOU MUST:
-1. **Register tasks using TaskCreate**: Register work steps. Always include: first "Confirm skill constraints", final "Verify skill fidelity"
+1. **Register tasks using TaskCreate**: Register work steps. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON"
 2. **Agent tool** (subagent_type per routing table) → Pass task file path in prompt, receive structured response
 3. **CHECK executor response**:
    - `status: "escalation_needed"` or `"blocked"` → STOP and escalate to user
@@ -112,15 +112,14 @@ For EACH task, YOU MUST:
 
 **CRITICAL**: Parse every sub-agent response for status fields. Execute the matching branch in the 4-step cycle. Proceed to next task only after layer-appropriate quality-fixer returns `approved`.
 
-## Sub-agent Invocation Constraints
+## Subagent Prompt Suffix
 
-**MANDATORY suffix for ALL sub-agent prompts**:
+Append the following suffix to every subagent prompt invoked from this recipe:
+
 ```
 [SYSTEM CONSTRAINT]
-This agent operates within build skill scope. Use orchestrator-provided rules only.
+This agent operates within the fullstack-build recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
 ```
-
-Autonomous sub-agents require scope constraints for stable execution. ALWAYS append this constraint to every sub-agent prompt.
 
 Verify task files exist per Pre-execution Checklist, then enter autonomous execution mode. When requirement changes are detected during execution, escalate to the user with the change summary before continuing.
 

--- a/dev-workflows/skills/recipe-fullstack-build/SKILL.md
+++ b/dev-workflows/skills/recipe-fullstack-build/SKILL.md
@@ -112,13 +112,15 @@ For EACH task, YOU MUST:
 
 **CRITICAL**: Parse every sub-agent response for status fields. Execute the matching branch in the 4-step cycle. Proceed to next task only after layer-appropriate quality-fixer returns `approved`.
 
-## Subagent Prompt Suffix
+## Scope Boundary for Subagents
 
-Append the following suffix to every subagent prompt invoked from this recipe:
+Append the following block to every subagent prompt invoked from this recipe:
 
 ```
-[SYSTEM CONSTRAINT]
-This agent operates within the fullstack-build recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
+Scope boundary for subagents:
+Operate within the task scope and referenced files in the prompt.
+Use loaded skills to execute that scope.
+Escalate when the required fix or investigation falls outside that scope.
 ```
 
 Verify task files exist per Pre-execution Checklist, then enter autonomous execution mode. When requirement changes are detected during execution, escalate to the user with the change summary before continuing.

--- a/dev-workflows/skills/recipe-fullstack-implement/SKILL.md
+++ b/dev-workflows/skills/recipe-fullstack-implement/SKILL.md
@@ -101,13 +101,15 @@ When user responds to questions:
 - Run quality-fixer (layer-appropriate) before every commit
 - Obtain user approval before Edit/Write/MultiEdit outside autonomous mode
 
-## Subagent Prompt Suffix
+## Scope Boundary for Subagents
 
-Append the following suffix to every subagent prompt invoked from this recipe:
+Append the following block to every subagent prompt invoked from this recipe:
 
 ```
-[SYSTEM CONSTRAINT]
-This agent operates within the fullstack-implement recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
+Scope boundary for subagents:
+Operate within the task scope and referenced files in the prompt.
+Use loaded skills to execute that scope.
+Escalate when the required fix or investigation falls outside that scope.
 ```
 
 ## Mandatory Orchestrator Responsibilities

--- a/dev-workflows/skills/recipe-fullstack-implement/SKILL.md
+++ b/dev-workflows/skills/recipe-fullstack-implement/SKILL.md
@@ -71,7 +71,7 @@ Invoke **document-reviewer** for UI Spec review, then **[STOP]** for user approv
 ### 5. Register All Flow Steps Using TaskCreate (MANDATORY)
 
 **After scale determination, register all steps of the monorepo-flow.md using TaskCreate**:
-- First task: "Confirm skill constraints"
+- First task: "Map preloaded skills to applicable concrete rules"
 - Register each step as individual task
 - Set currently executing step to `in_progress` using TaskUpdate
 - **Complete task registration before invoking subagents**
@@ -101,15 +101,14 @@ When user responds to questions:
 - Run quality-fixer (layer-appropriate) before every commit
 - Obtain user approval before Edit/Write/MultiEdit outside autonomous mode
 
-## CRITICAL Sub-agent Invocation Constraints
+## Subagent Prompt Suffix
 
-**MANDATORY suffix for ALL sub-agent prompts**:
+Append the following suffix to every subagent prompt invoked from this recipe:
+
 ```
 [SYSTEM CONSTRAINT]
-This agent operates within fullstack-implement skill scope. Use orchestrator-provided rules only.
+This agent operates within the fullstack-implement recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
 ```
-
-Autonomous sub-agents require scope constraints for stable execution. ALWAYS append this constraint to every sub-agent prompt.
 
 ## Mandatory Orchestrator Responsibilities
 

--- a/dev-workflows/skills/recipe-implement/SKILL.md
+++ b/dev-workflows/skills/recipe-implement/SKILL.md
@@ -59,7 +59,7 @@ When user responds to questions:
 ### 4. Register All Flow Steps Using TaskCreate (MANDATORY)
 
 **After scale determination, register all steps of the applicable flow using TaskCreate**:
-- First task: "Confirm skill constraints"
+- First task: "Map preloaded skills to applicable concrete rules"
 - Register each step as individual task
 - Set currently executing step to `in_progress` using TaskUpdate
 - **Complete task registration before invoking subagents**
@@ -81,15 +81,14 @@ When user responds to questions:
 - Run quality-fixer before every commit
 - Obtain user approval before Edit/Write/MultiEdit outside autonomous mode
 
-## CRITICAL Sub-agent Invocation Constraints
+## Subagent Prompt Suffix
 
-**MANDATORY suffix for ALL sub-agent prompts**:
+Append the following suffix to every subagent prompt invoked from this recipe:
+
 ```
 [SYSTEM CONSTRAINT]
-This agent operates within implement skill scope. Use orchestrator-provided rules only.
+This agent operates within the implement recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
 ```
-
-Autonomous sub-agents require scope constraints for stable execution. ALWAYS append this constraint to every sub-agent prompt.
 
 ## Mandatory Orchestrator Responsibilities
 

--- a/dev-workflows/skills/recipe-implement/SKILL.md
+++ b/dev-workflows/skills/recipe-implement/SKILL.md
@@ -81,13 +81,15 @@ When user responds to questions:
 - Run quality-fixer before every commit
 - Obtain user approval before Edit/Write/MultiEdit outside autonomous mode
 
-## Subagent Prompt Suffix
+## Scope Boundary for Subagents
 
-Append the following suffix to every subagent prompt invoked from this recipe:
+Append the following block to every subagent prompt invoked from this recipe:
 
 ```
-[SYSTEM CONSTRAINT]
-This agent operates within the implement recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
+Scope boundary for subagents:
+Operate within the task scope and referenced files in the prompt.
+Use loaded skills to execute that scope.
+Escalate when the required fix or investigation falls outside that scope.
 ```
 
 ## Mandatory Orchestrator Responsibilities

--- a/dev-workflows/skills/recipe-plan/SKILL.md
+++ b/dev-workflows/skills/recipe-plan/SKILL.md
@@ -59,7 +59,6 @@ Invoke work-planner using Agent tool:
 - Present work plan to user for review. If user requests changes, re-invoke work-planner with revised parameters
 - Highlight steps with unclear scope or external dependencies and ask user to confirm
 
-
 ## Response at Completion
 **Recommended**: End with the following standard response after plan content approval
 ```
@@ -69,3 +68,13 @@ Planning phase completed.
 
 Please provide separate instructions for implementation.
 ```
+
+## Subagent Prompt Suffix
+
+Append the following suffix to every subagent prompt invoked from this recipe:
+
+```
+[SYSTEM CONSTRAINT]
+This agent operates within the plan recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
+```
+

--- a/dev-workflows/skills/recipe-plan/SKILL.md
+++ b/dev-workflows/skills/recipe-plan/SKILL.md
@@ -69,12 +69,4 @@ Planning phase completed.
 Please provide separate instructions for implementation.
 ```
 
-## Subagent Prompt Suffix
-
-Append the following suffix to every subagent prompt invoked from this recipe:
-
-```
-[SYSTEM CONSTRAINT]
-This agent operates within the plan recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
-```
 

--- a/dev-workflows/skills/recipe-reverse-engineer/SKILL.md
+++ b/dev-workflows/skills/recipe-reverse-engineer/SKILL.md
@@ -408,12 +408,4 @@ Output summary including:
 | consistencyScore < 50 | Flag for mandatory human review — require explicit human approval |
 | Review rejects after 2 revisions | Stop loop, flag for human intervention |
 
-## Subagent Prompt Suffix
-
-Append the following suffix to every subagent prompt invoked from this recipe:
-
-```
-[SYSTEM CONSTRAINT]
-This agent operates within the reverse-engineer recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
-```
 

--- a/dev-workflows/skills/recipe-reverse-engineer/SKILL.md
+++ b/dev-workflows/skills/recipe-reverse-engineer/SKILL.md
@@ -407,3 +407,13 @@ Output summary including:
 | Generation fails | Log failure, continue with other units, report in summary |
 | consistencyScore < 50 | Flag for mandatory human review — require explicit human approval |
 | Review rejects after 2 revisions | Stop loop, flag for human intervention |
+
+## Subagent Prompt Suffix
+
+Append the following suffix to every subagent prompt invoked from this recipe:
+
+```
+[SYSTEM CONSTRAINT]
+This agent operates within the reverse-engineer recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
+```
+

--- a/dev-workflows/skills/recipe-review/SKILL.md
+++ b/dev-workflows/skills/recipe-review/SKILL.md
@@ -158,3 +158,13 @@ Remaining issues:
 - Committed secrets (blocked → human intervention)
 
 **Scope**: Design Doc compliance validation, security review, and auto-fixes.
+
+## Subagent Prompt Suffix
+
+Append the following suffix to every subagent prompt invoked from this recipe:
+
+```
+[SYSTEM CONSTRAINT]
+This agent operates within the review recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
+```
+

--- a/dev-workflows/skills/recipe-review/SKILL.md
+++ b/dev-workflows/skills/recipe-review/SKILL.md
@@ -159,12 +159,14 @@ Remaining issues:
 
 **Scope**: Design Doc compliance validation, security review, and auto-fixes.
 
-## Subagent Prompt Suffix
+## Scope Boundary for Subagents
 
-Append the following suffix to every subagent prompt invoked from this recipe:
+Append the following block to every subagent prompt invoked from this recipe:
 
 ```
-[SYSTEM CONSTRAINT]
-This agent operates within the review recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
+Scope boundary for subagents:
+Operate within the review scope and referenced files in the prompt.
+Use loaded skills to execute that scope.
+Escalate when the required fix or investigation falls outside that scope.
 ```
 

--- a/dev-workflows/skills/recipe-task/SKILL.md
+++ b/dev-workflows/skills/recipe-task/SKILL.md
@@ -39,7 +39,7 @@ After receiving rule-advisor's JSON response, proceed with:
 
 **Step 3: Create Task List with TaskCreate**
 
-Register work steps using TaskCreate. Always include: first "Confirm skill constraints", final "Verify skill fidelity".
+Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON".
 
 Break down the task based on rule-advisor's guidance:
 - Reflect `taskAnalysis.essence` in task descriptions
@@ -56,3 +56,13 @@ Proceed with task execution following:
 - Task structure (managed via TaskCreate/TaskUpdate)
 - Quality standards defined in the selectedRules output from rule-advisor
 - Monitor warningPatterns flags throughout execution and adjust approach when triggered
+
+## Subagent Prompt Suffix
+
+Append the following suffix to every subagent prompt invoked from this recipe:
+
+```
+[SYSTEM CONSTRAINT]
+This agent operates within the task recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
+```
+

--- a/dev-workflows/skills/recipe-task/SKILL.md
+++ b/dev-workflows/skills/recipe-task/SKILL.md
@@ -57,12 +57,4 @@ Proceed with task execution following:
 - Quality standards defined in the selectedRules output from rule-advisor
 - Monitor warningPatterns flags throughout execution and adjust approach when triggered
 
-## Subagent Prompt Suffix
-
-Append the following suffix to every subagent prompt invoked from this recipe:
-
-```
-[SYSTEM CONSTRAINT]
-This agent operates within the task recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
-```
 

--- a/dev-workflows/skills/recipe-update-doc/SKILL.md
+++ b/dev-workflows/skills/recipe-update-doc/SKILL.md
@@ -212,3 +212,13 @@ prompt: |
 Document update completed.
 - Updated document: docs/design/[document-name].md
 - Approval status: User approved
+
+## Subagent Prompt Suffix
+
+Append the following suffix to every subagent prompt invoked from this recipe:
+
+```
+[SYSTEM CONSTRAINT]
+This agent operates within the update-doc recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
+```
+

--- a/dev-workflows/skills/recipe-update-doc/SKILL.md
+++ b/dev-workflows/skills/recipe-update-doc/SKILL.md
@@ -213,12 +213,4 @@ Document update completed.
 - Updated document: docs/design/[document-name].md
 - Approval status: User approved
 
-## Subagent Prompt Suffix
-
-Append the following suffix to every subagent prompt invoked from this recipe:
-
-```
-[SYSTEM CONSTRAINT]
-This agent operates within the update-doc recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
-```
 

--- a/dev-workflows/skills/subagents-orchestration-guide/SKILL.md
+++ b/dev-workflows/skills/subagents-orchestration-guide/SKILL.md
@@ -153,6 +153,10 @@ Every subagent prompt must include:
 
 Construct the prompt from the agent's Input Parameters section and the deliverables available at that point in the flow.
 
+Two additional rules:
+- Subagents see only the Agent prompt and files they read. Include required paths, prior JSON, parameters, and scope constraints explicitly.
+- Replace every `[placeholder]` in examples below with concrete values before invoking the Agent tool.
+
 ### Call Example (requirement-analyzer)
 - subagent_type: "requirement-analyzer"
 - description: "Requirement analysis"
@@ -181,7 +185,6 @@ Subagents respond in JSON format. Key fields for orchestrator decisions:
 - **integration-test-reviewer**: status (approved/needs_revision/blocked), requiredFixes
 - **security-reviewer**: status (approved/approved_with_notes/needs_revision/blocked), findings, notes, requiredFixes
 - **acceptance-test-generator**: status, generatedFiles (integration: path|null, e2e: path|null), budgetUsage, e2eAbsenceReason (null when E2E emitted, otherwise: no_multi_step_journey|below_threshold_user_confirmed)
-
 
 ## Handling Requirement Changes
 
@@ -214,15 +217,21 @@ Criteria for timing when to call each agent:
 - **prd-creator**: Request updates according to requirement changes → Execute document-reviewer for consistency check
 - **document-reviewer**: Always execute before user approval after PRD/ADR/Design Doc creation/update
 
-## Basic Flow for Work Planning
+## Basic Flow: Planning and Implementation
 
-Always start with requirement-analyzer, then select the minimum document flow required by scale and affected layers.
+Always start with requirement-analyzer, then select the minimum planning flow required by scale and affected layers.
 
-| Scale | Required flow |
+### Planning flow (per scale)
+
+| Scale | Planning flow (ends at task-decomposer for Medium/Large; ends at work-planner for Small) |
 |-------|---------------|
 | Large | requirement-analyzer → PRD → PRD review → optional UI Spec → optional ADR → codebase-analyzer → Design Doc → code-verifier → document-reviewer → design-sync → acceptance-test-generator → work-planner → task-decomposer |
 | Medium | requirement-analyzer → codebase-analyzer → optional UI Spec → optional ADR → Design Doc → code-verifier → document-reviewer → design-sync → acceptance-test-generator → work-planner → task-decomposer |
-| Small | requirement-analyzer → work-planner → direct implementation |
+| Small | requirement-analyzer → work-planner |
+
+After the planning flow completes and the user grants batch approval, execute the task execution cycle: `task-executor → quality-fixer → commit` for each task. See "Autonomous Execution Mode" below for full per-task details. At Small scale this cycle still applies — implementation runs through `task-executor`, not orchestrator-direct edits.
+
+Each agent name in the chain is invoked via the Agent tool (per "Orchestrator's Permitted Tools" above).
 
 Rules:
 - Large scale requires PRD before Design Doc creation

--- a/dev-workflows/skills/task-analyzer/references/skills-index.yaml
+++ b/dev-workflows/skills/task-analyzer/references/skills-index.yaml
@@ -19,6 +19,7 @@ skills:
       - "Function Design"
       - "Error Handling"
       - "Dependency Management"
+      - "Reference Representativeness"
       - "Performance Considerations"
       - "Code Organization"
       - "Commenting Principles"
@@ -55,7 +56,7 @@ skills:
       - "Test Organization"
       - "Performance Considerations"
       - "Continuous Integration"
-      - "Common Anti-Patterns to Avoid"
+      - "Test Design Guardrails"
       - "Regression Testing"
       - "Testing Best Practices by Language Paradigm"
       - "Documentation and Communication"
@@ -76,6 +77,7 @@ skills:
       - "Rule of Three - Criteria for Code Duplication"
       - "Common Failure Patterns and Avoidance Methods"
       - "Debugging Techniques"
+      - "Quality Assurance Mechanism Awareness"
       - "Quality Check Workflow"
       - "Situations Requiring Technical Decisions"
       - "Implementation Completeness Assurance"
@@ -115,7 +117,7 @@ skills:
       - "Meta-cognitive Strategy Selection Process"
       - "Verification Level Definitions"
       - "Integration Point Definitions"
-      - "Anti-patterns"
+      - "Quality Checks"
       - "Guidelines for Meta-cognitive Execution"
 
   integration-e2e-testing:
@@ -131,6 +133,7 @@ skills:
       - "Test Type Definition and Limits"
       - "Behavior-First Principle"
       - "ROI Calculation"
+      - "Multi-Step User Journey Definition"
       - "Test Skeleton Specification"
       - "EARS Format Mapping"
       - "Test File Naming Convention"
@@ -147,7 +150,6 @@ skills:
       - "Conductor Pattern"
     sections:
       - "Role: The Orchestrator"
-      - "Decision Flow When Receiving Tasks"
       - "Available Subagents"
       - "Orchestration Principles"
       - "Constraints Between Subagents"
@@ -156,12 +158,10 @@ skills:
       - "How to Call Subagents"
       - "Structured Response Specification"
       - "Handling Requirement Changes"
-      - "Basic Flow for Work Planning"
+      - "Basic Flow: Planning and Implementation"
       - "Autonomous Execution Mode"
       - "Main Orchestrator Roles"
       - "Important Constraints"
-      - "Required Dialogue Points with Humans"
-      - "Action Checklist"
       - "References"
 
   # Frontend-Specific Skills

--- a/dev-workflows/skills/testing-principles/SKILL.md
+++ b/dev-workflows/skills/testing-principles/SKILL.md
@@ -238,7 +238,7 @@ The appropriate approach depends on project environment and CI/CD capabilities.
 - AI-generated data access code has heightened schema hallucination risk
 - Generated queries may use correct syntax but reference nonexistent schema elements
 - Mock-based tests pass regardless of schema accuracy
-- Mitigation: Design Docs should include explicit schema references; code-verifier reverse coverage verifies data operations against documented schemas
+- Mitigation: Design Docs should include explicit schema references so that documented schemas can be cross-checked against data access code during review
 
 ## Test Quality Practices
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-workflows",
-  "version": "0.16.16",
+  "version": "0.16.17",
   "private": true,
   "type": "module",
   "engines": {

--- a/skills/documentation-criteria/SKILL.md
+++ b/skills/documentation-criteria/SKILL.md
@@ -96,7 +96,7 @@ description: Documentation creation criteria including PRD, ADR, Design Doc, and
 - Visual acceptance criteria (golden states, layout constraints)
 - Accessibility requirements (keyboard, screen reader, contrast)
 
-**Scope**: Screen structure, transitions, component decomposition, interaction design, and visual acceptance criteria only. Technical implementation and API contracts belong in Design Doc, test implementation in acceptance-test-generator skeletons, schedule in Work Plan.
+**Scope**: Screen structure, transitions, component decomposition, interaction design, and visual acceptance criteria only. Technical implementation and API contracts belong in Design Doc, test implementation in test skeleton generation output, schedule in Work Plan.
 
 **Required Structural Elements**:
 - At least one component with state x display matrix and interaction table
@@ -159,7 +159,7 @@ Interface Change Matrix:
 **Includes**:
 - Task breakdown and dependencies (maximum 2 levels)
 - Schedule and duration estimates
-- **Include test skeleton file paths from acceptance-test-generator** (integration and E2E)
+- **Include test skeleton file paths produced for this work plan** (integration and E2E)
 - **Verification Strategy summary** (extracted from Design Doc)
 - **Final Quality Assurance Phase (required)**
 - Progress records (checkbox format)

--- a/skills/documentation-criteria/references/task-template.md
+++ b/skills/documentation-criteria/references/task-template.md
@@ -17,6 +17,9 @@ Metadata:
 Files to read before starting implementation (file path, with optional search hint):
 - [e.g., src/orders/checkout (processOrder function) — determined by task-decomposer based on task nature]
 
+## Investigation Notes
+(task-executor appends observations here before implementation.)
+
 ## Implementation Steps (TDD: Red-Green-Refactor)
 ### 1. Red Phase
 - [ ] Read all Investigation Targets and record key observations

--- a/skills/documentation-criteria/references/task-template.md
+++ b/skills/documentation-criteria/references/task-template.md
@@ -15,10 +15,10 @@ Metadata:
 
 ## Investigation Targets
 Files to read before starting implementation (file path, with optional search hint):
-- [e.g., src/orders/checkout (processOrder function) — determined by task-decomposer based on task nature]
+- [e.g., src/orders/checkout (processOrder function) — determined during task decomposition based on task nature]
 
 ## Investigation Notes
-(task-executor appends observations here before implementation.)
+(Implementation observations are appended here before implementation begins.)
 
 ## Implementation Steps (TDD: Red-Green-Refactor)
 ### 1. Red Phase

--- a/skills/documentation-criteria/references/ui-spec-template.md
+++ b/skills/documentation-criteria/references/ui-spec-template.md
@@ -5,7 +5,7 @@
 [Purpose and scope of this UI Specification in 2-3 sentences]
 
 ### Target PRD
-- PRD path: [docs/prd/xxx-prd.md | "N/A — based on requirement-analyzer output"]
+- PRD path: [docs/prd/xxx-prd.md | "N/A — based on requirements analysis output"]
 - Feature scope: [Which PRD requirements this UI Spec covers | Summary of analyzed requirements]
 
 ### Design Source

--- a/skills/recipe-add-integration-tests/SKILL.md
+++ b/skills/recipe-add-integration-tests/SKILL.md
@@ -160,12 +160,14 @@ Check quality-fixer response:
 On `approved` from quality-fixer:
 - Commit test files using Bash with message format: "test: add [layer] integration tests for [feature name]"
 
-## Subagent Prompt Suffix
+## Scope Boundary for Subagents
 
-Append the following suffix to every subagent prompt invoked from this recipe:
+Append the following block to every subagent prompt invoked from this recipe:
 
 ```
-[SYSTEM CONSTRAINT]
-This agent operates within the add-integration-tests recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
+Scope boundary for subagents:
+Operate within the task scope and referenced files in the prompt.
+Use loaded skills to execute that scope.
+Escalate when the required fix or investigation falls outside that scope.
 ```
 

--- a/skills/recipe-add-integration-tests/SKILL.md
+++ b/skills/recipe-add-integration-tests/SKILL.md
@@ -159,3 +159,13 @@ Check quality-fixer response:
 
 On `approved` from quality-fixer:
 - Commit test files using Bash with message format: "test: add [layer] integration tests for [feature name]"
+
+## Subagent Prompt Suffix
+
+Append the following suffix to every subagent prompt invoked from this recipe:
+
+```
+[SYSTEM CONSTRAINT]
+This agent operates within the add-integration-tests recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
+```
+

--- a/skills/recipe-build/SKILL.md
+++ b/skills/recipe-build/SKILL.md
@@ -95,13 +95,15 @@ For EACH task, YOU MUST:
 
 **CRITICAL**: Parse every sub-agent response for status fields. Execute the matching branch in the 4-step cycle. Proceed to next task only after quality-fixer returns `approved`.
 
-## Subagent Prompt Suffix
+## Scope Boundary for Subagents
 
-Append the following suffix to every subagent prompt invoked from this recipe:
+Append the following block to every subagent prompt invoked from this recipe:
 
 ```
-[SYSTEM CONSTRAINT]
-This agent operates within the build recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
+Scope boundary for subagents:
+Operate within the task scope and referenced files in the prompt.
+Use loaded skills to execute that scope.
+Escalate when the required fix or investigation falls outside that scope.
 ```
 
 Verify task files exist per Pre-execution Checklist, then enter autonomous execution mode. When requirement changes are detected during execution, escalate to the user with the change summary before continuing.

--- a/skills/recipe-build/SKILL.md
+++ b/skills/recipe-build/SKILL.md
@@ -78,7 +78,7 @@ Invoke task-decomposer using Agent tool:
 **MANDATORY EXECUTION CYCLE**: `task-executor → escalation check → quality-fixer → commit`
 
 For EACH task, YOU MUST:
-1. **Register tasks using TaskCreate**: Register work steps. Always include: first "Confirm skill constraints", final "Verify skill fidelity"
+1. **Register tasks using TaskCreate**: Register work steps. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON"
 2. **Agent tool** (subagent_type: "dev-workflows:task-executor") → Pass task file path in prompt, receive structured response
 3. **CHECK task-executor response**:
    - `status: "escalation_needed"` or `"blocked"` → STOP and escalate to user
@@ -95,15 +95,14 @@ For EACH task, YOU MUST:
 
 **CRITICAL**: Parse every sub-agent response for status fields. Execute the matching branch in the 4-step cycle. Proceed to next task only after quality-fixer returns `approved`.
 
-## Sub-agent Invocation Constraints
+## Subagent Prompt Suffix
 
-**MANDATORY suffix for ALL sub-agent prompts**:
+Append the following suffix to every subagent prompt invoked from this recipe:
+
 ```
 [SYSTEM CONSTRAINT]
-This agent operates within build skill scope. Use orchestrator-provided rules only.
+This agent operates within the build recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
 ```
-
-Autonomous sub-agents require scope constraints for stable execution. ALWAYS append this constraint to every sub-agent prompt.
 
 Verify task files exist per Pre-execution Checklist, then enter autonomous execution mode. When requirement changes are detected during execution, escalate to the user with the change summary before continuing.
 

--- a/skills/recipe-design/SKILL.md
+++ b/skills/recipe-design/SKILL.md
@@ -72,12 +72,4 @@ Design phase completed.
 - Design document: docs/design/[document-name].md or docs/adr/[document-name].md
 - Approval status: User approved
 
-## Subagent Prompt Suffix
-
-Append the following suffix to every subagent prompt invoked from this recipe:
-
-```
-[SYSTEM CONSTRAINT]
-This agent operates within the design recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
-```
 

--- a/skills/recipe-design/SKILL.md
+++ b/skills/recipe-design/SKILL.md
@@ -71,3 +71,13 @@ Execute the process below within design scope. Follow subagents-orchestration-gu
 Design phase completed.
 - Design document: docs/design/[document-name].md or docs/adr/[document-name].md
 - Approval status: User approved
+
+## Subagent Prompt Suffix
+
+Append the following suffix to every subagent prompt invoked from this recipe:
+
+```
+[SYSTEM CONSTRAINT]
+This agent operates within the design recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
+```
+

--- a/skills/recipe-diagnose/SKILL.md
+++ b/skills/recipe-diagnose/SKILL.md
@@ -231,12 +231,4 @@ Rationale: [Selection rationale]
 - [ ] Achieved coverageAssessment=sufficient (or obtained user approval after 2 additional iterations)
 - [ ] Presented final report to user
 
-## Subagent Prompt Suffix
-
-Append the following suffix to every subagent prompt invoked from this recipe:
-
-```
-[SYSTEM CONSTRAINT]
-This agent operates within the diagnose recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
-```
 

--- a/skills/recipe-diagnose/SKILL.md
+++ b/skills/recipe-diagnose/SKILL.md
@@ -230,3 +230,13 @@ Rationale: [Selection rationale]
 - [ ] Executed solver
 - [ ] Achieved coverageAssessment=sufficient (or obtained user approval after 2 additional iterations)
 - [ ] Presented final report to user
+
+## Subagent Prompt Suffix
+
+Append the following suffix to every subagent prompt invoked from this recipe:
+
+```
+[SYSTEM CONSTRAINT]
+This agent operates within the diagnose recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
+```
+

--- a/skills/recipe-front-build/SKILL.md
+++ b/skills/recipe-front-build/SKILL.md
@@ -95,13 +95,15 @@ For EACH task, YOU MUST:
 
 **CRITICAL**: Parse every sub-agent response for status fields. Execute the matching branch in the 4-step cycle. Proceed to next task only after quality-fixer-frontend returns `approved`.
 
-## Subagent Prompt Suffix
+## Scope Boundary for Subagents
 
-Append the following suffix to every subagent prompt invoked from this recipe:
+Append the following block to every subagent prompt invoked from this recipe:
 
 ```
-[SYSTEM CONSTRAINT]
-This agent operates within the front-build recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
+Scope boundary for subagents:
+Operate within the task scope and referenced files in the prompt.
+Use loaded skills to execute that scope.
+Escalate when the required fix or investigation falls outside that scope.
 ```
 
 Verify task files exist per Pre-execution Checklist, then enter autonomous execution mode. When requirement changes are detected during execution, escalate to the user with the change summary before continuing.

--- a/skills/recipe-front-build/SKILL.md
+++ b/skills/recipe-front-build/SKILL.md
@@ -78,7 +78,7 @@ Invoke task-decomposer using Agent tool:
 **MANDATORY EXECUTION CYCLE**: `task-executor-frontend → escalation check → quality-fixer-frontend → commit`
 
 For EACH task, YOU MUST:
-1. **Register tasks using TaskCreate**: Register work steps. Always include: first "Confirm skill constraints", final "Verify skill fidelity"
+1. **Register tasks using TaskCreate**: Register work steps. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON"
 2. **Agent tool** (subagent_type: "dev-workflows-frontend:task-executor-frontend") → Pass task file path in prompt, receive structured response
 3. **CHECK task-executor-frontend response**:
    - `status: "escalation_needed"` or `"blocked"` → STOP and escalate to user
@@ -95,15 +95,14 @@ For EACH task, YOU MUST:
 
 **CRITICAL**: Parse every sub-agent response for status fields. Execute the matching branch in the 4-step cycle. Proceed to next task only after quality-fixer-frontend returns `approved`.
 
-## Sub-agent Invocation Constraints
+## Subagent Prompt Suffix
 
-**MANDATORY suffix for ALL sub-agent prompts**:
+Append the following suffix to every subagent prompt invoked from this recipe:
+
 ```
 [SYSTEM CONSTRAINT]
-This agent operates within build skill scope. Use orchestrator-provided rules only.
+This agent operates within the front-build recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
 ```
-
-Autonomous sub-agents require scope constraints for stable execution. ALWAYS append this constraint to every sub-agent prompt.
 
 Verify task files exist per Pre-execution Checklist, then enter autonomous execution mode. When requirement changes are detected during execution, escalate to the user with the change summary before continuing.
 

--- a/skills/recipe-front-design/SKILL.md
+++ b/skills/recipe-front-design/SKILL.md
@@ -78,7 +78,7 @@ Then create the UI Specification:
   - `description: "UI Spec creation"`
   - If PRD exists and prototype provided: `prompt: "Create UI Spec from PRD at [path]. Prototype code is at [user-provided path]. Place prototype in docs/ui-spec/assets/{feature-name}/"`
   - If PRD exists and no prototype: `prompt: "Create UI Spec from PRD at [path]. No prototype code available."`
-  - If no PRD (medium scale): `prompt: "Create UI Spec based on the following requirements: [pass requirement-analyzer output]. No PRD available."` (add prototype path if provided)
+  - If no PRD (medium scale): `prompt: "Create UI Spec based on the following requirements: [requirements analysis output from Step 1]. No PRD available."` (add prototype path if provided)
 - Invoke **document-reviewer** to verify UI Spec
   - `subagent_type: "dev-workflows-frontend:document-reviewer"`, `description: "UI Spec review"`, `prompt: "doc_type: UISpec target: [ui-spec path] Review for consistency and completeness"`
 - **[STOP]**: Present UI Spec for user approval
@@ -91,11 +91,11 @@ First, analyze the existing codebase:
 Create appropriate design documents according to scale determination. technical-designer-frontend presents at least two architecture alternatives (technology selection, data flow design) with trade-offs for each:
 - Invoke **technical-designer-frontend** using Agent tool
   - For ADR: `subagent_type: "dev-workflows-frontend:technical-designer-frontend"`, `description: "ADR creation"`, `prompt: "Create ADR for [technical decision]. Present at least two alternatives with trade-offs."`
-  - For Design Doc: `subagent_type: "dev-workflows-frontend:technical-designer-frontend"`, `description: "Design Doc creation"`, `prompt: "Create Design Doc based on requirements. Codebase analysis: [JSON from codebase-analyzer]. UI Spec is at [ui-spec path]. Inherit component structure and state design from UI Spec. Present at least two architecture alternatives with trade-offs."`
+  - For Design Doc: `subagent_type: "dev-workflows-frontend:technical-designer-frontend"`, `description: "Design Doc creation"`, `prompt: "Create Design Doc based on requirements. Codebase analysis: [codebase analysis output from this step]. UI Spec is at [ui-spec path]. Inherit component structure and state design from UI Spec. Present at least two architecture alternatives with trade-offs."`
 - **(Design Doc only)** Invoke **code-verifier** to verify Design Doc against existing code. Skip for ADR.
   - `subagent_type: "dev-workflows-frontend:code-verifier"`, `description: "Design Doc verification"`, `prompt: "doc_type: design-doc document_path: [Design Doc path] Verify Design Doc against existing code."`
 - Invoke **document-reviewer** to verify consistency (pass code-verifier results for Design Doc; omit for ADR)
-  - `subagent_type: "dev-workflows-frontend:document-reviewer"`, `description: "Document review"`, `prompt: "Review [document path] for consistency and completeness. code_verification: [JSON from code-verifier] (Design Doc only)"`
+  - `subagent_type: "dev-workflows-frontend:document-reviewer"`, `description: "Document review"`, `prompt: "Review [document path] for consistency and completeness. code_verification: [code verification output from this step] (Design Doc only)"`
 
 ### Step 4: Design Consistency Verification
 - Invoke **design-sync** using Agent tool
@@ -119,12 +119,4 @@ Frontend design phase completed.
 - Design document: docs/design/[document-name].md or docs/adr/[document-name].md
 - Approval status: User approved
 
-## Subagent Prompt Suffix
-
-Append the following suffix to every subagent prompt invoked from this recipe:
-
-```
-[SYSTEM CONSTRAINT]
-This agent operates within the front-design recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
-```
 

--- a/skills/recipe-front-design/SKILL.md
+++ b/skills/recipe-front-design/SKILL.md
@@ -118,3 +118,13 @@ Frontend design phase completed.
 - UI Specification: docs/ui-spec/[feature-name]-ui-spec.md
 - Design document: docs/design/[document-name].md or docs/adr/[document-name].md
 - Approval status: User approved
+
+## Subagent Prompt Suffix
+
+Append the following suffix to every subagent prompt invoked from this recipe:
+
+```
+[SYSTEM CONSTRAINT]
+This agent operates within the front-design recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
+```
+

--- a/skills/recipe-front-plan/SKILL.md
+++ b/skills/recipe-front-plan/SKILL.md
@@ -73,3 +73,13 @@ Frontend planning phase completed.
 
 Please provide separate instructions for implementation.
 ```
+
+## Subagent Prompt Suffix
+
+Append the following suffix to every subagent prompt invoked from this recipe:
+
+```
+[SYSTEM CONSTRAINT]
+This agent operates within the front-plan recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
+```
+

--- a/skills/recipe-front-plan/SKILL.md
+++ b/skills/recipe-front-plan/SKILL.md
@@ -74,12 +74,4 @@ Frontend planning phase completed.
 Please provide separate instructions for implementation.
 ```
 
-## Subagent Prompt Suffix
-
-Append the following suffix to every subagent prompt invoked from this recipe:
-
-```
-[SYSTEM CONSTRAINT]
-This agent operates within the front-plan recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
-```
 

--- a/skills/recipe-front-review/SKILL.md
+++ b/skills/recipe-front-review/SKILL.md
@@ -156,12 +156,14 @@ Remaining issues:
 
 **Scope**: Design Doc compliance validation, security review, and auto-fixes.
 
-## Subagent Prompt Suffix
+## Scope Boundary for Subagents
 
-Append the following suffix to every subagent prompt invoked from this recipe:
+Append the following block to every subagent prompt invoked from this recipe:
 
 ```
-[SYSTEM CONSTRAINT]
-This agent operates within the front-review recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
+Scope boundary for subagents:
+Operate within the review scope and referenced files in the prompt.
+Use loaded skills to execute that scope.
+Escalate when the required fix or investigation falls outside that scope.
 ```
 

--- a/skills/recipe-front-review/SKILL.md
+++ b/skills/recipe-front-review/SKILL.md
@@ -155,3 +155,13 @@ Remaining issues:
 - Committed secrets (blocked → human intervention)
 
 **Scope**: Design Doc compliance validation, security review, and auto-fixes.
+
+## Subagent Prompt Suffix
+
+Append the following suffix to every subagent prompt invoked from this recipe:
+
+```
+[SYSTEM CONSTRAINT]
+This agent operates within the front-review recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
+```
+

--- a/skills/recipe-fullstack-build/SKILL.md
+++ b/skills/recipe-fullstack-build/SKILL.md
@@ -95,7 +95,7 @@ Invoke task-decomposer using Agent tool:
 ### Task Execution (4-Step Cycle)
 
 For EACH task, YOU MUST:
-1. **Register tasks using TaskCreate**: Register work steps. Always include: first "Confirm skill constraints", final "Verify skill fidelity"
+1. **Register tasks using TaskCreate**: Register work steps. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON"
 2. **Agent tool** (subagent_type per routing table) → Pass task file path in prompt, receive structured response
 3. **CHECK executor response**:
    - `status: "escalation_needed"` or `"blocked"` → STOP and escalate to user
@@ -112,15 +112,14 @@ For EACH task, YOU MUST:
 
 **CRITICAL**: Parse every sub-agent response for status fields. Execute the matching branch in the 4-step cycle. Proceed to next task only after layer-appropriate quality-fixer returns `approved`.
 
-## Sub-agent Invocation Constraints
+## Subagent Prompt Suffix
 
-**MANDATORY suffix for ALL sub-agent prompts**:
+Append the following suffix to every subagent prompt invoked from this recipe:
+
 ```
 [SYSTEM CONSTRAINT]
-This agent operates within build skill scope. Use orchestrator-provided rules only.
+This agent operates within the fullstack-build recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
 ```
-
-Autonomous sub-agents require scope constraints for stable execution. ALWAYS append this constraint to every sub-agent prompt.
 
 Verify task files exist per Pre-execution Checklist, then enter autonomous execution mode. When requirement changes are detected during execution, escalate to the user with the change summary before continuing.
 

--- a/skills/recipe-fullstack-build/SKILL.md
+++ b/skills/recipe-fullstack-build/SKILL.md
@@ -112,13 +112,15 @@ For EACH task, YOU MUST:
 
 **CRITICAL**: Parse every sub-agent response for status fields. Execute the matching branch in the 4-step cycle. Proceed to next task only after layer-appropriate quality-fixer returns `approved`.
 
-## Subagent Prompt Suffix
+## Scope Boundary for Subagents
 
-Append the following suffix to every subagent prompt invoked from this recipe:
+Append the following block to every subagent prompt invoked from this recipe:
 
 ```
-[SYSTEM CONSTRAINT]
-This agent operates within the fullstack-build recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
+Scope boundary for subagents:
+Operate within the task scope and referenced files in the prompt.
+Use loaded skills to execute that scope.
+Escalate when the required fix or investigation falls outside that scope.
 ```
 
 Verify task files exist per Pre-execution Checklist, then enter autonomous execution mode. When requirement changes are detected during execution, escalate to the user with the change summary before continuing.

--- a/skills/recipe-fullstack-implement/SKILL.md
+++ b/skills/recipe-fullstack-implement/SKILL.md
@@ -101,13 +101,15 @@ When user responds to questions:
 - Run quality-fixer (layer-appropriate) before every commit
 - Obtain user approval before Edit/Write/MultiEdit outside autonomous mode
 
-## Subagent Prompt Suffix
+## Scope Boundary for Subagents
 
-Append the following suffix to every subagent prompt invoked from this recipe:
+Append the following block to every subagent prompt invoked from this recipe:
 
 ```
-[SYSTEM CONSTRAINT]
-This agent operates within the fullstack-implement recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
+Scope boundary for subagents:
+Operate within the task scope and referenced files in the prompt.
+Use loaded skills to execute that scope.
+Escalate when the required fix or investigation falls outside that scope.
 ```
 
 ## Mandatory Orchestrator Responsibilities

--- a/skills/recipe-fullstack-implement/SKILL.md
+++ b/skills/recipe-fullstack-implement/SKILL.md
@@ -71,7 +71,7 @@ Invoke **document-reviewer** for UI Spec review, then **[STOP]** for user approv
 ### 5. Register All Flow Steps Using TaskCreate (MANDATORY)
 
 **After scale determination, register all steps of the monorepo-flow.md using TaskCreate**:
-- First task: "Confirm skill constraints"
+- First task: "Map preloaded skills to applicable concrete rules"
 - Register each step as individual task
 - Set currently executing step to `in_progress` using TaskUpdate
 - **Complete task registration before invoking subagents**
@@ -101,15 +101,14 @@ When user responds to questions:
 - Run quality-fixer (layer-appropriate) before every commit
 - Obtain user approval before Edit/Write/MultiEdit outside autonomous mode
 
-## CRITICAL Sub-agent Invocation Constraints
+## Subagent Prompt Suffix
 
-**MANDATORY suffix for ALL sub-agent prompts**:
+Append the following suffix to every subagent prompt invoked from this recipe:
+
 ```
 [SYSTEM CONSTRAINT]
-This agent operates within fullstack-implement skill scope. Use orchestrator-provided rules only.
+This agent operates within the fullstack-implement recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
 ```
-
-Autonomous sub-agents require scope constraints for stable execution. ALWAYS append this constraint to every sub-agent prompt.
 
 ## Mandatory Orchestrator Responsibilities
 

--- a/skills/recipe-implement/SKILL.md
+++ b/skills/recipe-implement/SKILL.md
@@ -59,7 +59,7 @@ When user responds to questions:
 ### 4. Register All Flow Steps Using TaskCreate (MANDATORY)
 
 **After scale determination, register all steps of the applicable flow using TaskCreate**:
-- First task: "Confirm skill constraints"
+- First task: "Map preloaded skills to applicable concrete rules"
 - Register each step as individual task
 - Set currently executing step to `in_progress` using TaskUpdate
 - **Complete task registration before invoking subagents**
@@ -81,15 +81,14 @@ When user responds to questions:
 - Run quality-fixer before every commit
 - Obtain user approval before Edit/Write/MultiEdit outside autonomous mode
 
-## CRITICAL Sub-agent Invocation Constraints
+## Subagent Prompt Suffix
 
-**MANDATORY suffix for ALL sub-agent prompts**:
+Append the following suffix to every subagent prompt invoked from this recipe:
+
 ```
 [SYSTEM CONSTRAINT]
-This agent operates within implement skill scope. Use orchestrator-provided rules only.
+This agent operates within the implement recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
 ```
-
-Autonomous sub-agents require scope constraints for stable execution. ALWAYS append this constraint to every sub-agent prompt.
 
 ## Mandatory Orchestrator Responsibilities
 

--- a/skills/recipe-implement/SKILL.md
+++ b/skills/recipe-implement/SKILL.md
@@ -81,13 +81,15 @@ When user responds to questions:
 - Run quality-fixer before every commit
 - Obtain user approval before Edit/Write/MultiEdit outside autonomous mode
 
-## Subagent Prompt Suffix
+## Scope Boundary for Subagents
 
-Append the following suffix to every subagent prompt invoked from this recipe:
+Append the following block to every subagent prompt invoked from this recipe:
 
 ```
-[SYSTEM CONSTRAINT]
-This agent operates within the implement recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
+Scope boundary for subagents:
+Operate within the task scope and referenced files in the prompt.
+Use loaded skills to execute that scope.
+Escalate when the required fix or investigation falls outside that scope.
 ```
 
 ## Mandatory Orchestrator Responsibilities

--- a/skills/recipe-plan/SKILL.md
+++ b/skills/recipe-plan/SKILL.md
@@ -59,7 +59,6 @@ Invoke work-planner using Agent tool:
 - Present work plan to user for review. If user requests changes, re-invoke work-planner with revised parameters
 - Highlight steps with unclear scope or external dependencies and ask user to confirm
 
-
 ## Response at Completion
 **Recommended**: End with the following standard response after plan content approval
 ```
@@ -69,3 +68,13 @@ Planning phase completed.
 
 Please provide separate instructions for implementation.
 ```
+
+## Subagent Prompt Suffix
+
+Append the following suffix to every subagent prompt invoked from this recipe:
+
+```
+[SYSTEM CONSTRAINT]
+This agent operates within the plan recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
+```
+

--- a/skills/recipe-plan/SKILL.md
+++ b/skills/recipe-plan/SKILL.md
@@ -69,12 +69,4 @@ Planning phase completed.
 Please provide separate instructions for implementation.
 ```
 
-## Subagent Prompt Suffix
-
-Append the following suffix to every subagent prompt invoked from this recipe:
-
-```
-[SYSTEM CONSTRAINT]
-This agent operates within the plan recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
-```
 

--- a/skills/recipe-reverse-engineer/SKILL.md
+++ b/skills/recipe-reverse-engineer/SKILL.md
@@ -408,12 +408,4 @@ Output summary including:
 | consistencyScore < 50 | Flag for mandatory human review — require explicit human approval |
 | Review rejects after 2 revisions | Stop loop, flag for human intervention |
 
-## Subagent Prompt Suffix
-
-Append the following suffix to every subagent prompt invoked from this recipe:
-
-```
-[SYSTEM CONSTRAINT]
-This agent operates within the reverse-engineer recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
-```
 

--- a/skills/recipe-reverse-engineer/SKILL.md
+++ b/skills/recipe-reverse-engineer/SKILL.md
@@ -407,3 +407,13 @@ Output summary including:
 | Generation fails | Log failure, continue with other units, report in summary |
 | consistencyScore < 50 | Flag for mandatory human review — require explicit human approval |
 | Review rejects after 2 revisions | Stop loop, flag for human intervention |
+
+## Subagent Prompt Suffix
+
+Append the following suffix to every subagent prompt invoked from this recipe:
+
+```
+[SYSTEM CONSTRAINT]
+This agent operates within the reverse-engineer recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
+```
+

--- a/skills/recipe-review/SKILL.md
+++ b/skills/recipe-review/SKILL.md
@@ -158,3 +158,13 @@ Remaining issues:
 - Committed secrets (blocked → human intervention)
 
 **Scope**: Design Doc compliance validation, security review, and auto-fixes.
+
+## Subagent Prompt Suffix
+
+Append the following suffix to every subagent prompt invoked from this recipe:
+
+```
+[SYSTEM CONSTRAINT]
+This agent operates within the review recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
+```
+

--- a/skills/recipe-review/SKILL.md
+++ b/skills/recipe-review/SKILL.md
@@ -159,12 +159,14 @@ Remaining issues:
 
 **Scope**: Design Doc compliance validation, security review, and auto-fixes.
 
-## Subagent Prompt Suffix
+## Scope Boundary for Subagents
 
-Append the following suffix to every subagent prompt invoked from this recipe:
+Append the following block to every subagent prompt invoked from this recipe:
 
 ```
-[SYSTEM CONSTRAINT]
-This agent operates within the review recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
+Scope boundary for subagents:
+Operate within the review scope and referenced files in the prompt.
+Use loaded skills to execute that scope.
+Escalate when the required fix or investigation falls outside that scope.
 ```
 

--- a/skills/recipe-task/SKILL.md
+++ b/skills/recipe-task/SKILL.md
@@ -39,7 +39,7 @@ After receiving rule-advisor's JSON response, proceed with:
 
 **Step 3: Create Task List with TaskCreate**
 
-Register work steps using TaskCreate. Always include: first "Confirm skill constraints", final "Verify skill fidelity".
+Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON".
 
 Break down the task based on rule-advisor's guidance:
 - Reflect `taskAnalysis.essence` in task descriptions
@@ -56,3 +56,13 @@ Proceed with task execution following:
 - Task structure (managed via TaskCreate/TaskUpdate)
 - Quality standards defined in the selectedRules output from rule-advisor
 - Monitor warningPatterns flags throughout execution and adjust approach when triggered
+
+## Subagent Prompt Suffix
+
+Append the following suffix to every subagent prompt invoked from this recipe:
+
+```
+[SYSTEM CONSTRAINT]
+This agent operates within the task recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
+```
+

--- a/skills/recipe-task/SKILL.md
+++ b/skills/recipe-task/SKILL.md
@@ -57,12 +57,4 @@ Proceed with task execution following:
 - Quality standards defined in the selectedRules output from rule-advisor
 - Monitor warningPatterns flags throughout execution and adjust approach when triggered
 
-## Subagent Prompt Suffix
-
-Append the following suffix to every subagent prompt invoked from this recipe:
-
-```
-[SYSTEM CONSTRAINT]
-This agent operates within the task recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
-```
 

--- a/skills/recipe-update-doc/SKILL.md
+++ b/skills/recipe-update-doc/SKILL.md
@@ -212,3 +212,13 @@ prompt: |
 Document update completed.
 - Updated document: docs/design/[document-name].md
 - Approval status: User approved
+
+## Subagent Prompt Suffix
+
+Append the following suffix to every subagent prompt invoked from this recipe:
+
+```
+[SYSTEM CONSTRAINT]
+This agent operates within the update-doc recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
+```
+

--- a/skills/recipe-update-doc/SKILL.md
+++ b/skills/recipe-update-doc/SKILL.md
@@ -213,12 +213,4 @@ Document update completed.
 - Updated document: docs/design/[document-name].md
 - Approval status: User approved
 
-## Subagent Prompt Suffix
-
-Append the following suffix to every subagent prompt invoked from this recipe:
-
-```
-[SYSTEM CONSTRAINT]
-This agent operates within the update-doc recipe scope. Apply the rules provided in your frontmatter `skills:` and the orchestrator's prompt.
-```
 

--- a/skills/subagents-orchestration-guide/SKILL.md
+++ b/skills/subagents-orchestration-guide/SKILL.md
@@ -153,6 +153,10 @@ Every subagent prompt must include:
 
 Construct the prompt from the agent's Input Parameters section and the deliverables available at that point in the flow.
 
+Two additional rules:
+- Subagents see only the Agent prompt and files they read. Include required paths, prior JSON, parameters, and scope constraints explicitly.
+- Replace every `[placeholder]` in examples below with concrete values before invoking the Agent tool.
+
 ### Call Example (requirement-analyzer)
 - subagent_type: "requirement-analyzer"
 - description: "Requirement analysis"
@@ -181,7 +185,6 @@ Subagents respond in JSON format. Key fields for orchestrator decisions:
 - **integration-test-reviewer**: status (approved/needs_revision/blocked), requiredFixes
 - **security-reviewer**: status (approved/approved_with_notes/needs_revision/blocked), findings, notes, requiredFixes
 - **acceptance-test-generator**: status, generatedFiles (integration: path|null, e2e: path|null), budgetUsage, e2eAbsenceReason (null when E2E emitted, otherwise: no_multi_step_journey|below_threshold_user_confirmed)
-
 
 ## Handling Requirement Changes
 
@@ -214,15 +217,21 @@ Criteria for timing when to call each agent:
 - **prd-creator**: Request updates according to requirement changes → Execute document-reviewer for consistency check
 - **document-reviewer**: Always execute before user approval after PRD/ADR/Design Doc creation/update
 
-## Basic Flow for Work Planning
+## Basic Flow: Planning and Implementation
 
-Always start with requirement-analyzer, then select the minimum document flow required by scale and affected layers.
+Always start with requirement-analyzer, then select the minimum planning flow required by scale and affected layers.
 
-| Scale | Required flow |
+### Planning flow (per scale)
+
+| Scale | Planning flow (ends at task-decomposer for Medium/Large; ends at work-planner for Small) |
 |-------|---------------|
 | Large | requirement-analyzer → PRD → PRD review → optional UI Spec → optional ADR → codebase-analyzer → Design Doc → code-verifier → document-reviewer → design-sync → acceptance-test-generator → work-planner → task-decomposer |
 | Medium | requirement-analyzer → codebase-analyzer → optional UI Spec → optional ADR → Design Doc → code-verifier → document-reviewer → design-sync → acceptance-test-generator → work-planner → task-decomposer |
-| Small | requirement-analyzer → work-planner → direct implementation |
+| Small | requirement-analyzer → work-planner |
+
+After the planning flow completes and the user grants batch approval, execute the task execution cycle: `task-executor → quality-fixer → commit` for each task. See "Autonomous Execution Mode" below for full per-task details. At Small scale this cycle still applies — implementation runs through `task-executor`, not orchestrator-direct edits.
+
+Each agent name in the chain is invoked via the Agent tool (per "Orchestrator's Permitted Tools" above).
 
 Rules:
 - Large scale requires PRD before Design Doc creation

--- a/skills/task-analyzer/references/skills-index.yaml
+++ b/skills/task-analyzer/references/skills-index.yaml
@@ -19,6 +19,7 @@ skills:
       - "Function Design"
       - "Error Handling"
       - "Dependency Management"
+      - "Reference Representativeness"
       - "Performance Considerations"
       - "Code Organization"
       - "Commenting Principles"
@@ -55,7 +56,7 @@ skills:
       - "Test Organization"
       - "Performance Considerations"
       - "Continuous Integration"
-      - "Common Anti-Patterns to Avoid"
+      - "Test Design Guardrails"
       - "Regression Testing"
       - "Testing Best Practices by Language Paradigm"
       - "Documentation and Communication"
@@ -76,6 +77,7 @@ skills:
       - "Rule of Three - Criteria for Code Duplication"
       - "Common Failure Patterns and Avoidance Methods"
       - "Debugging Techniques"
+      - "Quality Assurance Mechanism Awareness"
       - "Quality Check Workflow"
       - "Situations Requiring Technical Decisions"
       - "Implementation Completeness Assurance"
@@ -115,7 +117,7 @@ skills:
       - "Meta-cognitive Strategy Selection Process"
       - "Verification Level Definitions"
       - "Integration Point Definitions"
-      - "Anti-patterns"
+      - "Quality Checks"
       - "Guidelines for Meta-cognitive Execution"
 
   integration-e2e-testing:
@@ -131,6 +133,7 @@ skills:
       - "Test Type Definition and Limits"
       - "Behavior-First Principle"
       - "ROI Calculation"
+      - "Multi-Step User Journey Definition"
       - "Test Skeleton Specification"
       - "EARS Format Mapping"
       - "Test File Naming Convention"
@@ -147,7 +150,6 @@ skills:
       - "Conductor Pattern"
     sections:
       - "Role: The Orchestrator"
-      - "Decision Flow When Receiving Tasks"
       - "Available Subagents"
       - "Orchestration Principles"
       - "Constraints Between Subagents"
@@ -156,12 +158,10 @@ skills:
       - "How to Call Subagents"
       - "Structured Response Specification"
       - "Handling Requirement Changes"
-      - "Basic Flow for Work Planning"
+      - "Basic Flow: Planning and Implementation"
       - "Autonomous Execution Mode"
       - "Main Orchestrator Roles"
       - "Important Constraints"
-      - "Required Dialogue Points with Humans"
-      - "Action Checklist"
       - "References"
 
   # Frontend-Specific Skills

--- a/skills/testing-principles/SKILL.md
+++ b/skills/testing-principles/SKILL.md
@@ -238,7 +238,7 @@ The appropriate approach depends on project environment and CI/CD capabilities.
 - AI-generated data access code has heightened schema hallucination risk
 - Generated queries may use correct syntax but reference nonexistent schema elements
 - Mock-based tests pass regardless of schema accuracy
-- Mitigation: Design Docs should include explicit schema references; code-verifier reverse coverage verifies data operations against documented schemas
+- Mitigation: Design Docs should include explicit schema references so that documented schemas can be cross-checked against data access code during review
 
 ## Test Quality Practices
 


### PR DESCRIPTION
## Summary

Strengthen subagent prompts so that each contract (output protocol, gates, scope, file boundaries, intermediate state) is unambiguous and model-independent. Removes vague phrases, redundant output instructions, and heading drift that previously left execution open to interpretation.

## Highlights

- **Output Protocol**: every JSON-returning agent now requires a single raw JSON object (no code fence, no surrounding prose) as the final message.
- **task-executor / task-executor-frontend**: Phase Entry Gate is limited to true preconditions; Step 1 / Step 2 / Exit gates take over mid-flow checks. File Scope Constraint and Out-of-Scope Escalation (2-5) added, with the allowed list aligned to the actual task-template fields (`Target Files`, task file, work plan, `Provides:`).
- **security-reviewer**: introduces `suspected_risk`, downgrades uncertain findings instead of discarding them, and routes them through Status Determination and the Quality Checklist.
- **technical-designer / -frontend**: explicit Gate 0/1/2/3 ordering with inline annotations on every subsection, and physical subsection order rearranged to match Gate order.
- **subagents-orchestration-guide**: Basic Flow split into a Planning flow and a separate task execution cycle; placeholder substitution rule and context isolation contract made explicit; `direct implementation` removed in favor of routing through `task-executor` even at Small scale.
- **Recipes**: collapsed the CRITICAL/MANDATORY/ALWAYS suffix block into a short positive Subagent Prompt Suffix across all 16 recipes.
- **Investigation Notes**: agents now append observations to the task file's `## Investigation Notes` section (added to task-template), so intermediate state is contractually persisted.
- **quality-fixer / -frontend**: Step 1 stub-detection scope is now `filesModified` (primary) with `git diff HEAD` as fallback, preventing cross-task false positives.
- **skills-index.yaml**: refreshed to match the actual sections of each SKILL.md (resolves several pre-existing drifts beyond this branch's renames).
- **Version**: bumped to **0.16.17** across `package.json`, marketplace, and all three plugin manifests.

## Notes

- Plugin subdirectories (`dev-workflows/`, `dev-workflows-frontend/`, `dev-skills/`) are regenerated via `pnpm sync`. `sync:check` passes.
- All edits are scoped to canonical sources under `agents/` and `skills/`; plugin subdirectories follow the existing single-source-of-truth pattern.

## Test plan

- [ ] `pnpm sync:check` passes (verified locally).
- [ ] Spot-check a representative subagent invocation (`task-executor`, `quality-fixer`, `code-reviewer`) to confirm raw-JSON output and gate behavior.
- [ ] Verify a recipe-orchestrated flow (`recipe-implement` or `recipe-design`) executes through to completion without falling back to orchestrator-direct edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)