### PR TITLE
refactor: start design recipes from codebase analysis instead of requirement-analyzer

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "dev-workflows",
       "source": "./dev-workflows",
       "strict": true,
-      "version": "0.19.2",
+      "version": "0.19.3",
       "description": "Skills + Subagents for backend development - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
       "author": {
         "name": "Shinsuke Kagawa",
@@ -83,7 +83,7 @@
       "name": "dev-workflows-frontend",
       "source": "./dev-workflows-frontend",
       "strict": true,
-      "version": "0.19.2",
+      "version": "0.19.3",
       "description": "Skills + Subagents for React/TypeScript - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
       "author": {
         "name": "Shinsuke Kagawa",
@@ -154,7 +154,7 @@
       "name": "dev-workflows-fullstack",
       "source": "./dev-workflows-fullstack",
       "strict": true,
-      "version": "0.19.2",
+      "version": "0.19.3",
       "description": "Skills + Subagents for fullstack development (backend + React/TypeScript) - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
       "author": {
         "name": "Shinsuke Kagawa",
@@ -242,7 +242,7 @@
       "name": "dev-skills",
       "source": "./dev-skills",
       "strict": true,
-      "version": "0.19.2",
+      "version": "0.19.3",
       "description": "Lightweight skills for users with existing workflows - coding best practices, testing principles, and design guidelines without recipe workflows or agents",
       "author": {
         "name": "Shinsuke Kagawa",

--- a/dev-skills/.claude-plugin/plugin.json
+++ b/dev-skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-skills",
   "description": "Lightweight skills for users with existing workflows - coding best practices, testing principles, and design guidelines without recipe workflows or agents",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows-frontend/.claude-plugin/plugin.json
+++ b/dev-workflows-frontend/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflows-frontend",
   "description": "Skills + Subagents for React/TypeScript - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows-frontend/skills/recipe-front-design/SKILL.md
+++ b/dev-workflows-frontend/skills/recipe-front-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: recipe-front-design
-description: Execute from requirement analysis to frontend design document creation
+description: Execute from codebase analysis to frontend design document creation
 disable-model-invocation: true
 ---
 
@@ -11,38 +11,43 @@ disable-model-invocation: true
 **Core Identity**: "I am an orchestrator." (see subagents-orchestration-guide skill)
 
 **Execution Protocol**:
-1. **Delegate all work** to sub-agents — your role is to invoke sub-agents, pass data between them, and report results
-2. **Follow subagents-orchestration-guide skill design flow** (this recipe covers medium/large frontend; refer to the guide for scale-specific variations):
-   - Execute: requirement-analyzer → external resource hearing → codebase-analyzer + ui-analyzer (parallel) → ui-spec-designer → technical-designer-frontend → code-verifier → document-reviewer → design-sync
+1. **Delegate all work** to sub-agents — your role is to invoke sub-agents, pass data between them, and report results. The one exception is the Step 1 scope bootstrap, a recipe-local orchestrator task limited to locating seed files.
+2. **Run the frontend design flow below in order** (this recipe covers medium/large frontend):
+   - Execute: scope bootstrap → codebase-analyzer → [Stop: Scope confirmation] → external resource hearing → ui-analyzer → ui-spec-designer → technical-designer-frontend → code-verifier → document-reviewer → design-sync
+   - ui-spec-designer, code-verifier, and design-sync apply when the design output is a Design Doc; all are skipped for ADR-only
    - **Stop at every `[Stop: ...]` marker** → Wait for user approval before proceeding
 3. **Scope**: Complete when design documents receive approval
 
-**CRITICAL**: Execute document-reviewer, design-sync, and all stopping points defined in subagents-orchestration-guide skill flows — each serves as a quality gate. Skipping any step risks undetected inconsistencies.
+**subagents-orchestration-guide usage**: Reference the guide only for orchestration principles (Delegation Boundary, Decision precedence, permitted tools), the Scale Determination table, and handoff contracts HC-02 onward. This recipe defines its own start order and subagent prompts. The guide's requirement-analyzer-origin flow, First Action Rule, HC-01, and Call Examples do not apply to this recipe.
+
+**CRITICAL**: Execute document-reviewer, design-sync (for Design Docs), and all stopping points — each serves as a quality gate. Skipping any step risks undetected inconsistencies.
 
 ## Workflow Overview
 
 ```
-Requirements → requirement-analyzer → [Stop: Scale determination]
-                                           ↓
-                          external resource hearing (frontend domain)
-                                           ↓
-                          codebase-analyzer + ui-analyzer (parallel)
-                                           ↓
-                                   ui-spec-designer → [Stop: UI Spec approval]
-                                           ↓
-                                   technical-designer-frontend
-                                           ↓
-                                   code-verifier → document-reviewer
-                                           ↓
-                                      design-sync → [Stop: Design approval]
+Requirements → scope bootstrap → codebase-analyzer → [Stop: Scope confirmation]
+                                                            ↓
+                                          external resource hearing (frontend domain)
+                                                            ↓
+                                                       ui-analyzer
+                                                            ↓
+                                              ui-spec-designer → [Stop: UI Spec approval]
+                                                            ↓
+                                              technical-designer-frontend
+                                                            ↓
+                                              code-verifier → document-reviewer
+                                                            ↓
+                                                 design-sync → [Stop: Design approval]
 ```
 
 ## Scope Boundaries
 
 **Included in this skill**:
-- Requirement analysis with requirement-analyzer
+- Scope bootstrap: locating seed files so codebase-analyzer receives a populated input
+- Codebase analysis with codebase-analyzer (entry point of the frontend design phase)
+- Scope confirmation with the user, grounded in codebase-analyzer findings
 - External resource hearing per the external-resource-context skill
-- Codebase analysis with codebase-analyzer and ui-analyzer in parallel (before document creation)
+- UI fact gathering with ui-analyzer
 - UI Specification creation with ui-spec-designer (prototype code inquiry included)
 - ADR creation (if architecture changes, new technology, or data flow changes)
 - Design Doc creation with technical-designer-frontend
@@ -52,39 +57,67 @@ Requirements → requirement-analyzer → [Stop: Scale determination]
 
 **Responsibility Boundary**: This skill completes with frontend design document (UI Spec/ADR/Design Doc) approval. Work planning and beyond are outside scope.
 
-Requirements: $ARGUMENTS
-
 ## Execution Flow
 
-### Step 1: Requirement Analysis Phase
-Considering the deep impact on design, first engage in dialogue to understand the background and purpose of requirements:
-- What problems do you want to solve?
-- Expected outcomes and success criteria
-- Relationship with existing systems
+Requirements: $ARGUMENTS
 
-Once the user has answered the three dialogue questions above, execute the process below within design scope. Follow subagents-orchestration-guide Call Examples for codebase-analyzer, ui-analyzer, and code-verifier invocations.
+### Step 1: Scope Bootstrap
+codebase-analyzer requires a populated `requirement_analysis.affectedFiles`. Build that seed with a lightweight, orchestrator-local pass — locating files only, with no deep reading and no design decisions:
 
-- Invoke **requirement-analyzer** using Agent tool
-  - `subagent_type: "dev-workflows-frontend:requirement-analyzer"`
-  - `description: "Requirement analysis"`
-  - `prompt: "Requirements: [user requirements] Execute requirement analysis and scale determination"`
-- **[STOP]**: Review requirement analysis results and address question items
+1. Extract candidate keywords from the user requirements (feature names, domain nouns, identifiers).
+2. Search the repository with Bash (`rg`, or `grep` when `rg` is unavailable) for files matching those keywords.
+3. Collect the matched file paths as the seed `affectedFiles`.
+4. **When the search returns no files**: ask the user which files or modules the design targets (AskUserQuestion), and use that answer as `affectedFiles` before invoking codebase-analyzer. If the user confirms no related code exists, report that codebase-grounded design does not apply and confirm with the user how to proceed.
+5. **When the search returns more than ~20 files**: the keywords are too broad for a focused design scope. Present the most relevant candidates to the user (AskUserQuestion) and confirm the seed `affectedFiles` before invoking codebase-analyzer.
 
-### Step 1.5: External Resource Hearing
-Run the hearing protocol per the external-resource-context skill (frontend domain). The orchestrator owns this step because it requires AskUserQuestion. The skill defines file-existence branching, two-phase hearing (structured axes + self-declaration), and persistence to `docs/project-context/external-resources.md`.
+This step locates seed files only. Reading files in full, tracing dependencies, and analysis remain codebase-analyzer's responsibility.
 
-### Step 2: UI Fact Gathering
-Invoke codebase-analyzer and ui-analyzer **in parallel** (single message with two Agent tool calls). They share input but produce complementary output. ui-analyzer reads the project-tier external-resources file and fetches external UI sources via the inherited MCP/URL access methods, then analyzes the UI codebase. codebase-analyzer covers data, contracts, dependencies, and quality assurance mechanisms.
+### Step 2: Codebase Analysis
+Invoke codebase-analyzer with its existing schema. The orchestrator constructs `requirement_analysis` from the Step 1 seed.
 
 - Invoke **codebase-analyzer** using Agent tool
-  - `subagent_type: "dev-workflows-frontend:codebase-analyzer"`, `description: "Codebase analysis"`, `prompt: "requirement_analysis: [JSON from Step 1]. requirements: [user requirements]. Analyze existing codebase for frontend design guidance (data, contracts, dependencies, quality assurance mechanisms)."`
-- Invoke **ui-analyzer** using Agent tool (parallel with the call above)
-  - `subagent_type: "dev-workflows-frontend:ui-analyzer"`, `description: "UI fact gathering"`, `prompt: "requirement_analysis: [JSON from Step 1]. requirements: [user requirements]. Read docs/project-context/external-resources.md, fetch external UI sources via the declared access methods, and analyze the existing UI codebase."`
+  - `subagent_type: "dev-workflows-frontend:codebase-analyzer"`, `description: "Codebase analysis"`
+  - `prompt`: include
+    - `requirements`: the user requirements verbatim
+    - `requirement_analysis`: a JSON object with all four fields — `affectedFiles` (Step 1 seed), `purpose` (the user requirements), `scale` (provisional value from the Scale Determination table applied to the seed file count), `technicalConsiderations` (`{ constraints: [], risks: [], dependencies: [] }` — the bootstrap performs no analysis, so the object is present with empty lists)
+    - Expected action: analyze the seed files for frontend design guidance (data, contracts, dependencies, quality assurance mechanisms)
 
-Both outputs (codebase-analyzer JSON and ui-analyzer JSON) are reused by ui-spec-designer in Step 3 and by technical-designer-frontend in Step 4.
+### Step 3: Scope Confirmation
+After codebase-analyzer returns, confirm the design scope with the user before any design work. This is a recipe-local confirmation step. Use AskUserQuestion.
 
-### Step 3: UI Specification Phase
-After Step 2 outputs are received, ask the user about prototype code:
+Present, sourced from the codebase-analyzer JSON:
+- **Target files/modules**: `analysisScope.filesAnalyzed` and the modules they belong to
+- **Affected layers**: layers touched, derived from `analysisScope.categoriesDetected` and `focusAreas`
+- **Unknowns/assumptions**: `limitations` plus any assumptions codebase-analyzer recorded
+- **Questions before design**: open points that need a user answer before design proceeds
+
+Ask the user to choose one:
+- **Proceed to design with this scope** — continue to Step 4
+- **Correct the scope and re-run** — return to Step 1 with the corrected scope; when the user names the corrected files or modules, use those directly as the Step 1 seed instead of re-deriving them by search
+- **Hold additional hearing, then proceed** — gather the missing answers, then continue to Step 4
+- **Produce an ADR** — when the confirmed scope involves architecture changes, new technology, or data flow changes, continue through the flow with an ADR as the design document; Step 6 (UI Specification) is skipped for ADR
+
+After the user confirms the scope, count the confirmed target files and set the scale from the subagents-orchestration-guide Scale Determination table. This confirmed scale supersedes the Step 2 provisional value and determines the design document.
+
+**[STOP]**: Wait for the user's choice before proceeding.
+
+### Step 4: External Resource Hearing
+Run the hearing protocol per the external-resource-context skill (frontend domain). The orchestrator owns this step because it requires AskUserQuestion. The skill defines file-existence branching, two-phase hearing (structured axes + self-declaration), and persistence to `docs/project-context/external-resources.md`.
+
+### Step 5: UI Fact Gathering
+Invoke ui-analyzer to gather UI facts. It reads the project-tier external-resources file, fetches external UI sources via the inherited MCP/URL access methods, then analyzes the UI codebase. Its output complements the codebase-analyzer output from Step 2 (data, contracts, dependencies, quality assurance mechanisms).
+
+- Invoke **ui-analyzer** using Agent tool
+  - `subagent_type: "dev-workflows-frontend:ui-analyzer"`, `description: "UI fact gathering"`
+  - `prompt`: include
+    - `requirements`: the user requirements
+    - `requirement_analysis`: a JSON object with all four fields — `affectedFiles` (`analysisScope.filesAnalyzed` from Step 2 codebase-analyzer), `purpose` (the user requirements), `scale` (the Step 3 confirmed scale), `technicalConsiderations` (`{ constraints: [], risks: [], dependencies: [] }`)
+    - Expected action: read `docs/project-context/external-resources.md`, fetch external UI sources via the declared access methods, and analyze the existing UI codebase
+
+Both outputs (codebase-analyzer JSON from Step 2 and ui-analyzer JSON from Step 5) are reused by ui-spec-designer in Step 6 and by technical-designer-frontend in Step 7.
+
+### Step 6: UI Specification Phase
+**When the design document is a Design Doc** (this step is skipped for ADR-only): after Step 5 output is received, ask the user about prototype code:
 
 **Ask the user**: "Do you have prototype code for this feature? If so, please provide the path to the code. The prototype will be placed in `docs/ui-spec/assets/` as reference material for the UI Spec."
 
@@ -95,39 +128,42 @@ Then create the UI Specification:
   - `subagent_type: "dev-workflows-frontend:ui-spec-designer"`
   - `description: "UI Spec creation"`
   - Build the prompt by including:
-    - Source: PRD path (Large scale) or requirement-analyzer output (Medium scale)
-    - `ui_analysis`: ui-analyzer JSON from Step 2 (includes externalResources fetched_summary and componentStructure / propsPatterns / cssLayout / etc.)
+    - Source: an existing PRD in `docs/prd/` when one exists for this feature; otherwise the user requirements with the Step 2 codebase-analyzer JSON and the Step 3 confirmed scope
+    - `ui_analysis`: ui-analyzer JSON from Step 5 (includes externalResources fetched_summary and componentStructure / propsPatterns / cssLayout / etc.)
     - Prototype path when provided
-  - Example: `prompt: "Create UI Spec from PRD at [path]. ui_analysis: [JSON from Step 2 ui-analyzer]. Prototype code is at [user-provided path]. Place prototype in docs/ui-spec/assets/{feature-name}/."`
+  - Example (existing PRD): `prompt: "Create UI Spec from PRD at [path]. ui_analysis: [JSON from Step 5 ui-analyzer]. Prototype code is at [user-provided path]. Place prototype in docs/ui-spec/assets/{feature-name}/."`
+  - Example (no PRD): `prompt: "Create UI Spec from these requirements: [user requirements verbatim]. Codebase analysis: [codebase-analyzer JSON from Step 2]. Confirmed scope: [Step 3 confirmed scope]. ui_analysis: [JSON from Step 5 ui-analyzer]. Prototype code is at [user-provided path]. Place prototype in docs/ui-spec/assets/{feature-name}/."`
 - Invoke **document-reviewer** to verify UI Spec
   - `subagent_type: "dev-workflows-frontend:document-reviewer"`, `description: "UI Spec review"`, `prompt: "doc_type: UISpec target: [ui-spec path] Review for consistency and completeness"`
 - **[STOP]**: Present UI Spec for user approval
 
-### Step 4: Design Document Creation Phase
-Create appropriate design documents according to scale determination. technical-designer-frontend presents at least two architecture alternatives (technology selection, data flow design) with trade-offs for each. Pass both Step 2 outputs:
+### Step 7: Design Document Creation Phase
+technical-designer-frontend presents at least two architecture alternatives (technology selection, data flow design) with trade-offs for each. Pass the Step 2 codebase-analyzer output and the Step 5 ui-analyzer output:
 - Invoke **technical-designer-frontend** using Agent tool
-  - For ADR: `subagent_type: "dev-workflows-frontend:technical-designer-frontend"`, `description: "ADR creation"`, `prompt: "Create ADR for [technical decision]. Present at least two alternatives with trade-offs."`
-  - For Design Doc: `subagent_type: "dev-workflows-frontend:technical-designer-frontend"`, `description: "Design Doc creation"`, `prompt: "Create Design Doc based on requirements. Codebase analysis: [codebase-analyzer JSON from Step 2]. UI analysis: [ui-analyzer JSON from Step 2]. UI Spec is at [ui-spec path]. Inherit component structure and state design from UI Spec. Apply code: prefix to codebase-analyzer fact_ids and ui: prefix to ui-analyzer fact_ids when filling the Fact Disposition Table. Present at least two architecture alternatives with trade-offs."`
+  - For ADR: `subagent_type: "dev-workflows-frontend:technical-designer-frontend"`, `description: "ADR creation"`, `prompt: "Create ADR for [technical decision]. Requirements: [user requirements verbatim]. Codebase analysis: [codebase-analyzer JSON from Step 2]. UI analysis: [ui-analyzer JSON from Step 5]. Confirmed scope: [Step 3 confirmed scope]. Present at least two alternatives with trade-offs."`
+  - For Design Doc: `subagent_type: "dev-workflows-frontend:technical-designer-frontend"`, `description: "Design Doc creation"`, `prompt: "Create Design Doc based on the requirements. Requirements: [user requirements verbatim]. Codebase analysis: [codebase-analyzer JSON from Step 2]. UI analysis: [ui-analyzer JSON from Step 5]. UI Spec is at [ui-spec path]. Inherit component structure and state design from UI Spec. Apply code: prefix to codebase-analyzer fact_ids and ui: prefix to ui-analyzer fact_ids when filling the Fact Disposition Table. Present at least two architecture alternatives with trade-offs."`
 - **(Design Doc only)** Invoke **code-verifier** to verify Design Doc against existing code. Skip for ADR.
   - `subagent_type: "dev-workflows-frontend:code-verifier"`, `description: "Design Doc verification"`, `prompt: "doc_type: design-doc document_path: [Design Doc path] Verify Design Doc against existing code."`
 - Invoke **document-reviewer** to verify consistency (pass code-verifier results for Design Doc; omit for ADR)
-  - `subagent_type: "dev-workflows-frontend:document-reviewer"`, `description: "Document review"`, `prompt: "Review [document path] for consistency and completeness. code_verification: [code verification output from this step] (Design Doc only)"`
+  - `subagent_type: "dev-workflows-frontend:document-reviewer"`, `description: "Document review"`, `prompt: "Review [document path] for consistency and completeness. codebase_analysis: [codebase-analyzer JSON from Step 2]. ui_analysis: [ui-analyzer JSON from Step 5]. code_verification: [code verification output from this step] (Design Doc only)"`
 
-### Step 5: Design Consistency Verification
-- Invoke **design-sync** using Agent tool
+### Step 8: Design Consistency Verification
+- **(Design Doc only)** Invoke **design-sync** using Agent tool. Skip for ADR-only.
   - `subagent_type: "dev-workflows-frontend:design-sync"`, `description: "Design consistency check"`, `prompt: "Check consistency across all Design Docs in docs/design/. Report conflicts and overlaps."`
-- **[STOP]**: Present design documents and design-sync results, obtain user approval
+- **[STOP]**: Present the design document, plus design-sync results for a Design Doc, and obtain user approval
 
 ## Completion Criteria
 
-- [ ] Executed requirement-analyzer and determined scale
+- [ ] Built the Step 1 scope bootstrap seed (or obtained target files from the user when the search returned none)
+- [ ] Executed codebase-analyzer with a populated `requirement_analysis`
+- [ ] Confirmed the design scope with the user and set the scale from the confirmed target files
 - [ ] Executed external resource hearing per the external-resource-context skill (file written or update explicitly skipped by user)
-- [ ] Executed codebase-analyzer and ui-analyzer in parallel; outputs reused by ui-spec-designer and technical-designer-frontend
+- [ ] Executed ui-analyzer; codebase-analyzer (Step 2) and ui-analyzer (Step 5) outputs reused by ui-spec-designer and technical-designer-frontend
 - [ ] Created UI Specification with ui-spec-designer (when applicable) — its External Resources Used section is filled
 - [ ] Created appropriate design document (ADR or Design Doc) with technical-designer-frontend — its External Resources Used subsection is filled when present
 - [ ] Executed code-verifier on Design Doc and passed results to document-reviewer (skip for ADR-only)
 - [ ] Executed document-reviewer and addressed feedback
-- [ ] Executed design-sync for consistency verification
+- [ ] Executed design-sync for consistency verification (skip for ADR-only)
 - [ ] Obtained user approval for design document
 
 ## Output Example

--- a/dev-workflows-fullstack/.claude-plugin/plugin.json
+++ b/dev-workflows-fullstack/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflows-fullstack",
   "description": "Skills + Subagents for fullstack development (backend + React/TypeScript) - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows-fullstack/skills/recipe-design/SKILL.md
+++ b/dev-workflows-fullstack/skills/recipe-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: recipe-design
-description: Execute from requirement analysis to design document creation
+description: Execute from codebase analysis to design document creation
 disable-model-invocation: true
 ---
 
@@ -11,31 +11,35 @@ disable-model-invocation: true
 **Core Identity**: "I am an orchestrator." (see subagents-orchestration-guide skill)
 
 **Execution Protocol**:
-1. **Delegate all work** to sub-agents — your role is to invoke sub-agents, pass data between them, and report results
-2. **Follow subagents-orchestration-guide skill design flow exactly**:
-   - Execute: requirement-analyzer → codebase-analyzer → technical-designer → code-verifier → document-reviewer → design-sync
+1. **Delegate all work** to sub-agents — your role is to invoke sub-agents, pass data between them, and report results. The one exception is the Step 1 scope bootstrap, a recipe-local orchestrator task limited to locating seed files.
+2. **Run the design flow below in order**:
+   - Execute: scope bootstrap → codebase-analyzer → [Stop: Scope confirmation] → technical-designer → code-verifier → document-reviewer → design-sync
+   - code-verifier and design-sync apply when the design output is a Design Doc; both are skipped for ADR-only
    - **Stop at every `[Stop: ...]` marker** → Wait for user approval before proceeding
 3. **Scope**: Complete when design documents receive approval
 
-**CRITICAL**: Execute document-reviewer, design-sync, and all stopping points defined in subagents-orchestration-guide skill flows — each serves as a quality gate. Skipping any step risks undetected inconsistencies.
+**subagents-orchestration-guide usage**: Reference the guide only for orchestration principles (Delegation Boundary, Decision precedence, permitted tools), the Scale Determination table, and handoff contracts HC-02 onward. This recipe defines its own start order and subagent prompts. The guide's requirement-analyzer-origin flow, First Action Rule, HC-01, and Call Examples do not apply to this recipe.
+
+**CRITICAL**: Execute document-reviewer, design-sync (for Design Docs), and all stopping points — each serves as a quality gate. Skipping any step risks undetected inconsistencies.
 
 ## Workflow Overview
 
 ```
-Requirements → requirement-analyzer → [Stop: Scale determination]
-                                           ↓
-                                   codebase-analyzer → technical-designer
-                                           ↓
-                                   code-verifier → document-reviewer
-                                           ↓
-                                      design-sync → [Stop: Design approval]
+Requirements → scope bootstrap → codebase-analyzer → [Stop: Scope confirmation]
+                                                            ↓
+                                                    technical-designer
+                                                            ↓
+                                                    code-verifier → document-reviewer
+                                                            ↓
+                                                       design-sync → [Stop: Design approval]
 ```
 
 ## Scope Boundaries
 
 **Included in this skill**:
-- Requirement analysis with requirement-analyzer
-- Codebase analysis with codebase-analyzer (before technical design)
+- Scope bootstrap: locating seed files so codebase-analyzer receives a populated input
+- Codebase analysis with codebase-analyzer (entry point of the design phase)
+- Scope confirmation with the user, grounded in codebase-analyzer findings
 - ADR creation (if architecture changes, new technology, or data flow changes)
 - Design Doc creation with technical-designer
 - Design Doc verification with code-verifier (before document review)
@@ -44,32 +48,77 @@ Requirements → requirement-analyzer → [Stop: Scale determination]
 
 **Responsibility Boundary**: This skill completes with design document (ADR/Design Doc) approval. Work planning and beyond are outside scope.
 
+## Execution Flow
+
 Requirements: $ARGUMENTS
 
-Considering the deep impact on design, first engage in dialogue to understand the background and purpose of requirements:
-- What problems do you want to solve?
-- Expected outcomes and success criteria
-- Relationship with existing systems
+### Step 1: Scope Bootstrap
+codebase-analyzer requires a populated `requirement_analysis.affectedFiles`. Build that seed with a lightweight, orchestrator-local pass — locating files only, with no deep reading and no design decisions:
 
-Once the user has answered the three dialogue questions above, analyze with requirement-analyzer and create appropriate design documents according to scale.
+1. Extract candidate keywords from the user requirements (feature names, domain nouns, identifiers).
+2. Search the repository with Bash (`rg`, or `grep` when `rg` is unavailable) for files matching those keywords.
+3. Collect the matched file paths as the seed `affectedFiles`.
+4. **When the search returns no files**: ask the user which files or modules the design targets (AskUserQuestion), and use that answer as `affectedFiles` before invoking codebase-analyzer. If the user confirms no related code exists, report that codebase-grounded design does not apply and confirm with the user how to proceed.
+5. **When the search returns more than ~20 files**: the keywords are too broad for a focused design scope. Present the most relevant candidates to the user (AskUserQuestion) and confirm the seed `affectedFiles` before invoking codebase-analyzer.
 
-Present at least two design alternatives with trade-offs for each.
+This step locates seed files only. Reading files in full, tracing dependencies, and analysis remain codebase-analyzer's responsibility.
 
-Execute the process below within design scope. Follow subagents-orchestration-guide Call Examples for codebase-analyzer and code-verifier invocations.
+### Step 2: Codebase Analysis
+Invoke codebase-analyzer with its existing schema. The orchestrator constructs `requirement_analysis` from the Step 1 seed.
+
+- Invoke **codebase-analyzer** using Agent tool
+  - `subagent_type: "dev-workflows-fullstack:codebase-analyzer"`, `description: "Codebase analysis"`
+  - `prompt`: include
+    - `requirements`: the user requirements verbatim
+    - `requirement_analysis`: a JSON object with all four fields — `affectedFiles` (Step 1 seed), `purpose` (the user requirements), `scale` (provisional value from the Scale Determination table applied to the seed file count), `technicalConsiderations` (`{ constraints: [], risks: [], dependencies: [] }` — the bootstrap performs no analysis, so the object is present with empty lists)
+    - Expected action: analyze the seed files and produce design guidance
+
+### Step 3: Scope Confirmation
+After codebase-analyzer returns, confirm the design scope with the user before any design work. This is a recipe-local confirmation step. Use AskUserQuestion.
+
+Present, sourced from the codebase-analyzer JSON:
+- **Target files/modules**: `analysisScope.filesAnalyzed` and the modules they belong to
+- **Affected layers**: layers touched, derived from `analysisScope.categoriesDetected` and `focusAreas`
+- **Unknowns/assumptions**: `limitations` plus any assumptions codebase-analyzer recorded
+- **Questions before design**: open points that need a user answer before design proceeds
+
+Ask the user to choose one:
+- **Proceed to design with this scope** — continue to Step 4 (Design Doc)
+- **Correct the scope and re-run** — return to Step 1 with the corrected scope; when the user names the corrected files or modules, use those directly as the Step 1 seed instead of re-deriving them by search
+- **Hold additional hearing, then proceed** — gather the missing answers, then continue to Step 4
+- **Produce an ADR** — when the confirmed scope involves architecture changes, new technology, or data flow changes, continue to Step 4 with technical-designer in ADR mode
+
+After the user confirms the scope, count the confirmed target files and set the scale from the subagents-orchestration-guide Scale Determination table. This confirmed scale supersedes the Step 2 provisional value and determines the design document.
+
+**[STOP]**: Wait for the user's choice before proceeding.
+
+### Step 4: Design Document Creation
+Pass the full codebase-analyzer JSON to technical-designer (handoff contract HC-02). technical-designer presents at least two design alternatives with trade-offs for each.
+
+- Invoke **technical-designer** using Agent tool
+  - For Design Doc: `subagent_type: "dev-workflows-fullstack:technical-designer"`, `description: "Design Doc creation"`, `prompt: "Create Design Doc based on the requirements. Requirements: [user requirements verbatim]. Codebase analysis: [codebase-analyzer JSON from Step 2]. Confirmed scope: [Step 3 confirmed scope]. Apply the code: prefix to codebase-analyzer fact_ids when filling the Fact Disposition Table. Present at least two architecture alternatives with trade-offs."`
+  - For ADR: `subagent_type: "dev-workflows-fullstack:technical-designer"`, `description: "ADR creation"`, `prompt: "Create ADR for [technical decision]. Requirements: [user requirements verbatim]. Codebase analysis: [codebase-analyzer JSON from Step 2]. Confirmed scope: [Step 3 confirmed scope]. Present at least two alternatives with trade-offs."`
+- **(Design Doc only)** Invoke **code-verifier** to verify the Design Doc against existing code. Skip for ADR.
+  - `subagent_type: "dev-workflows-fullstack:code-verifier"`, `description: "Design Doc verification"`, `prompt: "doc_type: design-doc document_path: [Design Doc path] Verify Design Doc against existing code."`
+- Invoke **document-reviewer** to verify consistency (pass code-verifier results for Design Doc; omit for ADR)
+  - `subagent_type: "dev-workflows-fullstack:document-reviewer"`, `description: "Document review"`, `prompt: "Review [document path] for consistency and completeness. codebase_analysis: [codebase-analyzer JSON from Step 2]. code_verification: [code-verifier output from this step] (Design Doc only)"`
+- **(Design Doc only)** Invoke **design-sync** to verify consistency across design documents. Skip for ADR-only.
+  - `subagent_type: "dev-workflows-fullstack:design-sync"`, `description: "Design consistency check"`, `prompt: "Check consistency across all Design Docs in docs/design/. Report conflicts and overlaps."`
+
+**[STOP]**: Present the design document, plus design-sync results for a Design Doc, and obtain user approval.
 
 ## Completion Criteria
 
-- [ ] Executed requirement-analyzer and determined scale
-- [ ] Executed codebase-analyzer and passed results to technical-designer
+- [ ] Built the Step 1 scope bootstrap seed (or obtained target files from the user when the search returned none)
+- [ ] Executed codebase-analyzer with a populated `requirement_analysis`
+- [ ] Confirmed the design scope with the user and set the scale from the confirmed target files
 - [ ] Created appropriate design document (ADR or Design Doc) with technical-designer
 - [ ] Executed code-verifier on Design Doc and passed results to document-reviewer (skip for ADR-only)
 - [ ] Executed document-reviewer and addressed feedback
-- [ ] Executed design-sync for consistency verification
+- [ ] Executed design-sync for consistency verification (skip for ADR-only)
 - [ ] Obtained user approval for design document
 
 ## Output Example
 Design phase completed.
 - Design document: docs/design/[document-name].md or docs/adr/[document-name].md
 - Approval status: User approved
-
-

--- a/dev-workflows-fullstack/skills/recipe-front-design/SKILL.md
+++ b/dev-workflows-fullstack/skills/recipe-front-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: recipe-front-design
-description: Execute from requirement analysis to frontend design document creation
+description: Execute from codebase analysis to frontend design document creation
 disable-model-invocation: true
 ---
 
@@ -11,38 +11,43 @@ disable-model-invocation: true
 **Core Identity**: "I am an orchestrator." (see subagents-orchestration-guide skill)
 
 **Execution Protocol**:
-1. **Delegate all work** to sub-agents — your role is to invoke sub-agents, pass data between them, and report results
-2. **Follow subagents-orchestration-guide skill design flow** (this recipe covers medium/large frontend; refer to the guide for scale-specific variations):
-   - Execute: requirement-analyzer → external resource hearing → codebase-analyzer + ui-analyzer (parallel) → ui-spec-designer → technical-designer-frontend → code-verifier → document-reviewer → design-sync
+1. **Delegate all work** to sub-agents — your role is to invoke sub-agents, pass data between them, and report results. The one exception is the Step 1 scope bootstrap, a recipe-local orchestrator task limited to locating seed files.
+2. **Run the frontend design flow below in order** (this recipe covers medium/large frontend):
+   - Execute: scope bootstrap → codebase-analyzer → [Stop: Scope confirmation] → external resource hearing → ui-analyzer → ui-spec-designer → technical-designer-frontend → code-verifier → document-reviewer → design-sync
+   - ui-spec-designer, code-verifier, and design-sync apply when the design output is a Design Doc; all are skipped for ADR-only
    - **Stop at every `[Stop: ...]` marker** → Wait for user approval before proceeding
 3. **Scope**: Complete when design documents receive approval
 
-**CRITICAL**: Execute document-reviewer, design-sync, and all stopping points defined in subagents-orchestration-guide skill flows — each serves as a quality gate. Skipping any step risks undetected inconsistencies.
+**subagents-orchestration-guide usage**: Reference the guide only for orchestration principles (Delegation Boundary, Decision precedence, permitted tools), the Scale Determination table, and handoff contracts HC-02 onward. This recipe defines its own start order and subagent prompts. The guide's requirement-analyzer-origin flow, First Action Rule, HC-01, and Call Examples do not apply to this recipe.
+
+**CRITICAL**: Execute document-reviewer, design-sync (for Design Docs), and all stopping points — each serves as a quality gate. Skipping any step risks undetected inconsistencies.
 
 ## Workflow Overview
 
 ```
-Requirements → requirement-analyzer → [Stop: Scale determination]
-                                           ↓
-                          external resource hearing (frontend domain)
-                                           ↓
-                          codebase-analyzer + ui-analyzer (parallel)
-                                           ↓
-                                   ui-spec-designer → [Stop: UI Spec approval]
-                                           ↓
-                                   technical-designer-frontend
-                                           ↓
-                                   code-verifier → document-reviewer
-                                           ↓
-                                      design-sync → [Stop: Design approval]
+Requirements → scope bootstrap → codebase-analyzer → [Stop: Scope confirmation]
+                                                            ↓
+                                          external resource hearing (frontend domain)
+                                                            ↓
+                                                       ui-analyzer
+                                                            ↓
+                                              ui-spec-designer → [Stop: UI Spec approval]
+                                                            ↓
+                                              technical-designer-frontend
+                                                            ↓
+                                              code-verifier → document-reviewer
+                                                            ↓
+                                                 design-sync → [Stop: Design approval]
 ```
 
 ## Scope Boundaries
 
 **Included in this skill**:
-- Requirement analysis with requirement-analyzer
+- Scope bootstrap: locating seed files so codebase-analyzer receives a populated input
+- Codebase analysis with codebase-analyzer (entry point of the frontend design phase)
+- Scope confirmation with the user, grounded in codebase-analyzer findings
 - External resource hearing per the external-resource-context skill
-- Codebase analysis with codebase-analyzer and ui-analyzer in parallel (before document creation)
+- UI fact gathering with ui-analyzer
 - UI Specification creation with ui-spec-designer (prototype code inquiry included)
 - ADR creation (if architecture changes, new technology, or data flow changes)
 - Design Doc creation with technical-designer-frontend
@@ -52,39 +57,67 @@ Requirements → requirement-analyzer → [Stop: Scale determination]
 
 **Responsibility Boundary**: This skill completes with frontend design document (UI Spec/ADR/Design Doc) approval. Work planning and beyond are outside scope.
 
-Requirements: $ARGUMENTS
-
 ## Execution Flow
 
-### Step 1: Requirement Analysis Phase
-Considering the deep impact on design, first engage in dialogue to understand the background and purpose of requirements:
-- What problems do you want to solve?
-- Expected outcomes and success criteria
-- Relationship with existing systems
+Requirements: $ARGUMENTS
 
-Once the user has answered the three dialogue questions above, execute the process below within design scope. Follow subagents-orchestration-guide Call Examples for codebase-analyzer, ui-analyzer, and code-verifier invocations.
+### Step 1: Scope Bootstrap
+codebase-analyzer requires a populated `requirement_analysis.affectedFiles`. Build that seed with a lightweight, orchestrator-local pass — locating files only, with no deep reading and no design decisions:
 
-- Invoke **requirement-analyzer** using Agent tool
-  - `subagent_type: "dev-workflows-fullstack:requirement-analyzer"`
-  - `description: "Requirement analysis"`
-  - `prompt: "Requirements: [user requirements] Execute requirement analysis and scale determination"`
-- **[STOP]**: Review requirement analysis results and address question items
+1. Extract candidate keywords from the user requirements (feature names, domain nouns, identifiers).
+2. Search the repository with Bash (`rg`, or `grep` when `rg` is unavailable) for files matching those keywords.
+3. Collect the matched file paths as the seed `affectedFiles`.
+4. **When the search returns no files**: ask the user which files or modules the design targets (AskUserQuestion), and use that answer as `affectedFiles` before invoking codebase-analyzer. If the user confirms no related code exists, report that codebase-grounded design does not apply and confirm with the user how to proceed.
+5. **When the search returns more than ~20 files**: the keywords are too broad for a focused design scope. Present the most relevant candidates to the user (AskUserQuestion) and confirm the seed `affectedFiles` before invoking codebase-analyzer.
 
-### Step 1.5: External Resource Hearing
-Run the hearing protocol per the external-resource-context skill (frontend domain). The orchestrator owns this step because it requires AskUserQuestion. The skill defines file-existence branching, two-phase hearing (structured axes + self-declaration), and persistence to `docs/project-context/external-resources.md`.
+This step locates seed files only. Reading files in full, tracing dependencies, and analysis remain codebase-analyzer's responsibility.
 
-### Step 2: UI Fact Gathering
-Invoke codebase-analyzer and ui-analyzer **in parallel** (single message with two Agent tool calls). They share input but produce complementary output. ui-analyzer reads the project-tier external-resources file and fetches external UI sources via the inherited MCP/URL access methods, then analyzes the UI codebase. codebase-analyzer covers data, contracts, dependencies, and quality assurance mechanisms.
+### Step 2: Codebase Analysis
+Invoke codebase-analyzer with its existing schema. The orchestrator constructs `requirement_analysis` from the Step 1 seed.
 
 - Invoke **codebase-analyzer** using Agent tool
-  - `subagent_type: "dev-workflows-fullstack:codebase-analyzer"`, `description: "Codebase analysis"`, `prompt: "requirement_analysis: [JSON from Step 1]. requirements: [user requirements]. Analyze existing codebase for frontend design guidance (data, contracts, dependencies, quality assurance mechanisms)."`
-- Invoke **ui-analyzer** using Agent tool (parallel with the call above)
-  - `subagent_type: "dev-workflows-fullstack:ui-analyzer"`, `description: "UI fact gathering"`, `prompt: "requirement_analysis: [JSON from Step 1]. requirements: [user requirements]. Read docs/project-context/external-resources.md, fetch external UI sources via the declared access methods, and analyze the existing UI codebase."`
+  - `subagent_type: "dev-workflows-fullstack:codebase-analyzer"`, `description: "Codebase analysis"`
+  - `prompt`: include
+    - `requirements`: the user requirements verbatim
+    - `requirement_analysis`: a JSON object with all four fields — `affectedFiles` (Step 1 seed), `purpose` (the user requirements), `scale` (provisional value from the Scale Determination table applied to the seed file count), `technicalConsiderations` (`{ constraints: [], risks: [], dependencies: [] }` — the bootstrap performs no analysis, so the object is present with empty lists)
+    - Expected action: analyze the seed files for frontend design guidance (data, contracts, dependencies, quality assurance mechanisms)
 
-Both outputs (codebase-analyzer JSON and ui-analyzer JSON) are reused by ui-spec-designer in Step 3 and by technical-designer-frontend in Step 4.
+### Step 3: Scope Confirmation
+After codebase-analyzer returns, confirm the design scope with the user before any design work. This is a recipe-local confirmation step. Use AskUserQuestion.
 
-### Step 3: UI Specification Phase
-After Step 2 outputs are received, ask the user about prototype code:
+Present, sourced from the codebase-analyzer JSON:
+- **Target files/modules**: `analysisScope.filesAnalyzed` and the modules they belong to
+- **Affected layers**: layers touched, derived from `analysisScope.categoriesDetected` and `focusAreas`
+- **Unknowns/assumptions**: `limitations` plus any assumptions codebase-analyzer recorded
+- **Questions before design**: open points that need a user answer before design proceeds
+
+Ask the user to choose one:
+- **Proceed to design with this scope** — continue to Step 4
+- **Correct the scope and re-run** — return to Step 1 with the corrected scope; when the user names the corrected files or modules, use those directly as the Step 1 seed instead of re-deriving them by search
+- **Hold additional hearing, then proceed** — gather the missing answers, then continue to Step 4
+- **Produce an ADR** — when the confirmed scope involves architecture changes, new technology, or data flow changes, continue through the flow with an ADR as the design document; Step 6 (UI Specification) is skipped for ADR
+
+After the user confirms the scope, count the confirmed target files and set the scale from the subagents-orchestration-guide Scale Determination table. This confirmed scale supersedes the Step 2 provisional value and determines the design document.
+
+**[STOP]**: Wait for the user's choice before proceeding.
+
+### Step 4: External Resource Hearing
+Run the hearing protocol per the external-resource-context skill (frontend domain). The orchestrator owns this step because it requires AskUserQuestion. The skill defines file-existence branching, two-phase hearing (structured axes + self-declaration), and persistence to `docs/project-context/external-resources.md`.
+
+### Step 5: UI Fact Gathering
+Invoke ui-analyzer to gather UI facts. It reads the project-tier external-resources file, fetches external UI sources via the inherited MCP/URL access methods, then analyzes the UI codebase. Its output complements the codebase-analyzer output from Step 2 (data, contracts, dependencies, quality assurance mechanisms).
+
+- Invoke **ui-analyzer** using Agent tool
+  - `subagent_type: "dev-workflows-fullstack:ui-analyzer"`, `description: "UI fact gathering"`
+  - `prompt`: include
+    - `requirements`: the user requirements
+    - `requirement_analysis`: a JSON object with all four fields — `affectedFiles` (`analysisScope.filesAnalyzed` from Step 2 codebase-analyzer), `purpose` (the user requirements), `scale` (the Step 3 confirmed scale), `technicalConsiderations` (`{ constraints: [], risks: [], dependencies: [] }`)
+    - Expected action: read `docs/project-context/external-resources.md`, fetch external UI sources via the declared access methods, and analyze the existing UI codebase
+
+Both outputs (codebase-analyzer JSON from Step 2 and ui-analyzer JSON from Step 5) are reused by ui-spec-designer in Step 6 and by technical-designer-frontend in Step 7.
+
+### Step 6: UI Specification Phase
+**When the design document is a Design Doc** (this step is skipped for ADR-only): after Step 5 output is received, ask the user about prototype code:
 
 **Ask the user**: "Do you have prototype code for this feature? If so, please provide the path to the code. The prototype will be placed in `docs/ui-spec/assets/` as reference material for the UI Spec."
 
@@ -95,39 +128,42 @@ Then create the UI Specification:
   - `subagent_type: "dev-workflows-fullstack:ui-spec-designer"`
   - `description: "UI Spec creation"`
   - Build the prompt by including:
-    - Source: PRD path (Large scale) or requirement-analyzer output (Medium scale)
-    - `ui_analysis`: ui-analyzer JSON from Step 2 (includes externalResources fetched_summary and componentStructure / propsPatterns / cssLayout / etc.)
+    - Source: an existing PRD in `docs/prd/` when one exists for this feature; otherwise the user requirements with the Step 2 codebase-analyzer JSON and the Step 3 confirmed scope
+    - `ui_analysis`: ui-analyzer JSON from Step 5 (includes externalResources fetched_summary and componentStructure / propsPatterns / cssLayout / etc.)
     - Prototype path when provided
-  - Example: `prompt: "Create UI Spec from PRD at [path]. ui_analysis: [JSON from Step 2 ui-analyzer]. Prototype code is at [user-provided path]. Place prototype in docs/ui-spec/assets/{feature-name}/."`
+  - Example (existing PRD): `prompt: "Create UI Spec from PRD at [path]. ui_analysis: [JSON from Step 5 ui-analyzer]. Prototype code is at [user-provided path]. Place prototype in docs/ui-spec/assets/{feature-name}/."`
+  - Example (no PRD): `prompt: "Create UI Spec from these requirements: [user requirements verbatim]. Codebase analysis: [codebase-analyzer JSON from Step 2]. Confirmed scope: [Step 3 confirmed scope]. ui_analysis: [JSON from Step 5 ui-analyzer]. Prototype code is at [user-provided path]. Place prototype in docs/ui-spec/assets/{feature-name}/."`
 - Invoke **document-reviewer** to verify UI Spec
   - `subagent_type: "dev-workflows-fullstack:document-reviewer"`, `description: "UI Spec review"`, `prompt: "doc_type: UISpec target: [ui-spec path] Review for consistency and completeness"`
 - **[STOP]**: Present UI Spec for user approval
 
-### Step 4: Design Document Creation Phase
-Create appropriate design documents according to scale determination. technical-designer-frontend presents at least two architecture alternatives (technology selection, data flow design) with trade-offs for each. Pass both Step 2 outputs:
+### Step 7: Design Document Creation Phase
+technical-designer-frontend presents at least two architecture alternatives (technology selection, data flow design) with trade-offs for each. Pass the Step 2 codebase-analyzer output and the Step 5 ui-analyzer output:
 - Invoke **technical-designer-frontend** using Agent tool
-  - For ADR: `subagent_type: "dev-workflows-fullstack:technical-designer-frontend"`, `description: "ADR creation"`, `prompt: "Create ADR for [technical decision]. Present at least two alternatives with trade-offs."`
-  - For Design Doc: `subagent_type: "dev-workflows-fullstack:technical-designer-frontend"`, `description: "Design Doc creation"`, `prompt: "Create Design Doc based on requirements. Codebase analysis: [codebase-analyzer JSON from Step 2]. UI analysis: [ui-analyzer JSON from Step 2]. UI Spec is at [ui-spec path]. Inherit component structure and state design from UI Spec. Apply code: prefix to codebase-analyzer fact_ids and ui: prefix to ui-analyzer fact_ids when filling the Fact Disposition Table. Present at least two architecture alternatives with trade-offs."`
+  - For ADR: `subagent_type: "dev-workflows-fullstack:technical-designer-frontend"`, `description: "ADR creation"`, `prompt: "Create ADR for [technical decision]. Requirements: [user requirements verbatim]. Codebase analysis: [codebase-analyzer JSON from Step 2]. UI analysis: [ui-analyzer JSON from Step 5]. Confirmed scope: [Step 3 confirmed scope]. Present at least two alternatives with trade-offs."`
+  - For Design Doc: `subagent_type: "dev-workflows-fullstack:technical-designer-frontend"`, `description: "Design Doc creation"`, `prompt: "Create Design Doc based on the requirements. Requirements: [user requirements verbatim]. Codebase analysis: [codebase-analyzer JSON from Step 2]. UI analysis: [ui-analyzer JSON from Step 5]. UI Spec is at [ui-spec path]. Inherit component structure and state design from UI Spec. Apply code: prefix to codebase-analyzer fact_ids and ui: prefix to ui-analyzer fact_ids when filling the Fact Disposition Table. Present at least two architecture alternatives with trade-offs."`
 - **(Design Doc only)** Invoke **code-verifier** to verify Design Doc against existing code. Skip for ADR.
   - `subagent_type: "dev-workflows-fullstack:code-verifier"`, `description: "Design Doc verification"`, `prompt: "doc_type: design-doc document_path: [Design Doc path] Verify Design Doc against existing code."`
 - Invoke **document-reviewer** to verify consistency (pass code-verifier results for Design Doc; omit for ADR)
-  - `subagent_type: "dev-workflows-fullstack:document-reviewer"`, `description: "Document review"`, `prompt: "Review [document path] for consistency and completeness. code_verification: [code verification output from this step] (Design Doc only)"`
+  - `subagent_type: "dev-workflows-fullstack:document-reviewer"`, `description: "Document review"`, `prompt: "Review [document path] for consistency and completeness. codebase_analysis: [codebase-analyzer JSON from Step 2]. ui_analysis: [ui-analyzer JSON from Step 5]. code_verification: [code verification output from this step] (Design Doc only)"`
 
-### Step 5: Design Consistency Verification
-- Invoke **design-sync** using Agent tool
+### Step 8: Design Consistency Verification
+- **(Design Doc only)** Invoke **design-sync** using Agent tool. Skip for ADR-only.
   - `subagent_type: "dev-workflows-fullstack:design-sync"`, `description: "Design consistency check"`, `prompt: "Check consistency across all Design Docs in docs/design/. Report conflicts and overlaps."`
-- **[STOP]**: Present design documents and design-sync results, obtain user approval
+- **[STOP]**: Present the design document, plus design-sync results for a Design Doc, and obtain user approval
 
 ## Completion Criteria
 
-- [ ] Executed requirement-analyzer and determined scale
+- [ ] Built the Step 1 scope bootstrap seed (or obtained target files from the user when the search returned none)
+- [ ] Executed codebase-analyzer with a populated `requirement_analysis`
+- [ ] Confirmed the design scope with the user and set the scale from the confirmed target files
 - [ ] Executed external resource hearing per the external-resource-context skill (file written or update explicitly skipped by user)
-- [ ] Executed codebase-analyzer and ui-analyzer in parallel; outputs reused by ui-spec-designer and technical-designer-frontend
+- [ ] Executed ui-analyzer; codebase-analyzer (Step 2) and ui-analyzer (Step 5) outputs reused by ui-spec-designer and technical-designer-frontend
 - [ ] Created UI Specification with ui-spec-designer (when applicable) — its External Resources Used section is filled
 - [ ] Created appropriate design document (ADR or Design Doc) with technical-designer-frontend — its External Resources Used subsection is filled when present
 - [ ] Executed code-verifier on Design Doc and passed results to document-reviewer (skip for ADR-only)
 - [ ] Executed document-reviewer and addressed feedback
-- [ ] Executed design-sync for consistency verification
+- [ ] Executed design-sync for consistency verification (skip for ADR-only)
 - [ ] Obtained user approval for design document
 
 ## Output Example

--- a/dev-workflows/.claude-plugin/plugin.json
+++ b/dev-workflows/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflows",
   "description": "Skills + Subagents for backend development - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows/skills/recipe-design/SKILL.md
+++ b/dev-workflows/skills/recipe-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: recipe-design
-description: Execute from requirement analysis to design document creation
+description: Execute from codebase analysis to design document creation
 disable-model-invocation: true
 ---
 
@@ -11,31 +11,35 @@ disable-model-invocation: true
 **Core Identity**: "I am an orchestrator." (see subagents-orchestration-guide skill)
 
 **Execution Protocol**:
-1. **Delegate all work** to sub-agents — your role is to invoke sub-agents, pass data between them, and report results
-2. **Follow subagents-orchestration-guide skill design flow exactly**:
-   - Execute: requirement-analyzer → codebase-analyzer → technical-designer → code-verifier → document-reviewer → design-sync
+1. **Delegate all work** to sub-agents — your role is to invoke sub-agents, pass data between them, and report results. The one exception is the Step 1 scope bootstrap, a recipe-local orchestrator task limited to locating seed files.
+2. **Run the design flow below in order**:
+   - Execute: scope bootstrap → codebase-analyzer → [Stop: Scope confirmation] → technical-designer → code-verifier → document-reviewer → design-sync
+   - code-verifier and design-sync apply when the design output is a Design Doc; both are skipped for ADR-only
    - **Stop at every `[Stop: ...]` marker** → Wait for user approval before proceeding
 3. **Scope**: Complete when design documents receive approval
 
-**CRITICAL**: Execute document-reviewer, design-sync, and all stopping points defined in subagents-orchestration-guide skill flows — each serves as a quality gate. Skipping any step risks undetected inconsistencies.
+**subagents-orchestration-guide usage**: Reference the guide only for orchestration principles (Delegation Boundary, Decision precedence, permitted tools), the Scale Determination table, and handoff contracts HC-02 onward. This recipe defines its own start order and subagent prompts. The guide's requirement-analyzer-origin flow, First Action Rule, HC-01, and Call Examples do not apply to this recipe.
+
+**CRITICAL**: Execute document-reviewer, design-sync (for Design Docs), and all stopping points — each serves as a quality gate. Skipping any step risks undetected inconsistencies.
 
 ## Workflow Overview
 
 ```
-Requirements → requirement-analyzer → [Stop: Scale determination]
-                                           ↓
-                                   codebase-analyzer → technical-designer
-                                           ↓
-                                   code-verifier → document-reviewer
-                                           ↓
-                                      design-sync → [Stop: Design approval]
+Requirements → scope bootstrap → codebase-analyzer → [Stop: Scope confirmation]
+                                                            ↓
+                                                    technical-designer
+                                                            ↓
+                                                    code-verifier → document-reviewer
+                                                            ↓
+                                                       design-sync → [Stop: Design approval]
 ```
 
 ## Scope Boundaries
 
 **Included in this skill**:
-- Requirement analysis with requirement-analyzer
-- Codebase analysis with codebase-analyzer (before technical design)
+- Scope bootstrap: locating seed files so codebase-analyzer receives a populated input
+- Codebase analysis with codebase-analyzer (entry point of the design phase)
+- Scope confirmation with the user, grounded in codebase-analyzer findings
 - ADR creation (if architecture changes, new technology, or data flow changes)
 - Design Doc creation with technical-designer
 - Design Doc verification with code-verifier (before document review)
@@ -44,32 +48,77 @@ Requirements → requirement-analyzer → [Stop: Scale determination]
 
 **Responsibility Boundary**: This skill completes with design document (ADR/Design Doc) approval. Work planning and beyond are outside scope.
 
+## Execution Flow
+
 Requirements: $ARGUMENTS
 
-Considering the deep impact on design, first engage in dialogue to understand the background and purpose of requirements:
-- What problems do you want to solve?
-- Expected outcomes and success criteria
-- Relationship with existing systems
+### Step 1: Scope Bootstrap
+codebase-analyzer requires a populated `requirement_analysis.affectedFiles`. Build that seed with a lightweight, orchestrator-local pass — locating files only, with no deep reading and no design decisions:
 
-Once the user has answered the three dialogue questions above, analyze with requirement-analyzer and create appropriate design documents according to scale.
+1. Extract candidate keywords from the user requirements (feature names, domain nouns, identifiers).
+2. Search the repository with Bash (`rg`, or `grep` when `rg` is unavailable) for files matching those keywords.
+3. Collect the matched file paths as the seed `affectedFiles`.
+4. **When the search returns no files**: ask the user which files or modules the design targets (AskUserQuestion), and use that answer as `affectedFiles` before invoking codebase-analyzer. If the user confirms no related code exists, report that codebase-grounded design does not apply and confirm with the user how to proceed.
+5. **When the search returns more than ~20 files**: the keywords are too broad for a focused design scope. Present the most relevant candidates to the user (AskUserQuestion) and confirm the seed `affectedFiles` before invoking codebase-analyzer.
 
-Present at least two design alternatives with trade-offs for each.
+This step locates seed files only. Reading files in full, tracing dependencies, and analysis remain codebase-analyzer's responsibility.
 
-Execute the process below within design scope. Follow subagents-orchestration-guide Call Examples for codebase-analyzer and code-verifier invocations.
+### Step 2: Codebase Analysis
+Invoke codebase-analyzer with its existing schema. The orchestrator constructs `requirement_analysis` from the Step 1 seed.
+
+- Invoke **codebase-analyzer** using Agent tool
+  - `subagent_type: "dev-workflows:codebase-analyzer"`, `description: "Codebase analysis"`
+  - `prompt`: include
+    - `requirements`: the user requirements verbatim
+    - `requirement_analysis`: a JSON object with all four fields — `affectedFiles` (Step 1 seed), `purpose` (the user requirements), `scale` (provisional value from the Scale Determination table applied to the seed file count), `technicalConsiderations` (`{ constraints: [], risks: [], dependencies: [] }` — the bootstrap performs no analysis, so the object is present with empty lists)
+    - Expected action: analyze the seed files and produce design guidance
+
+### Step 3: Scope Confirmation
+After codebase-analyzer returns, confirm the design scope with the user before any design work. This is a recipe-local confirmation step. Use AskUserQuestion.
+
+Present, sourced from the codebase-analyzer JSON:
+- **Target files/modules**: `analysisScope.filesAnalyzed` and the modules they belong to
+- **Affected layers**: layers touched, derived from `analysisScope.categoriesDetected` and `focusAreas`
+- **Unknowns/assumptions**: `limitations` plus any assumptions codebase-analyzer recorded
+- **Questions before design**: open points that need a user answer before design proceeds
+
+Ask the user to choose one:
+- **Proceed to design with this scope** — continue to Step 4 (Design Doc)
+- **Correct the scope and re-run** — return to Step 1 with the corrected scope; when the user names the corrected files or modules, use those directly as the Step 1 seed instead of re-deriving them by search
+- **Hold additional hearing, then proceed** — gather the missing answers, then continue to Step 4
+- **Produce an ADR** — when the confirmed scope involves architecture changes, new technology, or data flow changes, continue to Step 4 with technical-designer in ADR mode
+
+After the user confirms the scope, count the confirmed target files and set the scale from the subagents-orchestration-guide Scale Determination table. This confirmed scale supersedes the Step 2 provisional value and determines the design document.
+
+**[STOP]**: Wait for the user's choice before proceeding.
+
+### Step 4: Design Document Creation
+Pass the full codebase-analyzer JSON to technical-designer (handoff contract HC-02). technical-designer presents at least two design alternatives with trade-offs for each.
+
+- Invoke **technical-designer** using Agent tool
+  - For Design Doc: `subagent_type: "dev-workflows:technical-designer"`, `description: "Design Doc creation"`, `prompt: "Create Design Doc based on the requirements. Requirements: [user requirements verbatim]. Codebase analysis: [codebase-analyzer JSON from Step 2]. Confirmed scope: [Step 3 confirmed scope]. Apply the code: prefix to codebase-analyzer fact_ids when filling the Fact Disposition Table. Present at least two architecture alternatives with trade-offs."`
+  - For ADR: `subagent_type: "dev-workflows:technical-designer"`, `description: "ADR creation"`, `prompt: "Create ADR for [technical decision]. Requirements: [user requirements verbatim]. Codebase analysis: [codebase-analyzer JSON from Step 2]. Confirmed scope: [Step 3 confirmed scope]. Present at least two alternatives with trade-offs."`
+- **(Design Doc only)** Invoke **code-verifier** to verify the Design Doc against existing code. Skip for ADR.
+  - `subagent_type: "dev-workflows:code-verifier"`, `description: "Design Doc verification"`, `prompt: "doc_type: design-doc document_path: [Design Doc path] Verify Design Doc against existing code."`
+- Invoke **document-reviewer** to verify consistency (pass code-verifier results for Design Doc; omit for ADR)
+  - `subagent_type: "dev-workflows:document-reviewer"`, `description: "Document review"`, `prompt: "Review [document path] for consistency and completeness. codebase_analysis: [codebase-analyzer JSON from Step 2]. code_verification: [code-verifier output from this step] (Design Doc only)"`
+- **(Design Doc only)** Invoke **design-sync** to verify consistency across design documents. Skip for ADR-only.
+  - `subagent_type: "dev-workflows:design-sync"`, `description: "Design consistency check"`, `prompt: "Check consistency across all Design Docs in docs/design/. Report conflicts and overlaps."`
+
+**[STOP]**: Present the design document, plus design-sync results for a Design Doc, and obtain user approval.
 
 ## Completion Criteria
 
-- [ ] Executed requirement-analyzer and determined scale
-- [ ] Executed codebase-analyzer and passed results to technical-designer
+- [ ] Built the Step 1 scope bootstrap seed (or obtained target files from the user when the search returned none)
+- [ ] Executed codebase-analyzer with a populated `requirement_analysis`
+- [ ] Confirmed the design scope with the user and set the scale from the confirmed target files
 - [ ] Created appropriate design document (ADR or Design Doc) with technical-designer
 - [ ] Executed code-verifier on Design Doc and passed results to document-reviewer (skip for ADR-only)
 - [ ] Executed document-reviewer and addressed feedback
-- [ ] Executed design-sync for consistency verification
+- [ ] Executed design-sync for consistency verification (skip for ADR-only)
 - [ ] Obtained user approval for design document
 
 ## Output Example
 Design phase completed.
 - Design document: docs/design/[document-name].md or docs/adr/[document-name].md
 - Approval status: User approved
-
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-workflows",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "private": true,
   "type": "module",
   "engines": {

--- a/skills/recipe-design/SKILL.md
+++ b/skills/recipe-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: recipe-design
-description: Execute from requirement analysis to design document creation
+description: Execute from codebase analysis to design document creation
 disable-model-invocation: true
 ---
 
@@ -11,31 +11,35 @@ disable-model-invocation: true
 **Core Identity**: "I am an orchestrator." (see subagents-orchestration-guide skill)
 
 **Execution Protocol**:
-1. **Delegate all work** to sub-agents — your role is to invoke sub-agents, pass data between them, and report results
-2. **Follow subagents-orchestration-guide skill design flow exactly**:
-   - Execute: requirement-analyzer → codebase-analyzer → technical-designer → code-verifier → document-reviewer → design-sync
+1. **Delegate all work** to sub-agents — your role is to invoke sub-agents, pass data between them, and report results. The one exception is the Step 1 scope bootstrap, a recipe-local orchestrator task limited to locating seed files.
+2. **Run the design flow below in order**:
+   - Execute: scope bootstrap → codebase-analyzer → [Stop: Scope confirmation] → technical-designer → code-verifier → document-reviewer → design-sync
+   - code-verifier and design-sync apply when the design output is a Design Doc; both are skipped for ADR-only
    - **Stop at every `[Stop: ...]` marker** → Wait for user approval before proceeding
 3. **Scope**: Complete when design documents receive approval
 
-**CRITICAL**: Execute document-reviewer, design-sync, and all stopping points defined in subagents-orchestration-guide skill flows — each serves as a quality gate. Skipping any step risks undetected inconsistencies.
+**subagents-orchestration-guide usage**: Reference the guide only for orchestration principles (Delegation Boundary, Decision precedence, permitted tools), the Scale Determination table, and handoff contracts HC-02 onward. This recipe defines its own start order and subagent prompts. The guide's requirement-analyzer-origin flow, First Action Rule, HC-01, and Call Examples do not apply to this recipe.
+
+**CRITICAL**: Execute document-reviewer, design-sync (for Design Docs), and all stopping points — each serves as a quality gate. Skipping any step risks undetected inconsistencies.
 
 ## Workflow Overview
 
 ```
-Requirements → requirement-analyzer → [Stop: Scale determination]
-                                           ↓
-                                   codebase-analyzer → technical-designer
-                                           ↓
-                                   code-verifier → document-reviewer
-                                           ↓
-                                      design-sync → [Stop: Design approval]
+Requirements → scope bootstrap → codebase-analyzer → [Stop: Scope confirmation]
+                                                            ↓
+                                                    technical-designer
+                                                            ↓
+                                                    code-verifier → document-reviewer
+                                                            ↓
+                                                       design-sync → [Stop: Design approval]
 ```
 
 ## Scope Boundaries
 
 **Included in this skill**:
-- Requirement analysis with requirement-analyzer
-- Codebase analysis with codebase-analyzer (before technical design)
+- Scope bootstrap: locating seed files so codebase-analyzer receives a populated input
+- Codebase analysis with codebase-analyzer (entry point of the design phase)
+- Scope confirmation with the user, grounded in codebase-analyzer findings
 - ADR creation (if architecture changes, new technology, or data flow changes)
 - Design Doc creation with technical-designer
 - Design Doc verification with code-verifier (before document review)
@@ -44,32 +48,77 @@ Requirements → requirement-analyzer → [Stop: Scale determination]
 
 **Responsibility Boundary**: This skill completes with design document (ADR/Design Doc) approval. Work planning and beyond are outside scope.
 
+## Execution Flow
+
 Requirements: $ARGUMENTS
 
-Considering the deep impact on design, first engage in dialogue to understand the background and purpose of requirements:
-- What problems do you want to solve?
-- Expected outcomes and success criteria
-- Relationship with existing systems
+### Step 1: Scope Bootstrap
+codebase-analyzer requires a populated `requirement_analysis.affectedFiles`. Build that seed with a lightweight, orchestrator-local pass — locating files only, with no deep reading and no design decisions:
 
-Once the user has answered the three dialogue questions above, analyze with requirement-analyzer and create appropriate design documents according to scale.
+1. Extract candidate keywords from the user requirements (feature names, domain nouns, identifiers).
+2. Search the repository with Bash (`rg`, or `grep` when `rg` is unavailable) for files matching those keywords.
+3. Collect the matched file paths as the seed `affectedFiles`.
+4. **When the search returns no files**: ask the user which files or modules the design targets (AskUserQuestion), and use that answer as `affectedFiles` before invoking codebase-analyzer. If the user confirms no related code exists, report that codebase-grounded design does not apply and confirm with the user how to proceed.
+5. **When the search returns more than ~20 files**: the keywords are too broad for a focused design scope. Present the most relevant candidates to the user (AskUserQuestion) and confirm the seed `affectedFiles` before invoking codebase-analyzer.
 
-Present at least two design alternatives with trade-offs for each.
+This step locates seed files only. Reading files in full, tracing dependencies, and analysis remain codebase-analyzer's responsibility.
 
-Execute the process below within design scope. Follow subagents-orchestration-guide Call Examples for codebase-analyzer and code-verifier invocations.
+### Step 2: Codebase Analysis
+Invoke codebase-analyzer with its existing schema. The orchestrator constructs `requirement_analysis` from the Step 1 seed.
+
+- Invoke **codebase-analyzer** using Agent tool
+  - `subagent_type: "dev-workflows:codebase-analyzer"`, `description: "Codebase analysis"`
+  - `prompt`: include
+    - `requirements`: the user requirements verbatim
+    - `requirement_analysis`: a JSON object with all four fields — `affectedFiles` (Step 1 seed), `purpose` (the user requirements), `scale` (provisional value from the Scale Determination table applied to the seed file count), `technicalConsiderations` (`{ constraints: [], risks: [], dependencies: [] }` — the bootstrap performs no analysis, so the object is present with empty lists)
+    - Expected action: analyze the seed files and produce design guidance
+
+### Step 3: Scope Confirmation
+After codebase-analyzer returns, confirm the design scope with the user before any design work. This is a recipe-local confirmation step. Use AskUserQuestion.
+
+Present, sourced from the codebase-analyzer JSON:
+- **Target files/modules**: `analysisScope.filesAnalyzed` and the modules they belong to
+- **Affected layers**: layers touched, derived from `analysisScope.categoriesDetected` and `focusAreas`
+- **Unknowns/assumptions**: `limitations` plus any assumptions codebase-analyzer recorded
+- **Questions before design**: open points that need a user answer before design proceeds
+
+Ask the user to choose one:
+- **Proceed to design with this scope** — continue to Step 4 (Design Doc)
+- **Correct the scope and re-run** — return to Step 1 with the corrected scope; when the user names the corrected files or modules, use those directly as the Step 1 seed instead of re-deriving them by search
+- **Hold additional hearing, then proceed** — gather the missing answers, then continue to Step 4
+- **Produce an ADR** — when the confirmed scope involves architecture changes, new technology, or data flow changes, continue to Step 4 with technical-designer in ADR mode
+
+After the user confirms the scope, count the confirmed target files and set the scale from the subagents-orchestration-guide Scale Determination table. This confirmed scale supersedes the Step 2 provisional value and determines the design document.
+
+**[STOP]**: Wait for the user's choice before proceeding.
+
+### Step 4: Design Document Creation
+Pass the full codebase-analyzer JSON to technical-designer (handoff contract HC-02). technical-designer presents at least two design alternatives with trade-offs for each.
+
+- Invoke **technical-designer** using Agent tool
+  - For Design Doc: `subagent_type: "dev-workflows:technical-designer"`, `description: "Design Doc creation"`, `prompt: "Create Design Doc based on the requirements. Requirements: [user requirements verbatim]. Codebase analysis: [codebase-analyzer JSON from Step 2]. Confirmed scope: [Step 3 confirmed scope]. Apply the code: prefix to codebase-analyzer fact_ids when filling the Fact Disposition Table. Present at least two architecture alternatives with trade-offs."`
+  - For ADR: `subagent_type: "dev-workflows:technical-designer"`, `description: "ADR creation"`, `prompt: "Create ADR for [technical decision]. Requirements: [user requirements verbatim]. Codebase analysis: [codebase-analyzer JSON from Step 2]. Confirmed scope: [Step 3 confirmed scope]. Present at least two alternatives with trade-offs."`
+- **(Design Doc only)** Invoke **code-verifier** to verify the Design Doc against existing code. Skip for ADR.
+  - `subagent_type: "dev-workflows:code-verifier"`, `description: "Design Doc verification"`, `prompt: "doc_type: design-doc document_path: [Design Doc path] Verify Design Doc against existing code."`
+- Invoke **document-reviewer** to verify consistency (pass code-verifier results for Design Doc; omit for ADR)
+  - `subagent_type: "dev-workflows:document-reviewer"`, `description: "Document review"`, `prompt: "Review [document path] for consistency and completeness. codebase_analysis: [codebase-analyzer JSON from Step 2]. code_verification: [code-verifier output from this step] (Design Doc only)"`
+- **(Design Doc only)** Invoke **design-sync** to verify consistency across design documents. Skip for ADR-only.
+  - `subagent_type: "dev-workflows:design-sync"`, `description: "Design consistency check"`, `prompt: "Check consistency across all Design Docs in docs/design/. Report conflicts and overlaps."`
+
+**[STOP]**: Present the design document, plus design-sync results for a Design Doc, and obtain user approval.
 
 ## Completion Criteria
 
-- [ ] Executed requirement-analyzer and determined scale
-- [ ] Executed codebase-analyzer and passed results to technical-designer
+- [ ] Built the Step 1 scope bootstrap seed (or obtained target files from the user when the search returned none)
+- [ ] Executed codebase-analyzer with a populated `requirement_analysis`
+- [ ] Confirmed the design scope with the user and set the scale from the confirmed target files
 - [ ] Created appropriate design document (ADR or Design Doc) with technical-designer
 - [ ] Executed code-verifier on Design Doc and passed results to document-reviewer (skip for ADR-only)
 - [ ] Executed document-reviewer and addressed feedback
-- [ ] Executed design-sync for consistency verification
+- [ ] Executed design-sync for consistency verification (skip for ADR-only)
 - [ ] Obtained user approval for design document
 
 ## Output Example
 Design phase completed.
 - Design document: docs/design/[document-name].md or docs/adr/[document-name].md
 - Approval status: User approved
-
-

--- a/skills/recipe-front-design/SKILL.md
+++ b/skills/recipe-front-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: recipe-front-design
-description: Execute from requirement analysis to frontend design document creation
+description: Execute from codebase analysis to frontend design document creation
 disable-model-invocation: true
 ---
 
@@ -11,38 +11,43 @@ disable-model-invocation: true
 **Core Identity**: "I am an orchestrator." (see subagents-orchestration-guide skill)
 
 **Execution Protocol**:
-1. **Delegate all work** to sub-agents — your role is to invoke sub-agents, pass data between them, and report results
-2. **Follow subagents-orchestration-guide skill design flow** (this recipe covers medium/large frontend; refer to the guide for scale-specific variations):
-   - Execute: requirement-analyzer → external resource hearing → codebase-analyzer + ui-analyzer (parallel) → ui-spec-designer → technical-designer-frontend → code-verifier → document-reviewer → design-sync
+1. **Delegate all work** to sub-agents — your role is to invoke sub-agents, pass data between them, and report results. The one exception is the Step 1 scope bootstrap, a recipe-local orchestrator task limited to locating seed files.
+2. **Run the frontend design flow below in order** (this recipe covers medium/large frontend):
+   - Execute: scope bootstrap → codebase-analyzer → [Stop: Scope confirmation] → external resource hearing → ui-analyzer → ui-spec-designer → technical-designer-frontend → code-verifier → document-reviewer → design-sync
+   - ui-spec-designer, code-verifier, and design-sync apply when the design output is a Design Doc; all are skipped for ADR-only
    - **Stop at every `[Stop: ...]` marker** → Wait for user approval before proceeding
 3. **Scope**: Complete when design documents receive approval
 
-**CRITICAL**: Execute document-reviewer, design-sync, and all stopping points defined in subagents-orchestration-guide skill flows — each serves as a quality gate. Skipping any step risks undetected inconsistencies.
+**subagents-orchestration-guide usage**: Reference the guide only for orchestration principles (Delegation Boundary, Decision precedence, permitted tools), the Scale Determination table, and handoff contracts HC-02 onward. This recipe defines its own start order and subagent prompts. The guide's requirement-analyzer-origin flow, First Action Rule, HC-01, and Call Examples do not apply to this recipe.
+
+**CRITICAL**: Execute document-reviewer, design-sync (for Design Docs), and all stopping points — each serves as a quality gate. Skipping any step risks undetected inconsistencies.
 
 ## Workflow Overview
 
 ```
-Requirements → requirement-analyzer → [Stop: Scale determination]
-                                           ↓
-                          external resource hearing (frontend domain)
-                                           ↓
-                          codebase-analyzer + ui-analyzer (parallel)
-                                           ↓
-                                   ui-spec-designer → [Stop: UI Spec approval]
-                                           ↓
-                                   technical-designer-frontend
-                                           ↓
-                                   code-verifier → document-reviewer
-                                           ↓
-                                      design-sync → [Stop: Design approval]
+Requirements → scope bootstrap → codebase-analyzer → [Stop: Scope confirmation]
+                                                            ↓
+                                          external resource hearing (frontend domain)
+                                                            ↓
+                                                       ui-analyzer
+                                                            ↓
+                                              ui-spec-designer → [Stop: UI Spec approval]
+                                                            ↓
+                                              technical-designer-frontend
+                                                            ↓
+                                              code-verifier → document-reviewer
+                                                            ↓
+                                                 design-sync → [Stop: Design approval]
 ```
 
 ## Scope Boundaries
 
 **Included in this skill**:
-- Requirement analysis with requirement-analyzer
+- Scope bootstrap: locating seed files so codebase-analyzer receives a populated input
+- Codebase analysis with codebase-analyzer (entry point of the frontend design phase)
+- Scope confirmation with the user, grounded in codebase-analyzer findings
 - External resource hearing per the external-resource-context skill
-- Codebase analysis with codebase-analyzer and ui-analyzer in parallel (before document creation)
+- UI fact gathering with ui-analyzer
 - UI Specification creation with ui-spec-designer (prototype code inquiry included)
 - ADR creation (if architecture changes, new technology, or data flow changes)
 - Design Doc creation with technical-designer-frontend
@@ -52,39 +57,67 @@ Requirements → requirement-analyzer → [Stop: Scale determination]
 
 **Responsibility Boundary**: This skill completes with frontend design document (UI Spec/ADR/Design Doc) approval. Work planning and beyond are outside scope.
 
-Requirements: $ARGUMENTS
-
 ## Execution Flow
 
-### Step 1: Requirement Analysis Phase
-Considering the deep impact on design, first engage in dialogue to understand the background and purpose of requirements:
-- What problems do you want to solve?
-- Expected outcomes and success criteria
-- Relationship with existing systems
+Requirements: $ARGUMENTS
 
-Once the user has answered the three dialogue questions above, execute the process below within design scope. Follow subagents-orchestration-guide Call Examples for codebase-analyzer, ui-analyzer, and code-verifier invocations.
+### Step 1: Scope Bootstrap
+codebase-analyzer requires a populated `requirement_analysis.affectedFiles`. Build that seed with a lightweight, orchestrator-local pass — locating files only, with no deep reading and no design decisions:
 
-- Invoke **requirement-analyzer** using Agent tool
-  - `subagent_type: "dev-workflows-frontend:requirement-analyzer"`
-  - `description: "Requirement analysis"`
-  - `prompt: "Requirements: [user requirements] Execute requirement analysis and scale determination"`
-- **[STOP]**: Review requirement analysis results and address question items
+1. Extract candidate keywords from the user requirements (feature names, domain nouns, identifiers).
+2. Search the repository with Bash (`rg`, or `grep` when `rg` is unavailable) for files matching those keywords.
+3. Collect the matched file paths as the seed `affectedFiles`.
+4. **When the search returns no files**: ask the user which files or modules the design targets (AskUserQuestion), and use that answer as `affectedFiles` before invoking codebase-analyzer. If the user confirms no related code exists, report that codebase-grounded design does not apply and confirm with the user how to proceed.
+5. **When the search returns more than ~20 files**: the keywords are too broad for a focused design scope. Present the most relevant candidates to the user (AskUserQuestion) and confirm the seed `affectedFiles` before invoking codebase-analyzer.
 
-### Step 1.5: External Resource Hearing
-Run the hearing protocol per the external-resource-context skill (frontend domain). The orchestrator owns this step because it requires AskUserQuestion. The skill defines file-existence branching, two-phase hearing (structured axes + self-declaration), and persistence to `docs/project-context/external-resources.md`.
+This step locates seed files only. Reading files in full, tracing dependencies, and analysis remain codebase-analyzer's responsibility.
 
-### Step 2: UI Fact Gathering
-Invoke codebase-analyzer and ui-analyzer **in parallel** (single message with two Agent tool calls). They share input but produce complementary output. ui-analyzer reads the project-tier external-resources file and fetches external UI sources via the inherited MCP/URL access methods, then analyzes the UI codebase. codebase-analyzer covers data, contracts, dependencies, and quality assurance mechanisms.
+### Step 2: Codebase Analysis
+Invoke codebase-analyzer with its existing schema. The orchestrator constructs `requirement_analysis` from the Step 1 seed.
 
 - Invoke **codebase-analyzer** using Agent tool
-  - `subagent_type: "dev-workflows-frontend:codebase-analyzer"`, `description: "Codebase analysis"`, `prompt: "requirement_analysis: [JSON from Step 1]. requirements: [user requirements]. Analyze existing codebase for frontend design guidance (data, contracts, dependencies, quality assurance mechanisms)."`
-- Invoke **ui-analyzer** using Agent tool (parallel with the call above)
-  - `subagent_type: "dev-workflows-frontend:ui-analyzer"`, `description: "UI fact gathering"`, `prompt: "requirement_analysis: [JSON from Step 1]. requirements: [user requirements]. Read docs/project-context/external-resources.md, fetch external UI sources via the declared access methods, and analyze the existing UI codebase."`
+  - `subagent_type: "dev-workflows-frontend:codebase-analyzer"`, `description: "Codebase analysis"`
+  - `prompt`: include
+    - `requirements`: the user requirements verbatim
+    - `requirement_analysis`: a JSON object with all four fields — `affectedFiles` (Step 1 seed), `purpose` (the user requirements), `scale` (provisional value from the Scale Determination table applied to the seed file count), `technicalConsiderations` (`{ constraints: [], risks: [], dependencies: [] }` — the bootstrap performs no analysis, so the object is present with empty lists)
+    - Expected action: analyze the seed files for frontend design guidance (data, contracts, dependencies, quality assurance mechanisms)
 
-Both outputs (codebase-analyzer JSON and ui-analyzer JSON) are reused by ui-spec-designer in Step 3 and by technical-designer-frontend in Step 4.
+### Step 3: Scope Confirmation
+After codebase-analyzer returns, confirm the design scope with the user before any design work. This is a recipe-local confirmation step. Use AskUserQuestion.
 
-### Step 3: UI Specification Phase
-After Step 2 outputs are received, ask the user about prototype code:
+Present, sourced from the codebase-analyzer JSON:
+- **Target files/modules**: `analysisScope.filesAnalyzed` and the modules they belong to
+- **Affected layers**: layers touched, derived from `analysisScope.categoriesDetected` and `focusAreas`
+- **Unknowns/assumptions**: `limitations` plus any assumptions codebase-analyzer recorded
+- **Questions before design**: open points that need a user answer before design proceeds
+
+Ask the user to choose one:
+- **Proceed to design with this scope** — continue to Step 4
+- **Correct the scope and re-run** — return to Step 1 with the corrected scope; when the user names the corrected files or modules, use those directly as the Step 1 seed instead of re-deriving them by search
+- **Hold additional hearing, then proceed** — gather the missing answers, then continue to Step 4
+- **Produce an ADR** — when the confirmed scope involves architecture changes, new technology, or data flow changes, continue through the flow with an ADR as the design document; Step 6 (UI Specification) is skipped for ADR
+
+After the user confirms the scope, count the confirmed target files and set the scale from the subagents-orchestration-guide Scale Determination table. This confirmed scale supersedes the Step 2 provisional value and determines the design document.
+
+**[STOP]**: Wait for the user's choice before proceeding.
+
+### Step 4: External Resource Hearing
+Run the hearing protocol per the external-resource-context skill (frontend domain). The orchestrator owns this step because it requires AskUserQuestion. The skill defines file-existence branching, two-phase hearing (structured axes + self-declaration), and persistence to `docs/project-context/external-resources.md`.
+
+### Step 5: UI Fact Gathering
+Invoke ui-analyzer to gather UI facts. It reads the project-tier external-resources file, fetches external UI sources via the inherited MCP/URL access methods, then analyzes the UI codebase. Its output complements the codebase-analyzer output from Step 2 (data, contracts, dependencies, quality assurance mechanisms).
+
+- Invoke **ui-analyzer** using Agent tool
+  - `subagent_type: "dev-workflows-frontend:ui-analyzer"`, `description: "UI fact gathering"`
+  - `prompt`: include
+    - `requirements`: the user requirements
+    - `requirement_analysis`: a JSON object with all four fields — `affectedFiles` (`analysisScope.filesAnalyzed` from Step 2 codebase-analyzer), `purpose` (the user requirements), `scale` (the Step 3 confirmed scale), `technicalConsiderations` (`{ constraints: [], risks: [], dependencies: [] }`)
+    - Expected action: read `docs/project-context/external-resources.md`, fetch external UI sources via the declared access methods, and analyze the existing UI codebase
+
+Both outputs (codebase-analyzer JSON from Step 2 and ui-analyzer JSON from Step 5) are reused by ui-spec-designer in Step 6 and by technical-designer-frontend in Step 7.
+
+### Step 6: UI Specification Phase
+**When the design document is a Design Doc** (this step is skipped for ADR-only): after Step 5 output is received, ask the user about prototype code:
 
 **Ask the user**: "Do you have prototype code for this feature? If so, please provide the path to the code. The prototype will be placed in `docs/ui-spec/assets/` as reference material for the UI Spec."
 
@@ -95,39 +128,42 @@ Then create the UI Specification:
   - `subagent_type: "dev-workflows-frontend:ui-spec-designer"`
   - `description: "UI Spec creation"`
   - Build the prompt by including:
-    - Source: PRD path (Large scale) or requirement-analyzer output (Medium scale)
-    - `ui_analysis`: ui-analyzer JSON from Step 2 (includes externalResources fetched_summary and componentStructure / propsPatterns / cssLayout / etc.)
+    - Source: an existing PRD in `docs/prd/` when one exists for this feature; otherwise the user requirements with the Step 2 codebase-analyzer JSON and the Step 3 confirmed scope
+    - `ui_analysis`: ui-analyzer JSON from Step 5 (includes externalResources fetched_summary and componentStructure / propsPatterns / cssLayout / etc.)
     - Prototype path when provided
-  - Example: `prompt: "Create UI Spec from PRD at [path]. ui_analysis: [JSON from Step 2 ui-analyzer]. Prototype code is at [user-provided path]. Place prototype in docs/ui-spec/assets/{feature-name}/."`
+  - Example (existing PRD): `prompt: "Create UI Spec from PRD at [path]. ui_analysis: [JSON from Step 5 ui-analyzer]. Prototype code is at [user-provided path]. Place prototype in docs/ui-spec/assets/{feature-name}/."`
+  - Example (no PRD): `prompt: "Create UI Spec from these requirements: [user requirements verbatim]. Codebase analysis: [codebase-analyzer JSON from Step 2]. Confirmed scope: [Step 3 confirmed scope]. ui_analysis: [JSON from Step 5 ui-analyzer]. Prototype code is at [user-provided path]. Place prototype in docs/ui-spec/assets/{feature-name}/."`
 - Invoke **document-reviewer** to verify UI Spec
   - `subagent_type: "dev-workflows-frontend:document-reviewer"`, `description: "UI Spec review"`, `prompt: "doc_type: UISpec target: [ui-spec path] Review for consistency and completeness"`
 - **[STOP]**: Present UI Spec for user approval
 
-### Step 4: Design Document Creation Phase
-Create appropriate design documents according to scale determination. technical-designer-frontend presents at least two architecture alternatives (technology selection, data flow design) with trade-offs for each. Pass both Step 2 outputs:
+### Step 7: Design Document Creation Phase
+technical-designer-frontend presents at least two architecture alternatives (technology selection, data flow design) with trade-offs for each. Pass the Step 2 codebase-analyzer output and the Step 5 ui-analyzer output:
 - Invoke **technical-designer-frontend** using Agent tool
-  - For ADR: `subagent_type: "dev-workflows-frontend:technical-designer-frontend"`, `description: "ADR creation"`, `prompt: "Create ADR for [technical decision]. Present at least two alternatives with trade-offs."`
-  - For Design Doc: `subagent_type: "dev-workflows-frontend:technical-designer-frontend"`, `description: "Design Doc creation"`, `prompt: "Create Design Doc based on requirements. Codebase analysis: [codebase-analyzer JSON from Step 2]. UI analysis: [ui-analyzer JSON from Step 2]. UI Spec is at [ui-spec path]. Inherit component structure and state design from UI Spec. Apply code: prefix to codebase-analyzer fact_ids and ui: prefix to ui-analyzer fact_ids when filling the Fact Disposition Table. Present at least two architecture alternatives with trade-offs."`
+  - For ADR: `subagent_type: "dev-workflows-frontend:technical-designer-frontend"`, `description: "ADR creation"`, `prompt: "Create ADR for [technical decision]. Requirements: [user requirements verbatim]. Codebase analysis: [codebase-analyzer JSON from Step 2]. UI analysis: [ui-analyzer JSON from Step 5]. Confirmed scope: [Step 3 confirmed scope]. Present at least two alternatives with trade-offs."`
+  - For Design Doc: `subagent_type: "dev-workflows-frontend:technical-designer-frontend"`, `description: "Design Doc creation"`, `prompt: "Create Design Doc based on the requirements. Requirements: [user requirements verbatim]. Codebase analysis: [codebase-analyzer JSON from Step 2]. UI analysis: [ui-analyzer JSON from Step 5]. UI Spec is at [ui-spec path]. Inherit component structure and state design from UI Spec. Apply code: prefix to codebase-analyzer fact_ids and ui: prefix to ui-analyzer fact_ids when filling the Fact Disposition Table. Present at least two architecture alternatives with trade-offs."`
 - **(Design Doc only)** Invoke **code-verifier** to verify Design Doc against existing code. Skip for ADR.
   - `subagent_type: "dev-workflows-frontend:code-verifier"`, `description: "Design Doc verification"`, `prompt: "doc_type: design-doc document_path: [Design Doc path] Verify Design Doc against existing code."`
 - Invoke **document-reviewer** to verify consistency (pass code-verifier results for Design Doc; omit for ADR)
-  - `subagent_type: "dev-workflows-frontend:document-reviewer"`, `description: "Document review"`, `prompt: "Review [document path] for consistency and completeness. code_verification: [code verification output from this step] (Design Doc only)"`
+  - `subagent_type: "dev-workflows-frontend:document-reviewer"`, `description: "Document review"`, `prompt: "Review [document path] for consistency and completeness. codebase_analysis: [codebase-analyzer JSON from Step 2]. ui_analysis: [ui-analyzer JSON from Step 5]. code_verification: [code verification output from this step] (Design Doc only)"`
 
-### Step 5: Design Consistency Verification
-- Invoke **design-sync** using Agent tool
+### Step 8: Design Consistency Verification
+- **(Design Doc only)** Invoke **design-sync** using Agent tool. Skip for ADR-only.
   - `subagent_type: "dev-workflows-frontend:design-sync"`, `description: "Design consistency check"`, `prompt: "Check consistency across all Design Docs in docs/design/. Report conflicts and overlaps."`
-- **[STOP]**: Present design documents and design-sync results, obtain user approval
+- **[STOP]**: Present the design document, plus design-sync results for a Design Doc, and obtain user approval
 
 ## Completion Criteria
 
-- [ ] Executed requirement-analyzer and determined scale
+- [ ] Built the Step 1 scope bootstrap seed (or obtained target files from the user when the search returned none)
+- [ ] Executed codebase-analyzer with a populated `requirement_analysis`
+- [ ] Confirmed the design scope with the user and set the scale from the confirmed target files
 - [ ] Executed external resource hearing per the external-resource-context skill (file written or update explicitly skipped by user)
-- [ ] Executed codebase-analyzer and ui-analyzer in parallel; outputs reused by ui-spec-designer and technical-designer-frontend
+- [ ] Executed ui-analyzer; codebase-analyzer (Step 2) and ui-analyzer (Step 5) outputs reused by ui-spec-designer and technical-designer-frontend
 - [ ] Created UI Specification with ui-spec-designer (when applicable) — its External Resources Used section is filled
 - [ ] Created appropriate design document (ADR or Design Doc) with technical-designer-frontend — its External Resources Used subsection is filled when present
 - [ ] Executed code-verifier on Design Doc and passed results to document-reviewer (skip for ADR-only)
 - [ ] Executed document-reviewer and addressed feedback
-- [ ] Executed design-sync for consistency verification
+- [ ] Executed design-sync for consistency verification (skip for ADR-only)
 - [ ] Obtained user approval for design document
 
 ## Output Example


### PR DESCRIPTION
## Summary

`recipe-design` and `recipe-front-design` previously began with `requirement-analyzer`, organizing requirements from the user query alone before any code was inspected. In the design phase, a thin query-only requirements pass that misses the mark creates uncertainty and rework. Both recipes now enter design from a scope grounded in real code.

## What changed

**Design-phase entry (`recipe-design`, `recipe-front-design`)**
- Removed the `requirement-analyzer` call at the start of both design recipes.
- Added a recipe-local **scope bootstrap** (Step 1): the orchestrator extracts keywords from the user requirements, locates seed files with `rg`/`grep`, and builds the `requirement_analysis` seed that `codebase-analyzer` requires. Empty results fall back to asking the user; overly broad results (>~20 files) are narrowed with the user before proceeding.
- `codebase-analyzer` now runs first, with its existing schema unchanged.
- Added a recipe-local **scope confirmation** step after `codebase-analyzer`: the user reviews target files/modules, affected layers, unknowns, and open questions, then chooses to proceed / correct the scope / hear more / produce an ADR.
- Narrowed each recipe's dependency on `subagents-orchestration-guide` to orchestration principles, the Scale Determination table, and handoff contracts HC-02 onward. The recipes now define their own start order and inline all subagent prompts (including HC-04: `document-reviewer` receives `codebase_analysis`, plus `ui_analysis` for the frontend recipe).

## Out of scope (unchanged)

- `requirement-analyzer`, `codebase-analyzer`, `subagents-orchestration-guide`, and the implement recipes. `recipe-implement` / `recipe-fullstack-implement` still start with `requirement-analyzer`.
- No agent schema or handoff-contract changes; no new global orchestration concept.

## Release

- Bumped the four local plugins and `package.json` to `0.19.3`.

## Validation

- `claude plugin validate` — marketplace manifest + all four plugins pass
- `npm run sync:check` — generated plugin copies in sync
- `npm run check:skills-index` — all skills consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)
