### PR TITLE
refine: make Design Doc observable contracts first-class and enforced end-to-end

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "dev-workflows",
       "source": "./dev-workflows",
       "strict": true,
-      "version": "0.20.5",
+      "version": "0.21.0",
       "description": "Skills + Subagents for backend development - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
       "author": {
         "name": "Shinsuke Kagawa",
@@ -81,7 +81,7 @@
       "name": "dev-workflows-frontend",
       "source": "./dev-workflows-frontend",
       "strict": true,
-      "version": "0.20.5",
+      "version": "0.21.0",
       "description": "Skills + Subagents for React/TypeScript - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
       "author": {
         "name": "Shinsuke Kagawa",
@@ -152,7 +152,7 @@
       "name": "dev-workflows-fullstack",
       "source": "./dev-workflows-fullstack",
       "strict": true,
-      "version": "0.20.5",
+      "version": "0.21.0",
       "description": "Skills + Subagents for fullstack development (backend + React/TypeScript) - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
       "author": {
         "name": "Shinsuke Kagawa",
@@ -240,7 +240,7 @@
       "name": "dev-skills",
       "source": "./dev-skills",
       "strict": true,
-      "version": "0.20.5",
+      "version": "0.21.0",
       "description": "Lightweight skills for users with existing workflows - coding best practices, testing principles, and design guidelines without recipe workflows or agents",
       "author": {
         "name": "Shinsuke Kagawa",

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -45,6 +45,7 @@ Read the Design Doc **in full** and extract:
 - Architecture design and data flow
 - Interface contracts (function signatures, API endpoints, data structures)
 - Identifier specifications (resource names, endpoint paths, configuration keys, error codes, schema/model names)
+- Binding observable contracts: column/label sets and order, derived-display rules, and state-lifecycle negatives; plus Field Propagation Map rows that carry a Serialized Format + Consumer Parse Rule
 - Error handling policy
 - Non-functional requirements
 
@@ -60,7 +61,7 @@ For each acceptance criterion extracted in Step 1:
 - For behavior-changing ACs, confirm the evidence covers the boundary paths, not only the main path: where a distinct branch, state, input class, lifecycle step, or fallback governs the behavior, verify it is exercised. Compare the source/referenced behavior and the implemented behavior at the same granularity; an unsupported change in a boundary dimension is a `dd_violation`
 - Confirm the implementation keeps the core mechanism the AC, Design Doc, or referenced materials require. A simpler substitute that passes tests but drops the required mechanism is a `dd_violation`
 - For changes to persisted, shared, or externally observable state, identify the publication boundary (where the new state becomes observable to another process, component, user, or later step). State that is observable as complete while still partial, uninitialized, stale, or rollback-only is a `reliability` finding, because a downstream consumer can treat the incomplete state as complete and fail
-- When the reviewed change is classified as `bug-fix`, `regression`, `state-change`, or `boundary-change` (the task's `Change Category` field, when present, names the kind), check the cases sharing its path, contract, persisted state, or external boundary. A sibling case still carrying the same class of defect the change addressed is an `adjacent_residual` finding
+- When the reviewed change is classified as `bug-fix`, `regression`, `state-change`, or `boundary-change` (the task's `Change Category` field, when present, names the kind; when no field is present — e.g., reviewing a diff without task files — classify from the diff itself), check the cases sharing its path, contract, persisted state, or external boundary. A sibling case still carrying the same class of defect the change addressed is an `adjacent_residual` finding. When the task file is in scope, also read its Investigation Notes for residuals the executor recorded as out-of-scope, and verify each recorded residual; if it remains unfixed within the reviewed scope, report it as `adjacent_residual`, otherwise record why it is resolved or outside the review scope
 
 #### 2-2. Identifier Verification
 
@@ -81,6 +82,13 @@ Assign confidence based on evidence count:
 - **high**: 3+ sources agree
 - **medium**: 2 sources agree
 - **low**: 1 source only (implementation exists but no test or type confirmation)
+
+#### 2-4. Reference Contract and Boundary Verification
+
+Runs independently of the AC loop, so observable contracts that are not tied to an AC are also verified.
+
+1. For each binding observable value extracted in Step 1 (column/label set and order, derived-display rule, state-lifecycle negative), verify the implementation reproduces it exactly. A deviation is a `dd_violation` whose rationale names it a reference contract gap (the required observable value vs the implemented one).
+2. For each Field Propagation Map serialized boundary extracted in Step 1 (Serialized Format + Consumer Parse Rule), verify the producer emits the recorded representation and the consumer parses it by the recorded rule. A mismatch between the two sides is a `dd_violation` whose rationale names it a boundary contract gap (what the producer emits vs what the consumer parses).
 
 ### 3. Assess Code Quality
 

--- a/agents/document-reviewer.md
+++ b/agents/document-reviewer.md
@@ -43,7 +43,7 @@ You are an AI assistant specialized in technical document review.
 - Specialized verification based on doc_type
 - For DesignDoc: Verify "Applicable Standards" section exists with explicit/implicit classification
   - Missing or incomplete → `critical` issue; implicit standards without confirmation → `important` issue
-- For WorkPlan: confirm the plan carries the artifacts the semantic gate is judged against — Design-to-Plan Traceability, Failure Mode Checklist, Review Scope, Verification Strategy summary, and Proof Strategy. Read the referenced Design Doc(s) so AC / contract / state-transition coverage can be checked against the plan's tasks
+- For WorkPlan: confirm the plan carries the artifacts the semantic gate is judged against — Design-to-Plan Traceability, Reference Contract Values (when the Design Doc specifies binding observable values), Failure Mode Checklist, Review Scope, Verification Strategy summary, and Proof Strategy. Read the referenced Design Doc(s) so AC / contract / state-transition coverage and the content fidelity of binding observable values can be checked against the plan
 - If `code_verification` provided: extract discrepancy list and reverse coverage gaps; feed into Gate 1 as pre-verified evidence
 - If `codebase_analysis` provided: extract `focusAreas` and their `evidence` values for Gate 0 / Gate 1 Fact Disposition checks
 
@@ -108,6 +108,7 @@ For WorkPlan, additionally verify:
   - (3) Each cross-boundary, public-boundary, or persisted-state change names a task that verifies it through the real boundary — missing → `important` issue (category: `completeness`)
   - (4) Each traceability table present (Design-to-Plan, UI Spec Component, Connection Map, ADR Bindings) is filled to a granularity that resolves its target task — under-specified rows → `important` issue (category: `completeness`)
   - (5) The Failure Mode Checklist covers the plan's applicable domain-independent categories (same-value, no-op, empty input, invalid option, missing config, unavailable boundary, shared-state dependency, rollback-only visibility) — missing applicable category → `recommended` issue (category: `completeness`)
+  - (6) Binding observable values are carried with content fidelity, not only coverage: for each Design Doc observable contract that encodes a binding value (a column/label set and order, a derived-display rule, or a state-lifecycle negative), the plan's Reference Contract Values table carries the value verbatim from the Design Doc and maps it to a covering task. Re-derive each such value from the Design Doc and compare against the plan; a value reduced to a label, summarized, or absent while the Design Doc specifies it is a content-fidelity gap → `critical` issue (category: `completeness`)
   - Verdict mapping (WorkPlan): any semantic-gate `critical` issue forces the verdict to at least `needs_revision` — except a coverage gap traceable to a missing or contradictory Design Doc/input element (which re-planning cannot fix) → `rejected`; an `important`-only set caps the verdict at `approved_with_conditions`
 
 **Perspective-specific Mode**:
@@ -156,49 +157,15 @@ Complete all items before proceeding to output.
 
 ```json
 {
-  "metadata": {
-    "review_mode": "comprehensive",
-    "doc_type": "DesignDoc",
-    "target_path": "/path/to/document.md"
-  },
-  "scores": {
-    "consistency": 85,
-    "completeness": 80,
-    "rule_compliance": 90,
-    "clarity": 75
-  },
-  "gate0": {
-    "status": "pass|fail",
-    "missing_elements": []
-  },
-  "verdict": {
-    "decision": "approved_with_conditions",
-    "conditions": [
-      "Resolve FileUtil discrepancy",
-      "Add missing test files"
-    ]
-  },
+  "metadata": {"review_mode": "comprehensive", "doc_type": "DesignDoc", "target_path": "/path/to/document.md"},
+  "scores": {"consistency": 85, "completeness": 80, "rule_compliance": 90, "clarity": 75},
+  "gate0": {"status": "pass|fail", "missing_elements": []},
+  "verdict": {"decision": "approved_with_conditions", "conditions": ["Resolve FileUtil discrepancy", "Add missing test files"]},
   "issues": [
-    {
-      "id": "I001",
-      "severity": "critical",
-      "category": "implementation",
-      "location": "Section 3.2",
-      "description": "FileUtil method mismatch",
-      "suggestion": "Update document to reflect actual FileUtil usage"
-    }
+    {"id": "I001", "severity": "critical", "category": "implementation", "location": "Section 3.2", "description": "FileUtil method mismatch", "suggestion": "Update document to reflect actual FileUtil usage"}
   ],
-  "recommendations": [
-    "Priority fixes before approval",
-    "Documentation alignment with implementation"
-  ],
-  "prior_context_check": {
-    "items_received": 0,
-    "resolved": 0,
-    "partially_resolved": 0,
-    "unresolved": 0,
-    "items": []
-  }
+  "recommendations": ["Priority fixes before approval", "Documentation alignment with implementation"],
+  "prior_context_check": {"items_received": 0, "resolved": 0, "partially_resolved": 0, "unresolved": 0, "items": []}
 }
 ```
 
@@ -206,16 +173,8 @@ Complete all items before proceeding to output.
 
 ```json
 {
-  "metadata": {
-    "review_mode": "perspective",
-    "focus": "implementation",
-    "doc_type": "DesignDoc",
-    "target_path": "/path/to/document.md"
-  },
-  "analysis": {
-    "summary": "Analysis results description",
-    "scores": {}
-  },
+  "metadata": {"review_mode": "perspective", "focus": "implementation", "doc_type": "DesignDoc", "target_path": "/path/to/document.md"},
+  "analysis": {"summary": "Analysis results description", "scores": {}},
   "issues": [],
   "checklist": [
     {"item": "Check item description", "status": "pass|fail|na"}
@@ -236,12 +195,7 @@ Include in output when `prior_context_count > 0`:
     "partially_resolved": 1,
     "unresolved": 0,
     "items": [
-      {
-        "id": "D001",
-        "status": "resolved",
-        "location": "Section 3.2",
-        "evidence": "Code now matches documentation"
-      }
+      {"id": "D001", "status": "resolved", "location": "Section 3.2", "evidence": "Code now matches documentation"}
     ]
   }
 }

--- a/agents/task-decomposer.md
+++ b/agents/task-decomposer.md
@@ -183,7 +183,7 @@ When the work plan contains a Connection Map table, propagate boundary context t
 
 1. **Lookup by task ID**: For each row in the Connection Map, locate the task(s) listed in the "Covered By Task(s)" column
 2. **Append to Investigation Targets**: Add the boundary's owner module file paths on both sides to each matched task's Investigation Targets
-3. **Add a "Boundary Context" note in the task body**: Record the boundary identifier and expected signal verbatim from the Connection Map row, so the executor knows what observable evidence the implementation must produce
+3. **Add a "Boundary Context" note in the task body**: Record the boundary identifier and expected signal verbatim from the Connection Map row, so the executor knows what observable evidence the implementation must produce. When the row carries a **Serialized Format** and **Consumer Parse Rule** (a serialized in-runtime boundary), copy both verbatim into the note and state the roundtrip check the task must satisfy: the value the producer emits parses to the value the consumer expects.
 4. **Skip when not provided**: If the work plan has no Connection Map, skip this propagation step
 
 ## ADR Binding Propagation
@@ -213,6 +213,19 @@ When the work plan contains a Design-to-Plan Traceability table, propagate the m
 1. For each row, append the pair (`Design Doc`, `DD Section`) to every task listed in "Covered By Task(s)" as an Investigation Target, formatted as `[Design Doc value] (§ [DD Section value])`
 2. Deduplicate when the same (Design Doc, DD Section) pair appears in multiple rows for one task
 3. Apply only when the work plan contains a Design-to-Plan Traceability table
+
+## Reference Contract Propagation
+
+When the work plan contains a **Reference Contract Values** table, propagate each binding observable value to the task(s) it covers, so the executor is checked against the exact value rather than a back-pointer it must re-derive:
+
+1. **Lookup by task ID**: For each row, locate the task(s) listed in "Covered By Task(s)"
+2. **Append to Investigation Targets**: Add the row's `Design Doc (§ Section)` to each matched task (deduplicate against Design Traceability Propagation entries)
+3. **Add a Reference Contracts table row to the task**: For each matched row, add one row to the task's Reference Contracts table (see task template):
+   - **Source**: the `Design Doc (§ Section)` value
+   - **Contract Type**: copy the `Contract Type` value verbatim (structure-order / derived-display / state-lifecycle-negative)
+   - **Required Observable Value**: copy the value **verbatim** from the work plan row, preserving its exact wording and detail
+   - **Compliance Check**: write a Y/N-answerable positive predicate stating the final implementation reproduces the value (e.g., "the listed fields render in the specified order"; "the label shows the looked-up name in place of the raw code"; "the persisted state is applied only when the restore signal is present")
+4. **Apply only when provided**: Run this propagation only when the work plan contains a Reference Contract Values table. Serialized boundaries are propagated by Connection Map Propagation above, not here.
 
 ## Change Category Classification
 
@@ -333,6 +346,7 @@ Please execute decomposed tasks according to the order.
 - [ ] UI Spec Component → Task Mapping rows propagated to matching tasks (when work plan has the table)
 - [ ] Connection Map boundary rows propagated to matching tasks (when work plan has the table)
 - [ ] Design-to-Plan Traceability rows propagated to matching tasks as Investigation Targets (when work plan has the table)
+- [ ] Reference Contract Values rows propagated to matching tasks as Reference Contracts, value copied verbatim (when work plan has the table)
 - [ ] ADR Bindings rows propagated to matching tasks as Binding Decisions (when work plan has the table)
   - [ ] Source includes ADR path with section hint
   - [ ] Axis copied verbatim from the work plan row to the task's Binding Decisions table

--- a/agents/task-executor-frontend.md
+++ b/agents/task-executor-frontend.md
@@ -145,7 +145,7 @@ Runs after Pre-implementation Verification, before the Binding Decision Check. T
 
 1. From the Investigation Targets (the decomposition already extended them with the adjacent files), identify the cases sharing the same path, contract, persisted state, or external boundary as the change — fallback rendering, stale state, retries, and external calls related to the change.
 2. Check each for the same class of defect this task corrects.
-3. Fold adjacent residuals within the Target Files scope into this task's failing tests and implementation. Record any residual outside scope in the task file's Investigation Notes so downstream review (code-reviewer / verifier) can detect it.
+3. Plan to fold adjacent residuals within the Target Files scope into this task's failing tests and implementation during the Red phase. Record any residual outside scope in the task file's Investigation Notes so downstream review (code-reviewer) can read and detect it.
 
 #### Binding Decision Check (Required when the task file has a Binding Decisions section)
 
@@ -158,6 +158,18 @@ Runs after Pre-implementation Verification, before the TDD cycle.
    - `Y`: proceed
    - `N`: stop implementation and produce the final response with `status: "escalation_needed"` and `escalation_type: "binding_decision_violation"` with `phase: "pre_implementation"` (see Binding Decision Violation Escalation in Structured Response Specification). `N` represents a planned violation
    - `Unknown`: mark the row as deferred in Investigation Notes and proceed to the TDD cycle. The Exit Gate re-evaluates every row (including Unknown rows deferred from this step) against the final implementation and escalates if any remains `N` or `Unknown` at that point
+
+#### Reference Contract Check (Required when the task file has a Reference Contracts section)
+
+Runs after Pre-implementation Verification, alongside the Binding Decision Check.
+
+1. Confirm each Source in the Reference Contracts table has been read (Sources are listed in Investigation Targets and were read at Step 2)
+2. Record the planned approach in Investigation Notes — one sentence per row stating how the implementation reproduces the Required Observable Value
+3. Evaluate each row's Compliance Check against the planned approach. Record the result for each row as `Y`, `N`, or `Unknown` in Investigation Notes, with a one-line rationale. Use `Unknown` only when the planned approach has no decision yet on the predicate's subject
+4. Per row, branch on the evaluation:
+   - `Y`: proceed
+   - `N`: stop implementation and produce the final response with `status: "escalation_needed"` and `escalation_type: "design_compliance_violation"` (Escalation Response 2-1), populating `details.design_doc_expectation` with the Reference Contract row's Required Observable Value and `details.actual_situation` with the planned approach
+   - `Unknown`: mark the row as deferred in Investigation Notes and proceed to the TDD cycle. The Exit Gate re-evaluates every deferred row against the final implementation
 
 #### Reference Representativeness (Applied During Implementation)
 
@@ -349,6 +361,8 @@ This gate runs immediately before producing the final JSON response.
 ☐ All task checkboxes completed with evidence (or `escalation_needed` triggered earlier)
 ☐ Implementation is consistent with the Investigation Notes recorded at Step 2 (when Investigation Targets were present)
 ☐ Every Binding Decisions Compliance Check evaluates to `Y` against the final implementation, with evidence recorded in Investigation Notes (when the task file has a Binding Decisions section). Re-evaluate here even when the pre-implementation check passed, because the implementation may have diverged from the planned approach
+☐ Every Reference Contracts Compliance Check evaluates to `Y` against the final implementation, with evidence recorded in Investigation Notes (when the task file has a Reference Contracts section). Re-evaluate here even when the pre-implementation check passed
+☐ A test exercises the roundtrip — the value the producer emits parses to the value the consumer expects (when the task has a Boundary Context with a roundtrip check from the work plan's Connection Map)
 ☐ When test runs are cited as `runnableCheck` evidence, they are substantive and executable per the runnableCheck.result field spec (skipped tests, placeholder/TODO-only bodies, always-passing assertions, and 0-match runner reports do not count); non-test verification (build/typecheck/CLI) is not subject to this check
 ☐ Final response is a single JSON with `status: "completed"` or `status: "escalation_needed"` and matches the schema in Structured Response Specification
 

--- a/agents/task-executor.md
+++ b/agents/task-executor.md
@@ -140,7 +140,7 @@ Runs after Pre-implementation Verification, before the Binding Decision Check. T
 
 1. From the Investigation Targets (the decomposition already extended them with the adjacent files), identify the cases sharing the same path, contract, persisted state, or external boundary as the change — fallback behavior, stale state, retries, and external calls related to the change.
 2. Check each for the same class of defect this task corrects.
-3. Fold adjacent residuals within the Target Files scope into this task's failing tests and implementation. Record any residual outside scope in the task file's Investigation Notes so downstream review (code-reviewer / verifier) can detect it.
+3. Plan to fold adjacent residuals within the Target Files scope into this task's failing tests and implementation during the Red phase. Record any residual outside scope in the task file's Investigation Notes so downstream review (code-reviewer) can read and detect it.
 
 #### Binding Decision Check (Required when the task file has a Binding Decisions section)
 
@@ -153,6 +153,18 @@ Runs after Pre-implementation Verification, before the TDD cycle.
    - `Y`: proceed
    - `N`: stop implementation and produce the final response with `status: "escalation_needed"` and `escalation_type: "binding_decision_violation"` with `phase: "pre_implementation"` (see Binding Decision Violation Escalation in Structured Response Specification). `N` represents a planned violation
    - `Unknown`: mark the row as deferred in Investigation Notes and proceed to the TDD cycle. The Exit Gate re-evaluates every row (including Unknown rows deferred from this step) against the final implementation and escalates if any remains `N` or `Unknown` at that point
+
+#### Reference Contract Check (Required when the task file has a Reference Contracts section)
+
+Runs after Pre-implementation Verification, alongside the Binding Decision Check.
+
+1. Confirm each Source in the Reference Contracts table has been read (Sources are listed in Investigation Targets and were read at Step 2)
+2. Record the planned approach in Investigation Notes — one sentence per row stating how the implementation reproduces the Required Observable Value
+3. Evaluate each row's Compliance Check against the planned approach. Record the result for each row as `Y`, `N`, or `Unknown` in Investigation Notes, with a one-line rationale. Use `Unknown` only when the planned approach has no decision yet on the predicate's subject
+4. Per row, branch on the evaluation:
+   - `Y`: proceed
+   - `N`: stop implementation and produce the final response with `status: "escalation_needed"` and `escalation_type: "design_compliance_violation"` (Escalation Response 2-1), populating `details.design_doc_expectation` with the Reference Contract row's Required Observable Value and `details.actual_situation` with the planned approach
+   - `Unknown`: mark the row as deferred in Investigation Notes and proceed to the TDD cycle. The Exit Gate re-evaluates every deferred row against the final implementation
 
 #### Reference Representativeness (Applied During Implementation)
 
@@ -344,6 +356,8 @@ This gate runs immediately before producing the final JSON response.
 ☐ All task checkboxes completed with evidence (or `escalation_needed` triggered earlier)
 ☐ Implementation is consistent with the Investigation Notes recorded at Step 2 (when Investigation Targets were present)
 ☐ Every Binding Decisions Compliance Check evaluates to `Y` against the final implementation, with evidence recorded in Investigation Notes (when the task file has a Binding Decisions section). Re-evaluate here even when the pre-implementation check passed, because the implementation may have diverged from the planned approach
+☐ Every Reference Contracts Compliance Check evaluates to `Y` against the final implementation, with evidence recorded in Investigation Notes (when the task file has a Reference Contracts section). Re-evaluate here even when the pre-implementation check passed
+☐ A test exercises the roundtrip — the value the producer emits parses to the value the consumer expects (when the task has a Boundary Context with a roundtrip check from the work plan's Connection Map)
 ☐ When test runs are cited as `runnableCheck` evidence, they are substantive and executable per the runnableCheck.result field spec (skipped tests, placeholder/TODO-only bodies, always-passing assertions, and 0-match runner reports do not count); non-test verification (build/typecheck/CLI) is not subject to this check
 ☐ Final response is a single JSON with `status: "completed"` or `status: "escalation_needed"` and matches the schema in Structured Response Specification
 

--- a/agents/technical-designer-frontend.md
+++ b/agents/technical-designer-frontend.md
@@ -47,7 +47,6 @@ The subsections below are not parallel mandates; they form four serial gates. Co
 Each subsection below carries a `[Gate N — ...]` annotation in its heading. Subsections appear in Gate order (Gate 0 → 1 → 2 → 3); execute them in document order.
 
 ### Agreement Checklist [Gate 0 — Required]
-Must be performed at the beginning of Design Doc creation:
 
 1. **List agreements with user in bullet points**
    - Scope (which components/features to change)
@@ -64,7 +63,6 @@ Must be performed at the beginning of Design Doc creation:
 Fill the Design Doc's "External Resources Used" subsection (under Background and Context) per the external-resource-context skill (feature-tier protocol). When a UI Spec exists, inherit its External Resources Used table and expand it with Design-Doc-specific resources (API schema source, IaC source, etc.).
 
 ### Standards Identification [Gate 0 — Required]
-Must be performed before existing-state investigation:
 
 1. **Identify Project Standards**
    - Scan project configuration, rule files, UI Spec / UI analysis inputs, and existing frontend code patterns
@@ -86,7 +84,6 @@ Must be performed before existing-state investigation:
    - Deviations require documented rationale
 
 ### Existing Code Investigation [Gate 1 — Required]
-Must be performed before Design Doc creation:
 
 1. **Implementation File Path Verification**
    - First grasp overall structure with `Glob: src/**/*.tsx`
@@ -168,7 +165,6 @@ Execute the 5 steps below for each in-scope element, and record the result in th
    - For each rejected alternative, record 1-2 lines: what it was, why rejected. Include in the Design Doc to prevent re-proposal in subsequent iterations or by future agents.
 
 ### Implementation Approach Decision [Gate 2 — Required]
-Must be performed when creating Design Doc:
 
 1. **Approach Selection Criteria**
    - Execute Phase 1-4 of implementation-approach skill to select strategy
@@ -182,7 +178,6 @@ Must be performed when creating Design Doc:
    - Verification level for each task (L1/L2/L3 defined in implementation-approach skill)
 
 ### Common ADR Process [Gate 2 — Required]
-Perform before Design Doc creation:
 1. Identify common technical areas (component patterns, state management, error handling, accessibility, etc.)
 2. Search `docs/ADR/ADR-COMMON-*`, create if not found
 3. Include in Design Doc's "Prerequisite ADRs"
@@ -194,6 +189,9 @@ Define Props types and state management contracts between components (types, pre
 
 ### State Transitions [Gate 2 — Required when applicable]
 Document state definitions and transitions for stateful components (loading, error, success states).
+
+### Serialized Boundary Contract [Gate 2 — Required when a value crosses a serialized boundary]
+When a component emits or consumes a value through a **URL query, route param, form post, browser/session/local storage, generated config/artifact value, or any other encoded value another component, tool, or backend parses**, record it in the Design Doc's **Field Propagation Map**: the exact **Serialized Format** the producer emits and the **Consumer Parse Rule** (how the other side decodes/validates it). The producer and consumer must agree on the representation. Skip when no value crosses a serialized boundary.
 
 ## UI Spec Integration
 
@@ -222,7 +220,6 @@ For each integration boundary, define the contract:
 Confirm and document conflicts with existing components (naming conventions, prop patterns) at each integration point.
 
 ### Change Impact Map [Gate 3 — Required]
-Must be included when creating Design Doc:
 
 ```yaml
 Change Target: UserProfileCard component
@@ -300,34 +297,19 @@ When conversion is required, clearly specify wrapper implementation or migration
 - Follow respective templates (`template-en.md`)
 - For ADR, check existing numbers and use max+1, initial status is "Proposed"
 
-## ADR Responsibility Boundaries
+## Output Rules
 
-Include in ADR: Decisions, rationale, principled guidelines
-Exclude from ADR: Schedules, implementation procedures, specific code
-
-Implementation guidelines should only include principles (e.g., "Use custom hooks for logic reuse" ✓, "Implement in Phase 1" ✗)
-
-## Output Policy
-Execute file output immediately (considered approved at execution).
-
-## Scope Boundary
-
-Test derivation itself is a downstream agent responsibility.
-
-## Implementation Sample Standards Compliance
-
-All implementation samples in ADR and Design Docs MUST follow the loaded `typescript-rules` and `frontend-ai-guide` skills. Omit samples unless they clarify contracts or edge cases that prose cannot convey.
+- Execute file output immediately (considered approved at execution).
+- ADR includes decisions, rationale, and principled guidelines (e.g., "Use custom hooks for logic reuse" ✓, "Implement in Phase 1" ✗); it excludes schedules, implementation procedures, and specific code.
+- Test derivation is a downstream agent responsibility.
+- Implementation samples MUST follow the loaded `typescript-rules` and `frontend-ai-guide` skills; include a sample only when it clarifies a contract or edge case prose cannot convey.
 
 ## Diagram Creation (using mermaid notation)
 
 **ADR**: Option comparison diagram, decision impact diagram
 **Design Doc**: Component hierarchy diagram and data flow diagram are mandatory. Add state transition diagram and sequence diagram for complex cases.
 
-**React Diagrams**:
-- Component hierarchy following the project's adopted architecture (e.g., Atoms → Molecules → Organisms → Templates → Pages for Atomic Design; feature-folder tree for Feature-based; container vs presenter split for Container-Presenter)
-- Props flow diagram (parent → child data flow)
-- State management diagram (Context, custom hooks)
-- User interaction flow (click → state update → re-render)
+**React Diagrams**: component hierarchy (per the project's adopted architecture — Atomic Design layers, Feature-based folder tree, or Container/Presenter split), props flow (parent → child), state management (Context, custom hooks), and user interaction flow (click → state update → re-render).
 
 ## Final Output Check
 

--- a/agents/technical-designer.md
+++ b/agents/technical-designer.md
@@ -49,7 +49,6 @@ The subsections below are not parallel mandates; they form four serial gates. Co
 Each subsection below carries a `[Gate N — ...]` annotation in its heading. Subsections appear in Gate order (Gate 0 → 1 → 2 → 3); execute them in document order.
 
 ### Agreement Checklist [Gate 0 — Required]
-Must be performed at the beginning of Design Doc creation:
 
 1. **List agreements with user in bullet points**
    - Scope (what to change)
@@ -66,7 +65,6 @@ Must be performed at the beginning of Design Doc creation:
 Fill the Design Doc's "External Resources Used" subsection (under Background and Context) per the external-resource-context skill (feature-tier protocol).
 
 ### Standards Identification [Gate 0 — Required]
-Must be performed before any investigation:
 
 1. **Identify Project Standards**
    - Scan project configuration, rule files, and existing code patterns
@@ -88,7 +86,6 @@ Must be performed before any investigation:
    - Deviations require documented rationale
 
 ### Existing Code Investigation [Gate 1 — Required]
-Must be performed before Design Doc creation:
 
 1. **Implementation File Path Verification**
    - First grasp overall structure using Glob with detected project patterns
@@ -187,7 +184,6 @@ Execute the 5 steps below for each in-scope element, and record the result in th
    - For each rejected alternative, record 1-2 lines: what it was, why rejected. Include in the Design Doc to prevent re-proposal in subsequent iterations or by future agents.
 
 ### Implementation Approach Decision [Gate 2 — Required]
-Must be performed when creating Design Doc:
 
 1. **Approach Selection Criteria**
    - Execute Phase 1-4 of implementation-approach skill to select strategy
@@ -210,7 +206,6 @@ Must be performed when creating Design Doc:
    - Define early verification point: what is the first thing to verify, and how, to confirm the approach is correct before scaling. For replacements/modifications, the early verification point must be an output comparison of at least one representative case
 
 ### Common ADR Process [Gate 2 — Required]
-Perform before Design Doc creation:
 1. Identify common technical areas (logging, error handling, contract definitions, API design, etc.)
 2. Search `docs/ADR/ADR-COMMON-*`, create if not found
 3. Include in Design Doc's "Prerequisite ADRs"
@@ -240,7 +235,6 @@ For each integration boundary, define the contract:
 Confirm and document conflicts with existing systems (priority, naming conventions) at each integration point.
 
 ### Change Impact Map [Gate 3 — Required]
-Must be included when creating Design Doc:
 
 ```yaml
 Change Target: [ServiceName.methodName()]
@@ -258,6 +252,9 @@ No Ripple Effect:
 When new or changed fields cross component boundaries:
 
 Document each field's status (preserved / transformed / dropped) at each boundary with rationale.
+
+When the boundary is **serialized** — the value is encoded and re-parsed across a medium such as a query string, CLI argument, environment variable, config entry, message/queue payload, storage key, or file — also fill the template's **Serialized Format** (the exact representation the producer emits) and **Consumer Parse Rule** (how the consumer decodes/validates it) columns, so producer and consumer agree on the representation. Set both to "—" for in-memory field crossings.
+
 Skip if no fields cross component boundaries.
 
 ### Interface Change Impact Analysis [Gate 3 — Required]
@@ -314,23 +311,12 @@ When conversion is required, clearly specify adapter implementation or migration
 - Follow respective templates (`template.md`)
 - For ADR, check existing numbers and use max+1, initial status is "Proposed"
 
-## ADR Responsibility Boundaries
+## Output Rules
 
-Include in ADR: Decisions, rationale, principled guidelines
-Exclude from ADR: Schedules, implementation procedures, specific code
-
-Implementation guidelines should only include principles (e.g., "Use dependency injection"), not schedules or procedures.
-
-## Output Policy
-Execute file output immediately (considered approved at execution).
-
-## Scope Boundary
-
-Test derivation itself is a downstream agent responsibility.
-
-## Implementation Sample Standards Compliance
-
-All implementation samples in ADR and Design Docs MUST follow the loaded `coding-principles` and `testing-principles` skills. Omit samples unless they clarify contracts or edge cases that prose cannot convey.
+- Execute file output immediately (considered approved at execution).
+- ADR includes decisions, rationale, and principled guidelines (e.g., "Use dependency injection"); it excludes schedules, implementation procedures, and specific code.
+- Test derivation is a downstream agent responsibility.
+- Implementation samples MUST follow the loaded `coding-principles` and `testing-principles` skills; include a sample only when it clarifies a contract or edge case prose cannot convey.
 
 ## Diagram Creation (using mermaid notation)
 

--- a/agents/work-planner.md
+++ b/agents/work-planner.md
@@ -96,6 +96,8 @@ Map each extracted item to a covering task. Items may be covered by a dedicated 
 
 Record the mapping in the Design-to-Plan Traceability table (see plan template). If an item has no covering task, set Gap Status to `gap` with justification in Notes. Gaps with justification require user confirmation before plan approval.
 
+**Carry binding observable values verbatim.** When a Traceability row's DD Item encodes a binding observable value — a column/label set and order, a derived-display rule (a display value derived from another field), or a state-lifecycle negative (a condition under which the state must stay unused) — copy that value **verbatim from the Design Doc** into the plan's **Reference Contract Values** table (see plan template), one row per value, mapped to the covering task(s). Preserve the full value, so the covering task is later checked against this exact value rather than a re-derived summary. This table covers DD-derived observable contracts only; serialized boundaries go in the Connection Map (step 5b) and ADR-derived structural decisions in the ADR Bindings table.
+
 ### 5a. Map UI Spec Components to Tasks (when UI Spec provided)
 
 When a UI Spec is among the inputs, also map components and states to the tasks that implement them. This mapping is required for downstream task generation; without it the UI Spec does not reach the implementation phase.
@@ -107,25 +109,25 @@ For each component documented in the UI Spec:
 
 Record the mapping in the **UI Spec Component → Task Mapping** table (see plan template). One row per component. Components with no covering task are flagged as `gap` requiring user confirmation, identical to the Design-to-Plan Traceability rule.
 
-### 5b. Map Cross-Package Boundaries to Tasks (when implementation crosses runtime/deployment boundaries)
+### 5b. Map Boundaries to Tasks (when crossing a runtime/deployment boundary, or passing a serialized value across any boundary)
 
-When the implementation crosses a runtime or deployment boundary, build a Connection Map. This map is required so boundary context propagates to each affected task in the downstream task generation phase.
+Build a Connection Map when the implementation crosses a runtime or deployment boundary, **or when a value is serialized and re-parsed across any boundary (even within one runtime)**. This map is required so boundary context propagates to each affected task in the downstream task generation phase.
 
-**A boundary qualifies for the Connection Map only when ALL of the following hold**:
-- The two sides run in separate processes, services, or runtimes (e.g., web client ↔ HTTP server, service A ↔ service B over a network, frontend bundle ↔ backend handler)
-- A serialized contract crosses between them (HTTP request/response, message envelope, RPC call, event payload)
-- A failure on one side produces an observable signal on the other (status code, missing field, timeout, dropped message)
+**A boundary qualifies for the Connection Map when EITHER condition holds**:
+- *Cross-process*: the two sides run in separate processes, services, or runtimes (web client ↔ HTTP server, service A ↔ service B, frontend bundle ↔ backend handler); a serialized contract crosses between them (HTTP request/response, message envelope, RPC, event payload); and a failure on one side produces an observable signal on the other.
+- *Serialized in-runtime*: a value is encoded and re-parsed across a boundary even within a single runtime — through a medium such as a query string, CLI argument, environment variable, config entry, message/queue payload, storage key, or file (e.g., one component encodes a value another component or process later decodes; a value written to storage and read after a transition). The producer and consumer must agree on the exact representation.
 
 **Excluded — these are NOT boundaries for the Connection Map**:
-- A package importing a sibling utility, type definition, or shared constant from the same monorepo (in-process, no serialized contract)
-- Internal layering within the same runtime (e.g., handler → usecase → repository)
+- A package importing a sibling utility, type definition, or shared constant from the same monorepo (in-process, no serialized value)
+- Internal layering within the same runtime where values pass as typed in-memory calls (e.g., handler → usecase → repository)
 - Source code dependencies that compile/bundle into the same artifact
 
 For each qualifying boundary:
-1. Identify the boundary (e.g., `web → API gateway`, `service-A → service-B`, `frontend → shared client → backend handler`)
-2. Identify the owner module/package on each side
-3. Identify the expected signal that confirms the boundary works (e.g., HTTP 200 with schema X, message published to topic Y, row inserted in table Z)
-4. Identify the task(s) that implement either side of the boundary
+1. Identify the boundary (e.g., `service A → service B`, `producer → storage → consumer`, `component A → component B via an encoded parameter`)
+2. Identify the owner module/component on each side (producer and consumer)
+3. For a serialized boundary, record the **Serialized Format** (the exact representation the producer emits) and the **Consumer Parse Rule** (how the consumer decodes/validates it). Set both to "—" when the contract is already captured by the Expected Signal (e.g., a cross-process call whose body matches the agreed schema); fill them when producer and consumer must agree on a specific encoding of a value (query string, storage key, CLI argument, config entry, message field).
+4. Identify the expected signal that confirms the boundary works (e.g., a response matching the agreed schema; the consumer reproducing the producer's values)
+5. Identify the task(s) that implement either side of the boundary
 
 Record the mapping in the **Connection Map** table (see plan template). Omit this section entirely when no qualifying boundary exists.
 
@@ -319,11 +321,15 @@ When creating work plans, **Phase Structure Diagrams** and **Task Dependency Dia
 - [ ] Design-to-Plan Traceability table complete (all DD technical requirements categorized and mapped)
   - [ ] No `gap` entries without justification
   - [ ] All justified `gap` entries flagged for user confirmation before plan approval
+- [ ] Reference Contract Values table complete (when the Design Doc specifies binding observable values: column/label order, derived-display, state-lifecycle negative)
+  - [ ] Each value copied verbatim from the Design Doc, preserving full wording
+  - [ ] Each value mapped to a covering task
 - [ ] UI Spec Component → Task Mapping table complete (when UI Spec provided)
   - [ ] Every UI Spec component has a covering task, OR an explicit `gap` justification
   - [ ] Component reference uses the UI Spec section heading exactly as it appears in the document
-- [ ] Connection Map table complete (when implementation crosses packages/services)
+- [ ] Connection Map table complete (when crossing packages/services, or passing a serialized value across any boundary)
   - [ ] Every boundary lists owner modules and expected signal
+  - [ ] Serialized boundaries record Serialized Format and Consumer Parse Rule
   - [ ] Every boundary maps to at least one covering task on each side
 - [ ] ADR Bindings table complete (when ADR provided or referenced from Design Doc)
   - [ ] Each row represents one implementation-binding decision (placement, dependency, contract, data flow, or persistence)

--- a/dev-skills/.claude-plugin/plugin.json
+++ b/dev-skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-skills",
   "description": "Lightweight skills for users with existing workflows - coding best practices, testing principles, and design guidelines without recipe workflows or agents",
-  "version": "0.20.5",
+  "version": "0.21.0",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-skills/skills/documentation-criteria/references/design-template.md
+++ b/dev-skills/skills/documentation-criteria/references/design-template.md
@@ -107,10 +107,7 @@ Keywords determine test type and reduce ambiguity.
 - [ ] **When** user clicks login button with valid credentials, the system shall authenticate and redirect to dashboard
 - [ ] **If** credentials are invalid, **then** the system shall display error message "Invalid credentials"
 - [ ] **While** user is logged in, the system shall maintain the session for configured timeout period
-
-### [Functional Requirement 2]
-
-- [ ] The system shall display data list with pagination of 10 items per page
+- [ ] (ubiquitous, no keyword) The system shall display the data list with pagination of 10 items per page
 
 ## Existing Codebase Analysis
 
@@ -174,14 +171,11 @@ No Ripple Effect:
 
 | Integration Point | Location | Old Implementation | New Implementation | Switching Method | Verification Method |
 |-------------------|----------|-------------------|-------------------|------------------|-------------------|
-| Integration Point 1 | [Class/Function] | [Existing Process] | [New Process] | [DI/Factory etc.] | [How to verify this switching works] |
-| Integration Point 2 | [Another Location] | [Existing] | [New] | [Method] | [Verification approach] |
+| [Integration Point] | [Class/Function] | [Existing Process or N/A] | [New Process] | [DI/Factory/config/etc.] | [How to verify this switching works] |
 
 ### Main Components
 
-Repeat the block below for each component.
-
-#### Component 1
+#### [Component] (repeat per component)
 
 - **Responsibility**: [Scope of responsibility for this component]
 - **Interface**: [APIs and contract definitions provided]
@@ -206,7 +200,6 @@ One entry per new in-scope element. This section records the 5-step output produ
 
 **Step 1 — Fixed Requirements**
 - [AC ID or constraint ID]: [requirement / constraint text]
-- [AC ID or constraint ID]: [requirement / constraint text]
 
 **Steps 2–3 — Alternatives Compared**
 
@@ -214,7 +207,6 @@ One entry per new in-scope element. This section records the 5-step output produ
 |---|---|---|---|---|---|---|
 | [The added element as proposed] | | | | | | |
 | [Subtractive alternative — derive / compute on demand / keep at caller / reuse existing / do not introduce new state] | | | | | | |
-| [Optional third alternative] | | | | | | |
 
 **Step 4 — Selected Alternative and Rationale**
 - **Selected**: [alternative name]
@@ -224,23 +216,17 @@ One entry per new in-scope element. This section records the 5-step output produ
 
 **Step 5 — Rejected Alternatives Log**
 - [Alternative name]: [1-2 lines on what it was and why rejected]
-- [Alternative name]: [1-2 lines on what it was and why rejected]
 
 (Repeat the Element block above for each additional in-scope element.)
 
 Mark the whole section as N/A with brief rationale when the design introduces no in-scope elements.
 
-### Contract Definitions
+### Data Contracts
 
-```
-// Record major contract/interface definitions here
-```
-
-### Data Contract
-
-#### Component 1
+#### [Component or Boundary] (repeat per component/boundary)
 
 ```yaml
+Contract: [interface / function / API / schema name]
 Input:
   Type: [Data shape, contract, or schema]
   Preconditions: [Required items, format constraints]
@@ -257,9 +243,11 @@ Invariants:
 
 ### Field Propagation Map (When Fields Cross Boundaries)
 
-| Field | Boundary | Status | Detail |
-|-------|----------|--------|--------|
-| [field name] | [Component A → B] | preserved / transformed / dropped | [logic or reason] |
+A boundary here includes a **serialized boundary** — a value encoded on one side and parsed on the other through a medium such as a query string, CLI argument, environment variable, config entry, message/queue payload, storage key, or file — not only cross-process calls. For those, record the exact encoded representation and how the consumer parses it, so producer and consumer agree.
+
+| Field | Boundary | Status | Serialized Format | Consumer Parse Rule | Detail |
+|-------|----------|--------|-------------------|---------------------|--------|
+| [field name] | [Component A → B] | preserved / transformed / dropped | [exact representation the producer emits when the boundary is serialized; "—" otherwise] | [how the consumer decodes and validates that representation; "—" when not serialized] | [logic or reason] |
 
 ### State Transitions and Invariants (When Applicable)
 
@@ -317,9 +305,7 @@ System Invariants:
 
 ### Technical Dependencies and Implementation Order
 
-#### Required Implementation Order
-
-Repeat the entry below for each component/feature, in dependency order.
+#### Required Implementation Order (in dependency order, one entry per component/feature)
 
 1. **[Component/Feature]**
    - Technical Reason: [Why this needs to be implemented at this position]
@@ -365,15 +351,11 @@ Verification Strategy defines what correctness means and how to prove it at desi
 
 ### Correctness Proof Method
 
-How will this change's correctness be demonstrated?
-
 - **Correctness definition**: [What "correct" means for this change — e.g., "output matches existing behavior", "all ACs pass in production-equivalent environment", "generated queries execute without error on target DB"]
 - **Verification method**: [Specific technique — e.g., "compare new implementation output against existing implementation", "run against staging DB", "contract test with real API"]
 - **Verification timing**: [When verification occurs — e.g., "after first vertical slice", "per repository", "at integration phase"]
 
 ### Early Verification Point
-
-What is verified first, and how, to confirm the approach is correct before scaling?
 
 - **First verification target**: [The smallest unit that proves the approach works — e.g., "first repository migration", "single API endpoint", "one screen flow"]
 - **Success criteria**: [Observable outcome — e.g., "CSV download produces identical output to legacy", "API returns 200 with expected schema"]
@@ -400,12 +382,9 @@ This section records what was **excluded** from the current design surface. Spec
 
 ## Alternative Solutions
 
-### Alternative 1
-
-- **Overview**: [Description of alternative solution]
-- **Advantages**: [Advantages]
-- **Disadvantages**: [Disadvantages]
-- **Reason for Rejection**: [Why it wasn't adopted]
+| Alternative | Overview | Advantages | Disadvantages | Reason for Rejection |
+|---|---|---|---|---|
+| [Alternative 1] | | | | |
 
 ## Risks and Mitigation
 

--- a/dev-skills/skills/documentation-criteria/references/plan-template.md
+++ b/dev-skills/skills/documentation-criteria/references/plan-template.md
@@ -51,6 +51,16 @@ Maps each Design Doc technical requirement to the covering task(s). One row per 
 
 **Gap Status values**: `covered` (task exists), `gap` (no task — requires justification in Notes, user confirmation required before plan approval)
 
+## Reference Contract Values
+
+Include this section when a Traceability row's DD Item encodes a **binding observable value** the implementation must reproduce exactly: a column/label set and order, a derived-display rule (display value derived from another field), or a state-lifecycle negative (the condition under which the state must stay unused). **Serialized boundaries** (a value encoded and re-parsed across a boundary) are owned by the Connection Map / Field Propagation Map — record those there. These are DD-derived observable contracts; ADR-derived structural decisions belong in ADR Bindings. Omit the section when none apply.
+
+The Traceability table records *that* a row is covered; this table carries the row's value *verbatim* so the covering task can be checked against the exact contract rather than a re-derived summary.
+
+| Design Doc (§ Section) | Contract Type | Required Observable Value (verbatim) | Covered By Task(s) |
+|---|---|---|---|
+| [docs/design/XXX.md (§ Section)] | structure-order / derived-display / state-lifecycle-negative | [the exact value copied from the Design Doc — e.g., "the listed fields in the specified order"; "the label shows the looked-up name in place of the raw code"; "the persisted state is applied only when an explicit restore signal is present"] | [Phase X Task Y] |
+
 ## Failure Mode Checklist
 
 Domain-independent failure categories this implementation must guard against. Enumerate all eight categories, mark which apply, and list a covering task for each that applies; keep entries free of project-specific names.
@@ -92,11 +102,13 @@ One row per binding decision. A single ADR can contribute multiple rows. A singl
 
 ## Connection Map
 
-Include this section when the implementation crosses more than one package, service, or process boundary. Document each boundary. Omit the section when the implementation stays within a single package.
+Include this section when the implementation crosses a package, service, or process boundary, **or when a value is serialized and re-parsed across a boundary even within a single runtime** — through a medium such as a query string, CLI argument, environment variable, config entry, message/queue payload, storage key, or file (the producer and consumer must agree on the exact representation). Omit the section when no such boundary exists.
 
-| Boundary | Owner (left side) | Owner (right side) | Expected Signal | Covered By Task(s) |
-|---|---|---|---|---|
-| [e.g., "web client → API gateway"] | [module/package on the request side] | [module/package on the response side] | [Observable evidence the boundary works — e.g., "HTTP 200 with response matching ContractA", "row inserted in tableB", "message published to topicC"] | [Phase X Task Y on each side] |
+For a serialized boundary, fill Serialized Format and Consumer Parse Rule. Set them to "—" when the contract is already captured by the Expected Signal (e.g., a cross-process call whose body matches the agreed schema); fill them when producer and consumer must agree on a specific encoding of a value (query string, storage key, CLI argument, config entry, message field).
+
+| Boundary | Owner (left side) | Owner (right side) | Serialized Format | Consumer Parse Rule | Expected Signal | Covered By Task(s) |
+|---|---|---|---|---|---|---|
+| [producing side → consuming side] | [module/component on the producing side] | [module/component on the consuming side] | [exact representation the producer emits; "—" if not serialized] | [how the consumer decodes/validates it; "—" if not serialized] | [Observable evidence the boundary works — e.g., a response matching the agreed contract, or the consumer reproducing the producer's values] | [Phase X Task Y on each side] |
 
 ## Objective
 [Why this change is necessary, what problem it solves]

--- a/dev-skills/skills/documentation-criteria/references/task-template.md
+++ b/dev-skills/skills/documentation-criteria/references/task-template.md
@@ -33,6 +33,15 @@ Each row is an ADR decision the implementation in this task must comply with.
 |---|---|---|---|
 | [docs/adr/ADR-XXXX.md (§ <Source Section>) — substitute the section name (`Decision` or `Implementation Guidance`) from the matching work plan row] | [Axis value copied verbatim from the work plan's ADR Bindings row] | [Binding decision copied from the work plan's ADR Bindings row] | [Y/N-answerable positive predicate that evaluates whether the planned/final implementation satisfies the decision] |
 
+## Reference Contracts
+(Include this section when the work plan's Reference Contract Values table covers this task. Omit otherwise.)
+
+Each row is a DD-derived observable contract the implementation in this task must reproduce exactly. Serialized boundaries are carried by the Boundary Context (from the work plan's Connection Map), and ADR-derived structural decisions by Binding Decisions above.
+
+| Source | Contract Type | Required Observable Value | Compliance Check |
+|---|---|---|---|
+| [Design Doc path (§ Section) copied from the matching work plan Reference Contract Values row] | [Contract Type copied from the work plan row: structure-order / derived-display / state-lifecycle-negative] | [Required Observable Value copied verbatim from the work plan row] | [Y/N-answerable positive predicate that evaluates whether the planned/final implementation reproduces the value] |
+
 ## Investigation Notes
 (Implementation observations are appended here before implementation begins. When Binding Decisions exist, record the planned implementation approach and each Compliance Check result here.)
 
@@ -79,6 +88,7 @@ Each row is an ADR decision the implementation in this task must comply with.
 - [ ] Each Proof Obligation is met: the test turns red under its primary failure mode and exercises the stated boundary
 - [ ] Deliverables created (for research/design tasks)
 - [ ] (When Binding Decisions exist) Every Compliance Check evaluates to `Y` against the final implementation, with evidence recorded in Investigation Notes (file:line, test result, or command output)
+- [ ] (When Reference Contracts exist) Every Reference Contract Compliance Check evaluates to `Y` against the final implementation, with evidence recorded in Investigation Notes
 
 ## Notes
 - Impact scope: [Areas where changes may propagate]

--- a/dev-skills/skills/frontend-ai-guide/SKILL.md
+++ b/dev-skills/skills/frontend-ai-guide/SKILL.md
@@ -178,7 +178,7 @@ Read `package.json` scripts and run them with the project's package manager (`pa
 ### Performance vs Readability
 - Prioritize readability unless React DevTools Profiler identifies a measurable bottleneck (e.g., render time exceeding 16ms, unnecessary re-renders)
 - Measure before optimizing with React DevTools Profiler
-- When React Compiler is enabled, routine memoization is automatic; manual memoization is a profiler- or identity-justified exception (measured bottleneck, or stable reference identity for third-party APIs / effect dependencies)
+- Memoization policy (React Compiler vs manual `React.memo`/`useMemo`/`useCallback`): follow the typescript-rules skill (Performance Optimization)
 - Document reason with comments when optimizing
 
 ### Granularity of Component/Type Definitions

--- a/dev-workflows-frontend/.claude-plugin/plugin.json
+++ b/dev-workflows-frontend/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflows-frontend",
   "description": "Skills + Subagents for React/TypeScript - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
-  "version": "0.20.5",
+  "version": "0.21.0",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows-frontend/agents/code-reviewer.md
+++ b/dev-workflows-frontend/agents/code-reviewer.md
@@ -45,6 +45,7 @@ Read the Design Doc **in full** and extract:
 - Architecture design and data flow
 - Interface contracts (function signatures, API endpoints, data structures)
 - Identifier specifications (resource names, endpoint paths, configuration keys, error codes, schema/model names)
+- Binding observable contracts: column/label sets and order, derived-display rules, and state-lifecycle negatives; plus Field Propagation Map rows that carry a Serialized Format + Consumer Parse Rule
 - Error handling policy
 - Non-functional requirements
 
@@ -60,7 +61,7 @@ For each acceptance criterion extracted in Step 1:
 - For behavior-changing ACs, confirm the evidence covers the boundary paths, not only the main path: where a distinct branch, state, input class, lifecycle step, or fallback governs the behavior, verify it is exercised. Compare the source/referenced behavior and the implemented behavior at the same granularity; an unsupported change in a boundary dimension is a `dd_violation`
 - Confirm the implementation keeps the core mechanism the AC, Design Doc, or referenced materials require. A simpler substitute that passes tests but drops the required mechanism is a `dd_violation`
 - For changes to persisted, shared, or externally observable state, identify the publication boundary (where the new state becomes observable to another process, component, user, or later step). State that is observable as complete while still partial, uninitialized, stale, or rollback-only is a `reliability` finding, because a downstream consumer can treat the incomplete state as complete and fail
-- When the reviewed change is classified as `bug-fix`, `regression`, `state-change`, or `boundary-change` (the task's `Change Category` field, when present, names the kind), check the cases sharing its path, contract, persisted state, or external boundary. A sibling case still carrying the same class of defect the change addressed is an `adjacent_residual` finding
+- When the reviewed change is classified as `bug-fix`, `regression`, `state-change`, or `boundary-change` (the task's `Change Category` field, when present, names the kind; when no field is present — e.g., reviewing a diff without task files — classify from the diff itself), check the cases sharing its path, contract, persisted state, or external boundary. A sibling case still carrying the same class of defect the change addressed is an `adjacent_residual` finding. When the task file is in scope, also read its Investigation Notes for residuals the executor recorded as out-of-scope, and verify each recorded residual; if it remains unfixed within the reviewed scope, report it as `adjacent_residual`, otherwise record why it is resolved or outside the review scope
 
 #### 2-2. Identifier Verification
 
@@ -81,6 +82,13 @@ Assign confidence based on evidence count:
 - **high**: 3+ sources agree
 - **medium**: 2 sources agree
 - **low**: 1 source only (implementation exists but no test or type confirmation)
+
+#### 2-4. Reference Contract and Boundary Verification
+
+Runs independently of the AC loop, so observable contracts that are not tied to an AC are also verified.
+
+1. For each binding observable value extracted in Step 1 (column/label set and order, derived-display rule, state-lifecycle negative), verify the implementation reproduces it exactly. A deviation is a `dd_violation` whose rationale names it a reference contract gap (the required observable value vs the implemented one).
+2. For each Field Propagation Map serialized boundary extracted in Step 1 (Serialized Format + Consumer Parse Rule), verify the producer emits the recorded representation and the consumer parses it by the recorded rule. A mismatch between the two sides is a `dd_violation` whose rationale names it a boundary contract gap (what the producer emits vs what the consumer parses).
 
 ### 3. Assess Code Quality
 

--- a/dev-workflows-frontend/agents/document-reviewer.md
+++ b/dev-workflows-frontend/agents/document-reviewer.md
@@ -43,7 +43,7 @@ You are an AI assistant specialized in technical document review.
 - Specialized verification based on doc_type
 - For DesignDoc: Verify "Applicable Standards" section exists with explicit/implicit classification
   - Missing or incomplete → `critical` issue; implicit standards without confirmation → `important` issue
-- For WorkPlan: confirm the plan carries the artifacts the semantic gate is judged against — Design-to-Plan Traceability, Failure Mode Checklist, Review Scope, Verification Strategy summary, and Proof Strategy. Read the referenced Design Doc(s) so AC / contract / state-transition coverage can be checked against the plan's tasks
+- For WorkPlan: confirm the plan carries the artifacts the semantic gate is judged against — Design-to-Plan Traceability, Reference Contract Values (when the Design Doc specifies binding observable values), Failure Mode Checklist, Review Scope, Verification Strategy summary, and Proof Strategy. Read the referenced Design Doc(s) so AC / contract / state-transition coverage and the content fidelity of binding observable values can be checked against the plan
 - If `code_verification` provided: extract discrepancy list and reverse coverage gaps; feed into Gate 1 as pre-verified evidence
 - If `codebase_analysis` provided: extract `focusAreas` and their `evidence` values for Gate 0 / Gate 1 Fact Disposition checks
 
@@ -108,6 +108,7 @@ For WorkPlan, additionally verify:
   - (3) Each cross-boundary, public-boundary, or persisted-state change names a task that verifies it through the real boundary — missing → `important` issue (category: `completeness`)
   - (4) Each traceability table present (Design-to-Plan, UI Spec Component, Connection Map, ADR Bindings) is filled to a granularity that resolves its target task — under-specified rows → `important` issue (category: `completeness`)
   - (5) The Failure Mode Checklist covers the plan's applicable domain-independent categories (same-value, no-op, empty input, invalid option, missing config, unavailable boundary, shared-state dependency, rollback-only visibility) — missing applicable category → `recommended` issue (category: `completeness`)
+  - (6) Binding observable values are carried with content fidelity, not only coverage: for each Design Doc observable contract that encodes a binding value (a column/label set and order, a derived-display rule, or a state-lifecycle negative), the plan's Reference Contract Values table carries the value verbatim from the Design Doc and maps it to a covering task. Re-derive each such value from the Design Doc and compare against the plan; a value reduced to a label, summarized, or absent while the Design Doc specifies it is a content-fidelity gap → `critical` issue (category: `completeness`)
   - Verdict mapping (WorkPlan): any semantic-gate `critical` issue forces the verdict to at least `needs_revision` — except a coverage gap traceable to a missing or contradictory Design Doc/input element (which re-planning cannot fix) → `rejected`; an `important`-only set caps the verdict at `approved_with_conditions`
 
 **Perspective-specific Mode**:
@@ -156,49 +157,15 @@ Complete all items before proceeding to output.
 
 ```json
 {
-  "metadata": {
-    "review_mode": "comprehensive",
-    "doc_type": "DesignDoc",
-    "target_path": "/path/to/document.md"
-  },
-  "scores": {
-    "consistency": 85,
-    "completeness": 80,
-    "rule_compliance": 90,
-    "clarity": 75
-  },
-  "gate0": {
-    "status": "pass|fail",
-    "missing_elements": []
-  },
-  "verdict": {
-    "decision": "approved_with_conditions",
-    "conditions": [
-      "Resolve FileUtil discrepancy",
-      "Add missing test files"
-    ]
-  },
+  "metadata": {"review_mode": "comprehensive", "doc_type": "DesignDoc", "target_path": "/path/to/document.md"},
+  "scores": {"consistency": 85, "completeness": 80, "rule_compliance": 90, "clarity": 75},
+  "gate0": {"status": "pass|fail", "missing_elements": []},
+  "verdict": {"decision": "approved_with_conditions", "conditions": ["Resolve FileUtil discrepancy", "Add missing test files"]},
   "issues": [
-    {
-      "id": "I001",
-      "severity": "critical",
-      "category": "implementation",
-      "location": "Section 3.2",
-      "description": "FileUtil method mismatch",
-      "suggestion": "Update document to reflect actual FileUtil usage"
-    }
+    {"id": "I001", "severity": "critical", "category": "implementation", "location": "Section 3.2", "description": "FileUtil method mismatch", "suggestion": "Update document to reflect actual FileUtil usage"}
   ],
-  "recommendations": [
-    "Priority fixes before approval",
-    "Documentation alignment with implementation"
-  ],
-  "prior_context_check": {
-    "items_received": 0,
-    "resolved": 0,
-    "partially_resolved": 0,
-    "unresolved": 0,
-    "items": []
-  }
+  "recommendations": ["Priority fixes before approval", "Documentation alignment with implementation"],
+  "prior_context_check": {"items_received": 0, "resolved": 0, "partially_resolved": 0, "unresolved": 0, "items": []}
 }
 ```
 
@@ -206,16 +173,8 @@ Complete all items before proceeding to output.
 
 ```json
 {
-  "metadata": {
-    "review_mode": "perspective",
-    "focus": "implementation",
-    "doc_type": "DesignDoc",
-    "target_path": "/path/to/document.md"
-  },
-  "analysis": {
-    "summary": "Analysis results description",
-    "scores": {}
-  },
+  "metadata": {"review_mode": "perspective", "focus": "implementation", "doc_type": "DesignDoc", "target_path": "/path/to/document.md"},
+  "analysis": {"summary": "Analysis results description", "scores": {}},
   "issues": [],
   "checklist": [
     {"item": "Check item description", "status": "pass|fail|na"}
@@ -236,12 +195,7 @@ Include in output when `prior_context_count > 0`:
     "partially_resolved": 1,
     "unresolved": 0,
     "items": [
-      {
-        "id": "D001",
-        "status": "resolved",
-        "location": "Section 3.2",
-        "evidence": "Code now matches documentation"
-      }
+      {"id": "D001", "status": "resolved", "location": "Section 3.2", "evidence": "Code now matches documentation"}
     ]
   }
 }

--- a/dev-workflows-frontend/agents/task-decomposer.md
+++ b/dev-workflows-frontend/agents/task-decomposer.md
@@ -183,7 +183,7 @@ When the work plan contains a Connection Map table, propagate boundary context t
 
 1. **Lookup by task ID**: For each row in the Connection Map, locate the task(s) listed in the "Covered By Task(s)" column
 2. **Append to Investigation Targets**: Add the boundary's owner module file paths on both sides to each matched task's Investigation Targets
-3. **Add a "Boundary Context" note in the task body**: Record the boundary identifier and expected signal verbatim from the Connection Map row, so the executor knows what observable evidence the implementation must produce
+3. **Add a "Boundary Context" note in the task body**: Record the boundary identifier and expected signal verbatim from the Connection Map row, so the executor knows what observable evidence the implementation must produce. When the row carries a **Serialized Format** and **Consumer Parse Rule** (a serialized in-runtime boundary), copy both verbatim into the note and state the roundtrip check the task must satisfy: the value the producer emits parses to the value the consumer expects.
 4. **Skip when not provided**: If the work plan has no Connection Map, skip this propagation step
 
 ## ADR Binding Propagation
@@ -213,6 +213,19 @@ When the work plan contains a Design-to-Plan Traceability table, propagate the m
 1. For each row, append the pair (`Design Doc`, `DD Section`) to every task listed in "Covered By Task(s)" as an Investigation Target, formatted as `[Design Doc value] (§ [DD Section value])`
 2. Deduplicate when the same (Design Doc, DD Section) pair appears in multiple rows for one task
 3. Apply only when the work plan contains a Design-to-Plan Traceability table
+
+## Reference Contract Propagation
+
+When the work plan contains a **Reference Contract Values** table, propagate each binding observable value to the task(s) it covers, so the executor is checked against the exact value rather than a back-pointer it must re-derive:
+
+1. **Lookup by task ID**: For each row, locate the task(s) listed in "Covered By Task(s)"
+2. **Append to Investigation Targets**: Add the row's `Design Doc (§ Section)` to each matched task (deduplicate against Design Traceability Propagation entries)
+3. **Add a Reference Contracts table row to the task**: For each matched row, add one row to the task's Reference Contracts table (see task template):
+   - **Source**: the `Design Doc (§ Section)` value
+   - **Contract Type**: copy the `Contract Type` value verbatim (structure-order / derived-display / state-lifecycle-negative)
+   - **Required Observable Value**: copy the value **verbatim** from the work plan row, preserving its exact wording and detail
+   - **Compliance Check**: write a Y/N-answerable positive predicate stating the final implementation reproduces the value (e.g., "the listed fields render in the specified order"; "the label shows the looked-up name in place of the raw code"; "the persisted state is applied only when the restore signal is present")
+4. **Apply only when provided**: Run this propagation only when the work plan contains a Reference Contract Values table. Serialized boundaries are propagated by Connection Map Propagation above, not here.
 
 ## Change Category Classification
 
@@ -333,6 +346,7 @@ Please execute decomposed tasks according to the order.
 - [ ] UI Spec Component → Task Mapping rows propagated to matching tasks (when work plan has the table)
 - [ ] Connection Map boundary rows propagated to matching tasks (when work plan has the table)
 - [ ] Design-to-Plan Traceability rows propagated to matching tasks as Investigation Targets (when work plan has the table)
+- [ ] Reference Contract Values rows propagated to matching tasks as Reference Contracts, value copied verbatim (when work plan has the table)
 - [ ] ADR Bindings rows propagated to matching tasks as Binding Decisions (when work plan has the table)
   - [ ] Source includes ADR path with section hint
   - [ ] Axis copied verbatim from the work plan row to the task's Binding Decisions table

--- a/dev-workflows-frontend/agents/task-executor-frontend.md
+++ b/dev-workflows-frontend/agents/task-executor-frontend.md
@@ -145,7 +145,7 @@ Runs after Pre-implementation Verification, before the Binding Decision Check. T
 
 1. From the Investigation Targets (the decomposition already extended them with the adjacent files), identify the cases sharing the same path, contract, persisted state, or external boundary as the change — fallback rendering, stale state, retries, and external calls related to the change.
 2. Check each for the same class of defect this task corrects.
-3. Fold adjacent residuals within the Target Files scope into this task's failing tests and implementation. Record any residual outside scope in the task file's Investigation Notes so downstream review (code-reviewer / verifier) can detect it.
+3. Plan to fold adjacent residuals within the Target Files scope into this task's failing tests and implementation during the Red phase. Record any residual outside scope in the task file's Investigation Notes so downstream review (code-reviewer) can read and detect it.
 
 #### Binding Decision Check (Required when the task file has a Binding Decisions section)
 
@@ -158,6 +158,18 @@ Runs after Pre-implementation Verification, before the TDD cycle.
    - `Y`: proceed
    - `N`: stop implementation and produce the final response with `status: "escalation_needed"` and `escalation_type: "binding_decision_violation"` with `phase: "pre_implementation"` (see Binding Decision Violation Escalation in Structured Response Specification). `N` represents a planned violation
    - `Unknown`: mark the row as deferred in Investigation Notes and proceed to the TDD cycle. The Exit Gate re-evaluates every row (including Unknown rows deferred from this step) against the final implementation and escalates if any remains `N` or `Unknown` at that point
+
+#### Reference Contract Check (Required when the task file has a Reference Contracts section)
+
+Runs after Pre-implementation Verification, alongside the Binding Decision Check.
+
+1. Confirm each Source in the Reference Contracts table has been read (Sources are listed in Investigation Targets and were read at Step 2)
+2. Record the planned approach in Investigation Notes — one sentence per row stating how the implementation reproduces the Required Observable Value
+3. Evaluate each row's Compliance Check against the planned approach. Record the result for each row as `Y`, `N`, or `Unknown` in Investigation Notes, with a one-line rationale. Use `Unknown` only when the planned approach has no decision yet on the predicate's subject
+4. Per row, branch on the evaluation:
+   - `Y`: proceed
+   - `N`: stop implementation and produce the final response with `status: "escalation_needed"` and `escalation_type: "design_compliance_violation"` (Escalation Response 2-1), populating `details.design_doc_expectation` with the Reference Contract row's Required Observable Value and `details.actual_situation` with the planned approach
+   - `Unknown`: mark the row as deferred in Investigation Notes and proceed to the TDD cycle. The Exit Gate re-evaluates every deferred row against the final implementation
 
 #### Reference Representativeness (Applied During Implementation)
 
@@ -349,6 +361,8 @@ This gate runs immediately before producing the final JSON response.
 ☐ All task checkboxes completed with evidence (or `escalation_needed` triggered earlier)
 ☐ Implementation is consistent with the Investigation Notes recorded at Step 2 (when Investigation Targets were present)
 ☐ Every Binding Decisions Compliance Check evaluates to `Y` against the final implementation, with evidence recorded in Investigation Notes (when the task file has a Binding Decisions section). Re-evaluate here even when the pre-implementation check passed, because the implementation may have diverged from the planned approach
+☐ Every Reference Contracts Compliance Check evaluates to `Y` against the final implementation, with evidence recorded in Investigation Notes (when the task file has a Reference Contracts section). Re-evaluate here even when the pre-implementation check passed
+☐ A test exercises the roundtrip — the value the producer emits parses to the value the consumer expects (when the task has a Boundary Context with a roundtrip check from the work plan's Connection Map)
 ☐ When test runs are cited as `runnableCheck` evidence, they are substantive and executable per the runnableCheck.result field spec (skipped tests, placeholder/TODO-only bodies, always-passing assertions, and 0-match runner reports do not count); non-test verification (build/typecheck/CLI) is not subject to this check
 ☐ Final response is a single JSON with `status: "completed"` or `status: "escalation_needed"` and matches the schema in Structured Response Specification
 

--- a/dev-workflows-frontend/agents/technical-designer-frontend.md
+++ b/dev-workflows-frontend/agents/technical-designer-frontend.md
@@ -47,7 +47,6 @@ The subsections below are not parallel mandates; they form four serial gates. Co
 Each subsection below carries a `[Gate N — ...]` annotation in its heading. Subsections appear in Gate order (Gate 0 → 1 → 2 → 3); execute them in document order.
 
 ### Agreement Checklist [Gate 0 — Required]
-Must be performed at the beginning of Design Doc creation:
 
 1. **List agreements with user in bullet points**
    - Scope (which components/features to change)
@@ -64,7 +63,6 @@ Must be performed at the beginning of Design Doc creation:
 Fill the Design Doc's "External Resources Used" subsection (under Background and Context) per the external-resource-context skill (feature-tier protocol). When a UI Spec exists, inherit its External Resources Used table and expand it with Design-Doc-specific resources (API schema source, IaC source, etc.).
 
 ### Standards Identification [Gate 0 — Required]
-Must be performed before existing-state investigation:
 
 1. **Identify Project Standards**
    - Scan project configuration, rule files, UI Spec / UI analysis inputs, and existing frontend code patterns
@@ -86,7 +84,6 @@ Must be performed before existing-state investigation:
    - Deviations require documented rationale
 
 ### Existing Code Investigation [Gate 1 — Required]
-Must be performed before Design Doc creation:
 
 1. **Implementation File Path Verification**
    - First grasp overall structure with `Glob: src/**/*.tsx`
@@ -168,7 +165,6 @@ Execute the 5 steps below for each in-scope element, and record the result in th
    - For each rejected alternative, record 1-2 lines: what it was, why rejected. Include in the Design Doc to prevent re-proposal in subsequent iterations or by future agents.
 
 ### Implementation Approach Decision [Gate 2 — Required]
-Must be performed when creating Design Doc:
 
 1. **Approach Selection Criteria**
    - Execute Phase 1-4 of implementation-approach skill to select strategy
@@ -182,7 +178,6 @@ Must be performed when creating Design Doc:
    - Verification level for each task (L1/L2/L3 defined in implementation-approach skill)
 
 ### Common ADR Process [Gate 2 — Required]
-Perform before Design Doc creation:
 1. Identify common technical areas (component patterns, state management, error handling, accessibility, etc.)
 2. Search `docs/ADR/ADR-COMMON-*`, create if not found
 3. Include in Design Doc's "Prerequisite ADRs"
@@ -194,6 +189,9 @@ Define Props types and state management contracts between components (types, pre
 
 ### State Transitions [Gate 2 — Required when applicable]
 Document state definitions and transitions for stateful components (loading, error, success states).
+
+### Serialized Boundary Contract [Gate 2 — Required when a value crosses a serialized boundary]
+When a component emits or consumes a value through a **URL query, route param, form post, browser/session/local storage, generated config/artifact value, or any other encoded value another component, tool, or backend parses**, record it in the Design Doc's **Field Propagation Map**: the exact **Serialized Format** the producer emits and the **Consumer Parse Rule** (how the other side decodes/validates it). The producer and consumer must agree on the representation. Skip when no value crosses a serialized boundary.
 
 ## UI Spec Integration
 
@@ -222,7 +220,6 @@ For each integration boundary, define the contract:
 Confirm and document conflicts with existing components (naming conventions, prop patterns) at each integration point.
 
 ### Change Impact Map [Gate 3 — Required]
-Must be included when creating Design Doc:
 
 ```yaml
 Change Target: UserProfileCard component
@@ -300,34 +297,19 @@ When conversion is required, clearly specify wrapper implementation or migration
 - Follow respective templates (`template-en.md`)
 - For ADR, check existing numbers and use max+1, initial status is "Proposed"
 
-## ADR Responsibility Boundaries
+## Output Rules
 
-Include in ADR: Decisions, rationale, principled guidelines
-Exclude from ADR: Schedules, implementation procedures, specific code
-
-Implementation guidelines should only include principles (e.g., "Use custom hooks for logic reuse" ✓, "Implement in Phase 1" ✗)
-
-## Output Policy
-Execute file output immediately (considered approved at execution).
-
-## Scope Boundary
-
-Test derivation itself is a downstream agent responsibility.
-
-## Implementation Sample Standards Compliance
-
-All implementation samples in ADR and Design Docs MUST follow the loaded `typescript-rules` and `frontend-ai-guide` skills. Omit samples unless they clarify contracts or edge cases that prose cannot convey.
+- Execute file output immediately (considered approved at execution).
+- ADR includes decisions, rationale, and principled guidelines (e.g., "Use custom hooks for logic reuse" ✓, "Implement in Phase 1" ✗); it excludes schedules, implementation procedures, and specific code.
+- Test derivation is a downstream agent responsibility.
+- Implementation samples MUST follow the loaded `typescript-rules` and `frontend-ai-guide` skills; include a sample only when it clarifies a contract or edge case prose cannot convey.
 
 ## Diagram Creation (using mermaid notation)
 
 **ADR**: Option comparison diagram, decision impact diagram
 **Design Doc**: Component hierarchy diagram and data flow diagram are mandatory. Add state transition diagram and sequence diagram for complex cases.
 
-**React Diagrams**:
-- Component hierarchy following the project's adopted architecture (e.g., Atoms → Molecules → Organisms → Templates → Pages for Atomic Design; feature-folder tree for Feature-based; container vs presenter split for Container-Presenter)
-- Props flow diagram (parent → child data flow)
-- State management diagram (Context, custom hooks)
-- User interaction flow (click → state update → re-render)
+**React Diagrams**: component hierarchy (per the project's adopted architecture — Atomic Design layers, Feature-based folder tree, or Container/Presenter split), props flow (parent → child), state management (Context, custom hooks), and user interaction flow (click → state update → re-render).
 
 ## Final Output Check
 

--- a/dev-workflows-frontend/agents/work-planner.md
+++ b/dev-workflows-frontend/agents/work-planner.md
@@ -96,6 +96,8 @@ Map each extracted item to a covering task. Items may be covered by a dedicated 
 
 Record the mapping in the Design-to-Plan Traceability table (see plan template). If an item has no covering task, set Gap Status to `gap` with justification in Notes. Gaps with justification require user confirmation before plan approval.
 
+**Carry binding observable values verbatim.** When a Traceability row's DD Item encodes a binding observable value — a column/label set and order, a derived-display rule (a display value derived from another field), or a state-lifecycle negative (a condition under which the state must stay unused) — copy that value **verbatim from the Design Doc** into the plan's **Reference Contract Values** table (see plan template), one row per value, mapped to the covering task(s). Preserve the full value, so the covering task is later checked against this exact value rather than a re-derived summary. This table covers DD-derived observable contracts only; serialized boundaries go in the Connection Map (step 5b) and ADR-derived structural decisions in the ADR Bindings table.
+
 ### 5a. Map UI Spec Components to Tasks (when UI Spec provided)
 
 When a UI Spec is among the inputs, also map components and states to the tasks that implement them. This mapping is required for downstream task generation; without it the UI Spec does not reach the implementation phase.
@@ -107,25 +109,25 @@ For each component documented in the UI Spec:
 
 Record the mapping in the **UI Spec Component → Task Mapping** table (see plan template). One row per component. Components with no covering task are flagged as `gap` requiring user confirmation, identical to the Design-to-Plan Traceability rule.
 
-### 5b. Map Cross-Package Boundaries to Tasks (when implementation crosses runtime/deployment boundaries)
+### 5b. Map Boundaries to Tasks (when crossing a runtime/deployment boundary, or passing a serialized value across any boundary)
 
-When the implementation crosses a runtime or deployment boundary, build a Connection Map. This map is required so boundary context propagates to each affected task in the downstream task generation phase.
+Build a Connection Map when the implementation crosses a runtime or deployment boundary, **or when a value is serialized and re-parsed across any boundary (even within one runtime)**. This map is required so boundary context propagates to each affected task in the downstream task generation phase.
 
-**A boundary qualifies for the Connection Map only when ALL of the following hold**:
-- The two sides run in separate processes, services, or runtimes (e.g., web client ↔ HTTP server, service A ↔ service B over a network, frontend bundle ↔ backend handler)
-- A serialized contract crosses between them (HTTP request/response, message envelope, RPC call, event payload)
-- A failure on one side produces an observable signal on the other (status code, missing field, timeout, dropped message)
+**A boundary qualifies for the Connection Map when EITHER condition holds**:
+- *Cross-process*: the two sides run in separate processes, services, or runtimes (web client ↔ HTTP server, service A ↔ service B, frontend bundle ↔ backend handler); a serialized contract crosses between them (HTTP request/response, message envelope, RPC, event payload); and a failure on one side produces an observable signal on the other.
+- *Serialized in-runtime*: a value is encoded and re-parsed across a boundary even within a single runtime — through a medium such as a query string, CLI argument, environment variable, config entry, message/queue payload, storage key, or file (e.g., one component encodes a value another component or process later decodes; a value written to storage and read after a transition). The producer and consumer must agree on the exact representation.
 
 **Excluded — these are NOT boundaries for the Connection Map**:
-- A package importing a sibling utility, type definition, or shared constant from the same monorepo (in-process, no serialized contract)
-- Internal layering within the same runtime (e.g., handler → usecase → repository)
+- A package importing a sibling utility, type definition, or shared constant from the same monorepo (in-process, no serialized value)
+- Internal layering within the same runtime where values pass as typed in-memory calls (e.g., handler → usecase → repository)
 - Source code dependencies that compile/bundle into the same artifact
 
 For each qualifying boundary:
-1. Identify the boundary (e.g., `web → API gateway`, `service-A → service-B`, `frontend → shared client → backend handler`)
-2. Identify the owner module/package on each side
-3. Identify the expected signal that confirms the boundary works (e.g., HTTP 200 with schema X, message published to topic Y, row inserted in table Z)
-4. Identify the task(s) that implement either side of the boundary
+1. Identify the boundary (e.g., `service A → service B`, `producer → storage → consumer`, `component A → component B via an encoded parameter`)
+2. Identify the owner module/component on each side (producer and consumer)
+3. For a serialized boundary, record the **Serialized Format** (the exact representation the producer emits) and the **Consumer Parse Rule** (how the consumer decodes/validates it). Set both to "—" when the contract is already captured by the Expected Signal (e.g., a cross-process call whose body matches the agreed schema); fill them when producer and consumer must agree on a specific encoding of a value (query string, storage key, CLI argument, config entry, message field).
+4. Identify the expected signal that confirms the boundary works (e.g., a response matching the agreed schema; the consumer reproducing the producer's values)
+5. Identify the task(s) that implement either side of the boundary
 
 Record the mapping in the **Connection Map** table (see plan template). Omit this section entirely when no qualifying boundary exists.
 
@@ -319,11 +321,15 @@ When creating work plans, **Phase Structure Diagrams** and **Task Dependency Dia
 - [ ] Design-to-Plan Traceability table complete (all DD technical requirements categorized and mapped)
   - [ ] No `gap` entries without justification
   - [ ] All justified `gap` entries flagged for user confirmation before plan approval
+- [ ] Reference Contract Values table complete (when the Design Doc specifies binding observable values: column/label order, derived-display, state-lifecycle negative)
+  - [ ] Each value copied verbatim from the Design Doc, preserving full wording
+  - [ ] Each value mapped to a covering task
 - [ ] UI Spec Component → Task Mapping table complete (when UI Spec provided)
   - [ ] Every UI Spec component has a covering task, OR an explicit `gap` justification
   - [ ] Component reference uses the UI Spec section heading exactly as it appears in the document
-- [ ] Connection Map table complete (when implementation crosses packages/services)
+- [ ] Connection Map table complete (when crossing packages/services, or passing a serialized value across any boundary)
   - [ ] Every boundary lists owner modules and expected signal
+  - [ ] Serialized boundaries record Serialized Format and Consumer Parse Rule
   - [ ] Every boundary maps to at least one covering task on each side
 - [ ] ADR Bindings table complete (when ADR provided or referenced from Design Doc)
   - [ ] Each row represents one implementation-binding decision (placement, dependency, contract, data flow, or persistence)

--- a/dev-workflows-frontend/skills/documentation-criteria/references/design-template.md
+++ b/dev-workflows-frontend/skills/documentation-criteria/references/design-template.md
@@ -107,10 +107,7 @@ Keywords determine test type and reduce ambiguity.
 - [ ] **When** user clicks login button with valid credentials, the system shall authenticate and redirect to dashboard
 - [ ] **If** credentials are invalid, **then** the system shall display error message "Invalid credentials"
 - [ ] **While** user is logged in, the system shall maintain the session for configured timeout period
-
-### [Functional Requirement 2]
-
-- [ ] The system shall display data list with pagination of 10 items per page
+- [ ] (ubiquitous, no keyword) The system shall display the data list with pagination of 10 items per page
 
 ## Existing Codebase Analysis
 
@@ -174,14 +171,11 @@ No Ripple Effect:
 
 | Integration Point | Location | Old Implementation | New Implementation | Switching Method | Verification Method |
 |-------------------|----------|-------------------|-------------------|------------------|-------------------|
-| Integration Point 1 | [Class/Function] | [Existing Process] | [New Process] | [DI/Factory etc.] | [How to verify this switching works] |
-| Integration Point 2 | [Another Location] | [Existing] | [New] | [Method] | [Verification approach] |
+| [Integration Point] | [Class/Function] | [Existing Process or N/A] | [New Process] | [DI/Factory/config/etc.] | [How to verify this switching works] |
 
 ### Main Components
 
-Repeat the block below for each component.
-
-#### Component 1
+#### [Component] (repeat per component)
 
 - **Responsibility**: [Scope of responsibility for this component]
 - **Interface**: [APIs and contract definitions provided]
@@ -206,7 +200,6 @@ One entry per new in-scope element. This section records the 5-step output produ
 
 **Step 1 — Fixed Requirements**
 - [AC ID or constraint ID]: [requirement / constraint text]
-- [AC ID or constraint ID]: [requirement / constraint text]
 
 **Steps 2–3 — Alternatives Compared**
 
@@ -214,7 +207,6 @@ One entry per new in-scope element. This section records the 5-step output produ
 |---|---|---|---|---|---|---|
 | [The added element as proposed] | | | | | | |
 | [Subtractive alternative — derive / compute on demand / keep at caller / reuse existing / do not introduce new state] | | | | | | |
-| [Optional third alternative] | | | | | | |
 
 **Step 4 — Selected Alternative and Rationale**
 - **Selected**: [alternative name]
@@ -224,23 +216,17 @@ One entry per new in-scope element. This section records the 5-step output produ
 
 **Step 5 — Rejected Alternatives Log**
 - [Alternative name]: [1-2 lines on what it was and why rejected]
-- [Alternative name]: [1-2 lines on what it was and why rejected]
 
 (Repeat the Element block above for each additional in-scope element.)
 
 Mark the whole section as N/A with brief rationale when the design introduces no in-scope elements.
 
-### Contract Definitions
+### Data Contracts
 
-```
-// Record major contract/interface definitions here
-```
-
-### Data Contract
-
-#### Component 1
+#### [Component or Boundary] (repeat per component/boundary)
 
 ```yaml
+Contract: [interface / function / API / schema name]
 Input:
   Type: [Data shape, contract, or schema]
   Preconditions: [Required items, format constraints]
@@ -257,9 +243,11 @@ Invariants:
 
 ### Field Propagation Map (When Fields Cross Boundaries)
 
-| Field | Boundary | Status | Detail |
-|-------|----------|--------|--------|
-| [field name] | [Component A → B] | preserved / transformed / dropped | [logic or reason] |
+A boundary here includes a **serialized boundary** — a value encoded on one side and parsed on the other through a medium such as a query string, CLI argument, environment variable, config entry, message/queue payload, storage key, or file — not only cross-process calls. For those, record the exact encoded representation and how the consumer parses it, so producer and consumer agree.
+
+| Field | Boundary | Status | Serialized Format | Consumer Parse Rule | Detail |
+|-------|----------|--------|-------------------|---------------------|--------|
+| [field name] | [Component A → B] | preserved / transformed / dropped | [exact representation the producer emits when the boundary is serialized; "—" otherwise] | [how the consumer decodes and validates that representation; "—" when not serialized] | [logic or reason] |
 
 ### State Transitions and Invariants (When Applicable)
 
@@ -317,9 +305,7 @@ System Invariants:
 
 ### Technical Dependencies and Implementation Order
 
-#### Required Implementation Order
-
-Repeat the entry below for each component/feature, in dependency order.
+#### Required Implementation Order (in dependency order, one entry per component/feature)
 
 1. **[Component/Feature]**
    - Technical Reason: [Why this needs to be implemented at this position]
@@ -365,15 +351,11 @@ Verification Strategy defines what correctness means and how to prove it at desi
 
 ### Correctness Proof Method
 
-How will this change's correctness be demonstrated?
-
 - **Correctness definition**: [What "correct" means for this change — e.g., "output matches existing behavior", "all ACs pass in production-equivalent environment", "generated queries execute without error on target DB"]
 - **Verification method**: [Specific technique — e.g., "compare new implementation output against existing implementation", "run against staging DB", "contract test with real API"]
 - **Verification timing**: [When verification occurs — e.g., "after first vertical slice", "per repository", "at integration phase"]
 
 ### Early Verification Point
-
-What is verified first, and how, to confirm the approach is correct before scaling?
 
 - **First verification target**: [The smallest unit that proves the approach works — e.g., "first repository migration", "single API endpoint", "one screen flow"]
 - **Success criteria**: [Observable outcome — e.g., "CSV download produces identical output to legacy", "API returns 200 with expected schema"]
@@ -400,12 +382,9 @@ This section records what was **excluded** from the current design surface. Spec
 
 ## Alternative Solutions
 
-### Alternative 1
-
-- **Overview**: [Description of alternative solution]
-- **Advantages**: [Advantages]
-- **Disadvantages**: [Disadvantages]
-- **Reason for Rejection**: [Why it wasn't adopted]
+| Alternative | Overview | Advantages | Disadvantages | Reason for Rejection |
+|---|---|---|---|---|
+| [Alternative 1] | | | | |
 
 ## Risks and Mitigation
 

--- a/dev-workflows-frontend/skills/documentation-criteria/references/plan-template.md
+++ b/dev-workflows-frontend/skills/documentation-criteria/references/plan-template.md
@@ -51,6 +51,16 @@ Maps each Design Doc technical requirement to the covering task(s). One row per 
 
 **Gap Status values**: `covered` (task exists), `gap` (no task — requires justification in Notes, user confirmation required before plan approval)
 
+## Reference Contract Values
+
+Include this section when a Traceability row's DD Item encodes a **binding observable value** the implementation must reproduce exactly: a column/label set and order, a derived-display rule (display value derived from another field), or a state-lifecycle negative (the condition under which the state must stay unused). **Serialized boundaries** (a value encoded and re-parsed across a boundary) are owned by the Connection Map / Field Propagation Map — record those there. These are DD-derived observable contracts; ADR-derived structural decisions belong in ADR Bindings. Omit the section when none apply.
+
+The Traceability table records *that* a row is covered; this table carries the row's value *verbatim* so the covering task can be checked against the exact contract rather than a re-derived summary.
+
+| Design Doc (§ Section) | Contract Type | Required Observable Value (verbatim) | Covered By Task(s) |
+|---|---|---|---|
+| [docs/design/XXX.md (§ Section)] | structure-order / derived-display / state-lifecycle-negative | [the exact value copied from the Design Doc — e.g., "the listed fields in the specified order"; "the label shows the looked-up name in place of the raw code"; "the persisted state is applied only when an explicit restore signal is present"] | [Phase X Task Y] |
+
 ## Failure Mode Checklist
 
 Domain-independent failure categories this implementation must guard against. Enumerate all eight categories, mark which apply, and list a covering task for each that applies; keep entries free of project-specific names.
@@ -92,11 +102,13 @@ One row per binding decision. A single ADR can contribute multiple rows. A singl
 
 ## Connection Map
 
-Include this section when the implementation crosses more than one package, service, or process boundary. Document each boundary. Omit the section when the implementation stays within a single package.
+Include this section when the implementation crosses a package, service, or process boundary, **or when a value is serialized and re-parsed across a boundary even within a single runtime** — through a medium such as a query string, CLI argument, environment variable, config entry, message/queue payload, storage key, or file (the producer and consumer must agree on the exact representation). Omit the section when no such boundary exists.
 
-| Boundary | Owner (left side) | Owner (right side) | Expected Signal | Covered By Task(s) |
-|---|---|---|---|---|
-| [e.g., "web client → API gateway"] | [module/package on the request side] | [module/package on the response side] | [Observable evidence the boundary works — e.g., "HTTP 200 with response matching ContractA", "row inserted in tableB", "message published to topicC"] | [Phase X Task Y on each side] |
+For a serialized boundary, fill Serialized Format and Consumer Parse Rule. Set them to "—" when the contract is already captured by the Expected Signal (e.g., a cross-process call whose body matches the agreed schema); fill them when producer and consumer must agree on a specific encoding of a value (query string, storage key, CLI argument, config entry, message field).
+
+| Boundary | Owner (left side) | Owner (right side) | Serialized Format | Consumer Parse Rule | Expected Signal | Covered By Task(s) |
+|---|---|---|---|---|---|---|
+| [producing side → consuming side] | [module/component on the producing side] | [module/component on the consuming side] | [exact representation the producer emits; "—" if not serialized] | [how the consumer decodes/validates it; "—" if not serialized] | [Observable evidence the boundary works — e.g., a response matching the agreed contract, or the consumer reproducing the producer's values] | [Phase X Task Y on each side] |
 
 ## Objective
 [Why this change is necessary, what problem it solves]

--- a/dev-workflows-frontend/skills/documentation-criteria/references/task-template.md
+++ b/dev-workflows-frontend/skills/documentation-criteria/references/task-template.md
@@ -33,6 +33,15 @@ Each row is an ADR decision the implementation in this task must comply with.
 |---|---|---|---|
 | [docs/adr/ADR-XXXX.md (§ <Source Section>) — substitute the section name (`Decision` or `Implementation Guidance`) from the matching work plan row] | [Axis value copied verbatim from the work plan's ADR Bindings row] | [Binding decision copied from the work plan's ADR Bindings row] | [Y/N-answerable positive predicate that evaluates whether the planned/final implementation satisfies the decision] |
 
+## Reference Contracts
+(Include this section when the work plan's Reference Contract Values table covers this task. Omit otherwise.)
+
+Each row is a DD-derived observable contract the implementation in this task must reproduce exactly. Serialized boundaries are carried by the Boundary Context (from the work plan's Connection Map), and ADR-derived structural decisions by Binding Decisions above.
+
+| Source | Contract Type | Required Observable Value | Compliance Check |
+|---|---|---|---|
+| [Design Doc path (§ Section) copied from the matching work plan Reference Contract Values row] | [Contract Type copied from the work plan row: structure-order / derived-display / state-lifecycle-negative] | [Required Observable Value copied verbatim from the work plan row] | [Y/N-answerable positive predicate that evaluates whether the planned/final implementation reproduces the value] |
+
 ## Investigation Notes
 (Implementation observations are appended here before implementation begins. When Binding Decisions exist, record the planned implementation approach and each Compliance Check result here.)
 
@@ -79,6 +88,7 @@ Each row is an ADR decision the implementation in this task must comply with.
 - [ ] Each Proof Obligation is met: the test turns red under its primary failure mode and exercises the stated boundary
 - [ ] Deliverables created (for research/design tasks)
 - [ ] (When Binding Decisions exist) Every Compliance Check evaluates to `Y` against the final implementation, with evidence recorded in Investigation Notes (file:line, test result, or command output)
+- [ ] (When Reference Contracts exist) Every Reference Contract Compliance Check evaluates to `Y` against the final implementation, with evidence recorded in Investigation Notes
 
 ## Notes
 - Impact scope: [Areas where changes may propagate]

--- a/dev-workflows-frontend/skills/frontend-ai-guide/SKILL.md
+++ b/dev-workflows-frontend/skills/frontend-ai-guide/SKILL.md
@@ -178,7 +178,7 @@ Read `package.json` scripts and run them with the project's package manager (`pa
 ### Performance vs Readability
 - Prioritize readability unless React DevTools Profiler identifies a measurable bottleneck (e.g., render time exceeding 16ms, unnecessary re-renders)
 - Measure before optimizing with React DevTools Profiler
-- When React Compiler is enabled, routine memoization is automatic; manual memoization is a profiler- or identity-justified exception (measured bottleneck, or stable reference identity for third-party APIs / effect dependencies)
+- Memoization policy (React Compiler vs manual `React.memo`/`useMemo`/`useCallback`): follow the typescript-rules skill (Performance Optimization)
 - Document reason with comments when optimizing
 
 ### Granularity of Component/Type Definitions

--- a/dev-workflows-fullstack/.claude-plugin/plugin.json
+++ b/dev-workflows-fullstack/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflows-fullstack",
   "description": "Skills + Subagents for fullstack development (backend + React/TypeScript) - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
-  "version": "0.20.5",
+  "version": "0.21.0",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows-fullstack/agents/code-reviewer.md
+++ b/dev-workflows-fullstack/agents/code-reviewer.md
@@ -45,6 +45,7 @@ Read the Design Doc **in full** and extract:
 - Architecture design and data flow
 - Interface contracts (function signatures, API endpoints, data structures)
 - Identifier specifications (resource names, endpoint paths, configuration keys, error codes, schema/model names)
+- Binding observable contracts: column/label sets and order, derived-display rules, and state-lifecycle negatives; plus Field Propagation Map rows that carry a Serialized Format + Consumer Parse Rule
 - Error handling policy
 - Non-functional requirements
 
@@ -60,7 +61,7 @@ For each acceptance criterion extracted in Step 1:
 - For behavior-changing ACs, confirm the evidence covers the boundary paths, not only the main path: where a distinct branch, state, input class, lifecycle step, or fallback governs the behavior, verify it is exercised. Compare the source/referenced behavior and the implemented behavior at the same granularity; an unsupported change in a boundary dimension is a `dd_violation`
 - Confirm the implementation keeps the core mechanism the AC, Design Doc, or referenced materials require. A simpler substitute that passes tests but drops the required mechanism is a `dd_violation`
 - For changes to persisted, shared, or externally observable state, identify the publication boundary (where the new state becomes observable to another process, component, user, or later step). State that is observable as complete while still partial, uninitialized, stale, or rollback-only is a `reliability` finding, because a downstream consumer can treat the incomplete state as complete and fail
-- When the reviewed change is classified as `bug-fix`, `regression`, `state-change`, or `boundary-change` (the task's `Change Category` field, when present, names the kind), check the cases sharing its path, contract, persisted state, or external boundary. A sibling case still carrying the same class of defect the change addressed is an `adjacent_residual` finding
+- When the reviewed change is classified as `bug-fix`, `regression`, `state-change`, or `boundary-change` (the task's `Change Category` field, when present, names the kind; when no field is present — e.g., reviewing a diff without task files — classify from the diff itself), check the cases sharing its path, contract, persisted state, or external boundary. A sibling case still carrying the same class of defect the change addressed is an `adjacent_residual` finding. When the task file is in scope, also read its Investigation Notes for residuals the executor recorded as out-of-scope, and verify each recorded residual; if it remains unfixed within the reviewed scope, report it as `adjacent_residual`, otherwise record why it is resolved or outside the review scope
 
 #### 2-2. Identifier Verification
 
@@ -81,6 +82,13 @@ Assign confidence based on evidence count:
 - **high**: 3+ sources agree
 - **medium**: 2 sources agree
 - **low**: 1 source only (implementation exists but no test or type confirmation)
+
+#### 2-4. Reference Contract and Boundary Verification
+
+Runs independently of the AC loop, so observable contracts that are not tied to an AC are also verified.
+
+1. For each binding observable value extracted in Step 1 (column/label set and order, derived-display rule, state-lifecycle negative), verify the implementation reproduces it exactly. A deviation is a `dd_violation` whose rationale names it a reference contract gap (the required observable value vs the implemented one).
+2. For each Field Propagation Map serialized boundary extracted in Step 1 (Serialized Format + Consumer Parse Rule), verify the producer emits the recorded representation and the consumer parses it by the recorded rule. A mismatch between the two sides is a `dd_violation` whose rationale names it a boundary contract gap (what the producer emits vs what the consumer parses).
 
 ### 3. Assess Code Quality
 

--- a/dev-workflows-fullstack/agents/document-reviewer.md
+++ b/dev-workflows-fullstack/agents/document-reviewer.md
@@ -43,7 +43,7 @@ You are an AI assistant specialized in technical document review.
 - Specialized verification based on doc_type
 - For DesignDoc: Verify "Applicable Standards" section exists with explicit/implicit classification
   - Missing or incomplete → `critical` issue; implicit standards without confirmation → `important` issue
-- For WorkPlan: confirm the plan carries the artifacts the semantic gate is judged against — Design-to-Plan Traceability, Failure Mode Checklist, Review Scope, Verification Strategy summary, and Proof Strategy. Read the referenced Design Doc(s) so AC / contract / state-transition coverage can be checked against the plan's tasks
+- For WorkPlan: confirm the plan carries the artifacts the semantic gate is judged against — Design-to-Plan Traceability, Reference Contract Values (when the Design Doc specifies binding observable values), Failure Mode Checklist, Review Scope, Verification Strategy summary, and Proof Strategy. Read the referenced Design Doc(s) so AC / contract / state-transition coverage and the content fidelity of binding observable values can be checked against the plan
 - If `code_verification` provided: extract discrepancy list and reverse coverage gaps; feed into Gate 1 as pre-verified evidence
 - If `codebase_analysis` provided: extract `focusAreas` and their `evidence` values for Gate 0 / Gate 1 Fact Disposition checks
 
@@ -108,6 +108,7 @@ For WorkPlan, additionally verify:
   - (3) Each cross-boundary, public-boundary, or persisted-state change names a task that verifies it through the real boundary — missing → `important` issue (category: `completeness`)
   - (4) Each traceability table present (Design-to-Plan, UI Spec Component, Connection Map, ADR Bindings) is filled to a granularity that resolves its target task — under-specified rows → `important` issue (category: `completeness`)
   - (5) The Failure Mode Checklist covers the plan's applicable domain-independent categories (same-value, no-op, empty input, invalid option, missing config, unavailable boundary, shared-state dependency, rollback-only visibility) — missing applicable category → `recommended` issue (category: `completeness`)
+  - (6) Binding observable values are carried with content fidelity, not only coverage: for each Design Doc observable contract that encodes a binding value (a column/label set and order, a derived-display rule, or a state-lifecycle negative), the plan's Reference Contract Values table carries the value verbatim from the Design Doc and maps it to a covering task. Re-derive each such value from the Design Doc and compare against the plan; a value reduced to a label, summarized, or absent while the Design Doc specifies it is a content-fidelity gap → `critical` issue (category: `completeness`)
   - Verdict mapping (WorkPlan): any semantic-gate `critical` issue forces the verdict to at least `needs_revision` — except a coverage gap traceable to a missing or contradictory Design Doc/input element (which re-planning cannot fix) → `rejected`; an `important`-only set caps the verdict at `approved_with_conditions`
 
 **Perspective-specific Mode**:
@@ -156,49 +157,15 @@ Complete all items before proceeding to output.
 
 ```json
 {
-  "metadata": {
-    "review_mode": "comprehensive",
-    "doc_type": "DesignDoc",
-    "target_path": "/path/to/document.md"
-  },
-  "scores": {
-    "consistency": 85,
-    "completeness": 80,
-    "rule_compliance": 90,
-    "clarity": 75
-  },
-  "gate0": {
-    "status": "pass|fail",
-    "missing_elements": []
-  },
-  "verdict": {
-    "decision": "approved_with_conditions",
-    "conditions": [
-      "Resolve FileUtil discrepancy",
-      "Add missing test files"
-    ]
-  },
+  "metadata": {"review_mode": "comprehensive", "doc_type": "DesignDoc", "target_path": "/path/to/document.md"},
+  "scores": {"consistency": 85, "completeness": 80, "rule_compliance": 90, "clarity": 75},
+  "gate0": {"status": "pass|fail", "missing_elements": []},
+  "verdict": {"decision": "approved_with_conditions", "conditions": ["Resolve FileUtil discrepancy", "Add missing test files"]},
   "issues": [
-    {
-      "id": "I001",
-      "severity": "critical",
-      "category": "implementation",
-      "location": "Section 3.2",
-      "description": "FileUtil method mismatch",
-      "suggestion": "Update document to reflect actual FileUtil usage"
-    }
+    {"id": "I001", "severity": "critical", "category": "implementation", "location": "Section 3.2", "description": "FileUtil method mismatch", "suggestion": "Update document to reflect actual FileUtil usage"}
   ],
-  "recommendations": [
-    "Priority fixes before approval",
-    "Documentation alignment with implementation"
-  ],
-  "prior_context_check": {
-    "items_received": 0,
-    "resolved": 0,
-    "partially_resolved": 0,
-    "unresolved": 0,
-    "items": []
-  }
+  "recommendations": ["Priority fixes before approval", "Documentation alignment with implementation"],
+  "prior_context_check": {"items_received": 0, "resolved": 0, "partially_resolved": 0, "unresolved": 0, "items": []}
 }
 ```
 
@@ -206,16 +173,8 @@ Complete all items before proceeding to output.
 
 ```json
 {
-  "metadata": {
-    "review_mode": "perspective",
-    "focus": "implementation",
-    "doc_type": "DesignDoc",
-    "target_path": "/path/to/document.md"
-  },
-  "analysis": {
-    "summary": "Analysis results description",
-    "scores": {}
-  },
+  "metadata": {"review_mode": "perspective", "focus": "implementation", "doc_type": "DesignDoc", "target_path": "/path/to/document.md"},
+  "analysis": {"summary": "Analysis results description", "scores": {}},
   "issues": [],
   "checklist": [
     {"item": "Check item description", "status": "pass|fail|na"}
@@ -236,12 +195,7 @@ Include in output when `prior_context_count > 0`:
     "partially_resolved": 1,
     "unresolved": 0,
     "items": [
-      {
-        "id": "D001",
-        "status": "resolved",
-        "location": "Section 3.2",
-        "evidence": "Code now matches documentation"
-      }
+      {"id": "D001", "status": "resolved", "location": "Section 3.2", "evidence": "Code now matches documentation"}
     ]
   }
 }

--- a/dev-workflows-fullstack/agents/task-decomposer.md
+++ b/dev-workflows-fullstack/agents/task-decomposer.md
@@ -183,7 +183,7 @@ When the work plan contains a Connection Map table, propagate boundary context t
 
 1. **Lookup by task ID**: For each row in the Connection Map, locate the task(s) listed in the "Covered By Task(s)" column
 2. **Append to Investigation Targets**: Add the boundary's owner module file paths on both sides to each matched task's Investigation Targets
-3. **Add a "Boundary Context" note in the task body**: Record the boundary identifier and expected signal verbatim from the Connection Map row, so the executor knows what observable evidence the implementation must produce
+3. **Add a "Boundary Context" note in the task body**: Record the boundary identifier and expected signal verbatim from the Connection Map row, so the executor knows what observable evidence the implementation must produce. When the row carries a **Serialized Format** and **Consumer Parse Rule** (a serialized in-runtime boundary), copy both verbatim into the note and state the roundtrip check the task must satisfy: the value the producer emits parses to the value the consumer expects.
 4. **Skip when not provided**: If the work plan has no Connection Map, skip this propagation step
 
 ## ADR Binding Propagation
@@ -213,6 +213,19 @@ When the work plan contains a Design-to-Plan Traceability table, propagate the m
 1. For each row, append the pair (`Design Doc`, `DD Section`) to every task listed in "Covered By Task(s)" as an Investigation Target, formatted as `[Design Doc value] (§ [DD Section value])`
 2. Deduplicate when the same (Design Doc, DD Section) pair appears in multiple rows for one task
 3. Apply only when the work plan contains a Design-to-Plan Traceability table
+
+## Reference Contract Propagation
+
+When the work plan contains a **Reference Contract Values** table, propagate each binding observable value to the task(s) it covers, so the executor is checked against the exact value rather than a back-pointer it must re-derive:
+
+1. **Lookup by task ID**: For each row, locate the task(s) listed in "Covered By Task(s)"
+2. **Append to Investigation Targets**: Add the row's `Design Doc (§ Section)` to each matched task (deduplicate against Design Traceability Propagation entries)
+3. **Add a Reference Contracts table row to the task**: For each matched row, add one row to the task's Reference Contracts table (see task template):
+   - **Source**: the `Design Doc (§ Section)` value
+   - **Contract Type**: copy the `Contract Type` value verbatim (structure-order / derived-display / state-lifecycle-negative)
+   - **Required Observable Value**: copy the value **verbatim** from the work plan row, preserving its exact wording and detail
+   - **Compliance Check**: write a Y/N-answerable positive predicate stating the final implementation reproduces the value (e.g., "the listed fields render in the specified order"; "the label shows the looked-up name in place of the raw code"; "the persisted state is applied only when the restore signal is present")
+4. **Apply only when provided**: Run this propagation only when the work plan contains a Reference Contract Values table. Serialized boundaries are propagated by Connection Map Propagation above, not here.
 
 ## Change Category Classification
 
@@ -333,6 +346,7 @@ Please execute decomposed tasks according to the order.
 - [ ] UI Spec Component → Task Mapping rows propagated to matching tasks (when work plan has the table)
 - [ ] Connection Map boundary rows propagated to matching tasks (when work plan has the table)
 - [ ] Design-to-Plan Traceability rows propagated to matching tasks as Investigation Targets (when work plan has the table)
+- [ ] Reference Contract Values rows propagated to matching tasks as Reference Contracts, value copied verbatim (when work plan has the table)
 - [ ] ADR Bindings rows propagated to matching tasks as Binding Decisions (when work plan has the table)
   - [ ] Source includes ADR path with section hint
   - [ ] Axis copied verbatim from the work plan row to the task's Binding Decisions table

--- a/dev-workflows-fullstack/agents/task-executor-frontend.md
+++ b/dev-workflows-fullstack/agents/task-executor-frontend.md
@@ -145,7 +145,7 @@ Runs after Pre-implementation Verification, before the Binding Decision Check. T
 
 1. From the Investigation Targets (the decomposition already extended them with the adjacent files), identify the cases sharing the same path, contract, persisted state, or external boundary as the change — fallback rendering, stale state, retries, and external calls related to the change.
 2. Check each for the same class of defect this task corrects.
-3. Fold adjacent residuals within the Target Files scope into this task's failing tests and implementation. Record any residual outside scope in the task file's Investigation Notes so downstream review (code-reviewer / verifier) can detect it.
+3. Plan to fold adjacent residuals within the Target Files scope into this task's failing tests and implementation during the Red phase. Record any residual outside scope in the task file's Investigation Notes so downstream review (code-reviewer) can read and detect it.
 
 #### Binding Decision Check (Required when the task file has a Binding Decisions section)
 
@@ -158,6 +158,18 @@ Runs after Pre-implementation Verification, before the TDD cycle.
    - `Y`: proceed
    - `N`: stop implementation and produce the final response with `status: "escalation_needed"` and `escalation_type: "binding_decision_violation"` with `phase: "pre_implementation"` (see Binding Decision Violation Escalation in Structured Response Specification). `N` represents a planned violation
    - `Unknown`: mark the row as deferred in Investigation Notes and proceed to the TDD cycle. The Exit Gate re-evaluates every row (including Unknown rows deferred from this step) against the final implementation and escalates if any remains `N` or `Unknown` at that point
+
+#### Reference Contract Check (Required when the task file has a Reference Contracts section)
+
+Runs after Pre-implementation Verification, alongside the Binding Decision Check.
+
+1. Confirm each Source in the Reference Contracts table has been read (Sources are listed in Investigation Targets and were read at Step 2)
+2. Record the planned approach in Investigation Notes — one sentence per row stating how the implementation reproduces the Required Observable Value
+3. Evaluate each row's Compliance Check against the planned approach. Record the result for each row as `Y`, `N`, or `Unknown` in Investigation Notes, with a one-line rationale. Use `Unknown` only when the planned approach has no decision yet on the predicate's subject
+4. Per row, branch on the evaluation:
+   - `Y`: proceed
+   - `N`: stop implementation and produce the final response with `status: "escalation_needed"` and `escalation_type: "design_compliance_violation"` (Escalation Response 2-1), populating `details.design_doc_expectation` with the Reference Contract row's Required Observable Value and `details.actual_situation` with the planned approach
+   - `Unknown`: mark the row as deferred in Investigation Notes and proceed to the TDD cycle. The Exit Gate re-evaluates every deferred row against the final implementation
 
 #### Reference Representativeness (Applied During Implementation)
 
@@ -349,6 +361,8 @@ This gate runs immediately before producing the final JSON response.
 ☐ All task checkboxes completed with evidence (or `escalation_needed` triggered earlier)
 ☐ Implementation is consistent with the Investigation Notes recorded at Step 2 (when Investigation Targets were present)
 ☐ Every Binding Decisions Compliance Check evaluates to `Y` against the final implementation, with evidence recorded in Investigation Notes (when the task file has a Binding Decisions section). Re-evaluate here even when the pre-implementation check passed, because the implementation may have diverged from the planned approach
+☐ Every Reference Contracts Compliance Check evaluates to `Y` against the final implementation, with evidence recorded in Investigation Notes (when the task file has a Reference Contracts section). Re-evaluate here even when the pre-implementation check passed
+☐ A test exercises the roundtrip — the value the producer emits parses to the value the consumer expects (when the task has a Boundary Context with a roundtrip check from the work plan's Connection Map)
 ☐ When test runs are cited as `runnableCheck` evidence, they are substantive and executable per the runnableCheck.result field spec (skipped tests, placeholder/TODO-only bodies, always-passing assertions, and 0-match runner reports do not count); non-test verification (build/typecheck/CLI) is not subject to this check
 ☐ Final response is a single JSON with `status: "completed"` or `status: "escalation_needed"` and matches the schema in Structured Response Specification
 

--- a/dev-workflows-fullstack/agents/task-executor.md
+++ b/dev-workflows-fullstack/agents/task-executor.md
@@ -140,7 +140,7 @@ Runs after Pre-implementation Verification, before the Binding Decision Check. T
 
 1. From the Investigation Targets (the decomposition already extended them with the adjacent files), identify the cases sharing the same path, contract, persisted state, or external boundary as the change — fallback behavior, stale state, retries, and external calls related to the change.
 2. Check each for the same class of defect this task corrects.
-3. Fold adjacent residuals within the Target Files scope into this task's failing tests and implementation. Record any residual outside scope in the task file's Investigation Notes so downstream review (code-reviewer / verifier) can detect it.
+3. Plan to fold adjacent residuals within the Target Files scope into this task's failing tests and implementation during the Red phase. Record any residual outside scope in the task file's Investigation Notes so downstream review (code-reviewer) can read and detect it.
 
 #### Binding Decision Check (Required when the task file has a Binding Decisions section)
 
@@ -153,6 +153,18 @@ Runs after Pre-implementation Verification, before the TDD cycle.
    - `Y`: proceed
    - `N`: stop implementation and produce the final response with `status: "escalation_needed"` and `escalation_type: "binding_decision_violation"` with `phase: "pre_implementation"` (see Binding Decision Violation Escalation in Structured Response Specification). `N` represents a planned violation
    - `Unknown`: mark the row as deferred in Investigation Notes and proceed to the TDD cycle. The Exit Gate re-evaluates every row (including Unknown rows deferred from this step) against the final implementation and escalates if any remains `N` or `Unknown` at that point
+
+#### Reference Contract Check (Required when the task file has a Reference Contracts section)
+
+Runs after Pre-implementation Verification, alongside the Binding Decision Check.
+
+1. Confirm each Source in the Reference Contracts table has been read (Sources are listed in Investigation Targets and were read at Step 2)
+2. Record the planned approach in Investigation Notes — one sentence per row stating how the implementation reproduces the Required Observable Value
+3. Evaluate each row's Compliance Check against the planned approach. Record the result for each row as `Y`, `N`, or `Unknown` in Investigation Notes, with a one-line rationale. Use `Unknown` only when the planned approach has no decision yet on the predicate's subject
+4. Per row, branch on the evaluation:
+   - `Y`: proceed
+   - `N`: stop implementation and produce the final response with `status: "escalation_needed"` and `escalation_type: "design_compliance_violation"` (Escalation Response 2-1), populating `details.design_doc_expectation` with the Reference Contract row's Required Observable Value and `details.actual_situation` with the planned approach
+   - `Unknown`: mark the row as deferred in Investigation Notes and proceed to the TDD cycle. The Exit Gate re-evaluates every deferred row against the final implementation
 
 #### Reference Representativeness (Applied During Implementation)
 
@@ -344,6 +356,8 @@ This gate runs immediately before producing the final JSON response.
 ☐ All task checkboxes completed with evidence (or `escalation_needed` triggered earlier)
 ☐ Implementation is consistent with the Investigation Notes recorded at Step 2 (when Investigation Targets were present)
 ☐ Every Binding Decisions Compliance Check evaluates to `Y` against the final implementation, with evidence recorded in Investigation Notes (when the task file has a Binding Decisions section). Re-evaluate here even when the pre-implementation check passed, because the implementation may have diverged from the planned approach
+☐ Every Reference Contracts Compliance Check evaluates to `Y` against the final implementation, with evidence recorded in Investigation Notes (when the task file has a Reference Contracts section). Re-evaluate here even when the pre-implementation check passed
+☐ A test exercises the roundtrip — the value the producer emits parses to the value the consumer expects (when the task has a Boundary Context with a roundtrip check from the work plan's Connection Map)
 ☐ When test runs are cited as `runnableCheck` evidence, they are substantive and executable per the runnableCheck.result field spec (skipped tests, placeholder/TODO-only bodies, always-passing assertions, and 0-match runner reports do not count); non-test verification (build/typecheck/CLI) is not subject to this check
 ☐ Final response is a single JSON with `status: "completed"` or `status: "escalation_needed"` and matches the schema in Structured Response Specification
 

--- a/dev-workflows-fullstack/agents/technical-designer-frontend.md
+++ b/dev-workflows-fullstack/agents/technical-designer-frontend.md
@@ -47,7 +47,6 @@ The subsections below are not parallel mandates; they form four serial gates. Co
 Each subsection below carries a `[Gate N — ...]` annotation in its heading. Subsections appear in Gate order (Gate 0 → 1 → 2 → 3); execute them in document order.
 
 ### Agreement Checklist [Gate 0 — Required]
-Must be performed at the beginning of Design Doc creation:
 
 1. **List agreements with user in bullet points**
    - Scope (which components/features to change)
@@ -64,7 +63,6 @@ Must be performed at the beginning of Design Doc creation:
 Fill the Design Doc's "External Resources Used" subsection (under Background and Context) per the external-resource-context skill (feature-tier protocol). When a UI Spec exists, inherit its External Resources Used table and expand it with Design-Doc-specific resources (API schema source, IaC source, etc.).
 
 ### Standards Identification [Gate 0 — Required]
-Must be performed before existing-state investigation:
 
 1. **Identify Project Standards**
    - Scan project configuration, rule files, UI Spec / UI analysis inputs, and existing frontend code patterns
@@ -86,7 +84,6 @@ Must be performed before existing-state investigation:
    - Deviations require documented rationale
 
 ### Existing Code Investigation [Gate 1 — Required]
-Must be performed before Design Doc creation:
 
 1. **Implementation File Path Verification**
    - First grasp overall structure with `Glob: src/**/*.tsx`
@@ -168,7 +165,6 @@ Execute the 5 steps below for each in-scope element, and record the result in th
    - For each rejected alternative, record 1-2 lines: what it was, why rejected. Include in the Design Doc to prevent re-proposal in subsequent iterations or by future agents.
 
 ### Implementation Approach Decision [Gate 2 — Required]
-Must be performed when creating Design Doc:
 
 1. **Approach Selection Criteria**
    - Execute Phase 1-4 of implementation-approach skill to select strategy
@@ -182,7 +178,6 @@ Must be performed when creating Design Doc:
    - Verification level for each task (L1/L2/L3 defined in implementation-approach skill)
 
 ### Common ADR Process [Gate 2 — Required]
-Perform before Design Doc creation:
 1. Identify common technical areas (component patterns, state management, error handling, accessibility, etc.)
 2. Search `docs/ADR/ADR-COMMON-*`, create if not found
 3. Include in Design Doc's "Prerequisite ADRs"
@@ -194,6 +189,9 @@ Define Props types and state management contracts between components (types, pre
 
 ### State Transitions [Gate 2 — Required when applicable]
 Document state definitions and transitions for stateful components (loading, error, success states).
+
+### Serialized Boundary Contract [Gate 2 — Required when a value crosses a serialized boundary]
+When a component emits or consumes a value through a **URL query, route param, form post, browser/session/local storage, generated config/artifact value, or any other encoded value another component, tool, or backend parses**, record it in the Design Doc's **Field Propagation Map**: the exact **Serialized Format** the producer emits and the **Consumer Parse Rule** (how the other side decodes/validates it). The producer and consumer must agree on the representation. Skip when no value crosses a serialized boundary.
 
 ## UI Spec Integration
 
@@ -222,7 +220,6 @@ For each integration boundary, define the contract:
 Confirm and document conflicts with existing components (naming conventions, prop patterns) at each integration point.
 
 ### Change Impact Map [Gate 3 — Required]
-Must be included when creating Design Doc:
 
 ```yaml
 Change Target: UserProfileCard component
@@ -300,34 +297,19 @@ When conversion is required, clearly specify wrapper implementation or migration
 - Follow respective templates (`template-en.md`)
 - For ADR, check existing numbers and use max+1, initial status is "Proposed"
 
-## ADR Responsibility Boundaries
+## Output Rules
 
-Include in ADR: Decisions, rationale, principled guidelines
-Exclude from ADR: Schedules, implementation procedures, specific code
-
-Implementation guidelines should only include principles (e.g., "Use custom hooks for logic reuse" ✓, "Implement in Phase 1" ✗)
-
-## Output Policy
-Execute file output immediately (considered approved at execution).
-
-## Scope Boundary
-
-Test derivation itself is a downstream agent responsibility.
-
-## Implementation Sample Standards Compliance
-
-All implementation samples in ADR and Design Docs MUST follow the loaded `typescript-rules` and `frontend-ai-guide` skills. Omit samples unless they clarify contracts or edge cases that prose cannot convey.
+- Execute file output immediately (considered approved at execution).
+- ADR includes decisions, rationale, and principled guidelines (e.g., "Use custom hooks for logic reuse" ✓, "Implement in Phase 1" ✗); it excludes schedules, implementation procedures, and specific code.
+- Test derivation is a downstream agent responsibility.
+- Implementation samples MUST follow the loaded `typescript-rules` and `frontend-ai-guide` skills; include a sample only when it clarifies a contract or edge case prose cannot convey.
 
 ## Diagram Creation (using mermaid notation)
 
 **ADR**: Option comparison diagram, decision impact diagram
 **Design Doc**: Component hierarchy diagram and data flow diagram are mandatory. Add state transition diagram and sequence diagram for complex cases.
 
-**React Diagrams**:
-- Component hierarchy following the project's adopted architecture (e.g., Atoms → Molecules → Organisms → Templates → Pages for Atomic Design; feature-folder tree for Feature-based; container vs presenter split for Container-Presenter)
-- Props flow diagram (parent → child data flow)
-- State management diagram (Context, custom hooks)
-- User interaction flow (click → state update → re-render)
+**React Diagrams**: component hierarchy (per the project's adopted architecture — Atomic Design layers, Feature-based folder tree, or Container/Presenter split), props flow (parent → child), state management (Context, custom hooks), and user interaction flow (click → state update → re-render).
 
 ## Final Output Check
 

--- a/dev-workflows-fullstack/agents/technical-designer.md
+++ b/dev-workflows-fullstack/agents/technical-designer.md
@@ -49,7 +49,6 @@ The subsections below are not parallel mandates; they form four serial gates. Co
 Each subsection below carries a `[Gate N — ...]` annotation in its heading. Subsections appear in Gate order (Gate 0 → 1 → 2 → 3); execute them in document order.
 
 ### Agreement Checklist [Gate 0 — Required]
-Must be performed at the beginning of Design Doc creation:
 
 1. **List agreements with user in bullet points**
    - Scope (what to change)
@@ -66,7 +65,6 @@ Must be performed at the beginning of Design Doc creation:
 Fill the Design Doc's "External Resources Used" subsection (under Background and Context) per the external-resource-context skill (feature-tier protocol).
 
 ### Standards Identification [Gate 0 — Required]
-Must be performed before any investigation:
 
 1. **Identify Project Standards**
    - Scan project configuration, rule files, and existing code patterns
@@ -88,7 +86,6 @@ Must be performed before any investigation:
    - Deviations require documented rationale
 
 ### Existing Code Investigation [Gate 1 — Required]
-Must be performed before Design Doc creation:
 
 1. **Implementation File Path Verification**
    - First grasp overall structure using Glob with detected project patterns
@@ -187,7 +184,6 @@ Execute the 5 steps below for each in-scope element, and record the result in th
    - For each rejected alternative, record 1-2 lines: what it was, why rejected. Include in the Design Doc to prevent re-proposal in subsequent iterations or by future agents.
 
 ### Implementation Approach Decision [Gate 2 — Required]
-Must be performed when creating Design Doc:
 
 1. **Approach Selection Criteria**
    - Execute Phase 1-4 of implementation-approach skill to select strategy
@@ -210,7 +206,6 @@ Must be performed when creating Design Doc:
    - Define early verification point: what is the first thing to verify, and how, to confirm the approach is correct before scaling. For replacements/modifications, the early verification point must be an output comparison of at least one representative case
 
 ### Common ADR Process [Gate 2 — Required]
-Perform before Design Doc creation:
 1. Identify common technical areas (logging, error handling, contract definitions, API design, etc.)
 2. Search `docs/ADR/ADR-COMMON-*`, create if not found
 3. Include in Design Doc's "Prerequisite ADRs"
@@ -240,7 +235,6 @@ For each integration boundary, define the contract:
 Confirm and document conflicts with existing systems (priority, naming conventions) at each integration point.
 
 ### Change Impact Map [Gate 3 — Required]
-Must be included when creating Design Doc:
 
 ```yaml
 Change Target: [ServiceName.methodName()]
@@ -258,6 +252,9 @@ No Ripple Effect:
 When new or changed fields cross component boundaries:
 
 Document each field's status (preserved / transformed / dropped) at each boundary with rationale.
+
+When the boundary is **serialized** — the value is encoded and re-parsed across a medium such as a query string, CLI argument, environment variable, config entry, message/queue payload, storage key, or file — also fill the template's **Serialized Format** (the exact representation the producer emits) and **Consumer Parse Rule** (how the consumer decodes/validates it) columns, so producer and consumer agree on the representation. Set both to "—" for in-memory field crossings.
+
 Skip if no fields cross component boundaries.
 
 ### Interface Change Impact Analysis [Gate 3 — Required]
@@ -314,23 +311,12 @@ When conversion is required, clearly specify adapter implementation or migration
 - Follow respective templates (`template.md`)
 - For ADR, check existing numbers and use max+1, initial status is "Proposed"
 
-## ADR Responsibility Boundaries
+## Output Rules
 
-Include in ADR: Decisions, rationale, principled guidelines
-Exclude from ADR: Schedules, implementation procedures, specific code
-
-Implementation guidelines should only include principles (e.g., "Use dependency injection"), not schedules or procedures.
-
-## Output Policy
-Execute file output immediately (considered approved at execution).
-
-## Scope Boundary
-
-Test derivation itself is a downstream agent responsibility.
-
-## Implementation Sample Standards Compliance
-
-All implementation samples in ADR and Design Docs MUST follow the loaded `coding-principles` and `testing-principles` skills. Omit samples unless they clarify contracts or edge cases that prose cannot convey.
+- Execute file output immediately (considered approved at execution).
+- ADR includes decisions, rationale, and principled guidelines (e.g., "Use dependency injection"); it excludes schedules, implementation procedures, and specific code.
+- Test derivation is a downstream agent responsibility.
+- Implementation samples MUST follow the loaded `coding-principles` and `testing-principles` skills; include a sample only when it clarifies a contract or edge case prose cannot convey.
 
 ## Diagram Creation (using mermaid notation)
 

--- a/dev-workflows-fullstack/agents/work-planner.md
+++ b/dev-workflows-fullstack/agents/work-planner.md
@@ -96,6 +96,8 @@ Map each extracted item to a covering task. Items may be covered by a dedicated 
 
 Record the mapping in the Design-to-Plan Traceability table (see plan template). If an item has no covering task, set Gap Status to `gap` with justification in Notes. Gaps with justification require user confirmation before plan approval.
 
+**Carry binding observable values verbatim.** When a Traceability row's DD Item encodes a binding observable value — a column/label set and order, a derived-display rule (a display value derived from another field), or a state-lifecycle negative (a condition under which the state must stay unused) — copy that value **verbatim from the Design Doc** into the plan's **Reference Contract Values** table (see plan template), one row per value, mapped to the covering task(s). Preserve the full value, so the covering task is later checked against this exact value rather than a re-derived summary. This table covers DD-derived observable contracts only; serialized boundaries go in the Connection Map (step 5b) and ADR-derived structural decisions in the ADR Bindings table.
+
 ### 5a. Map UI Spec Components to Tasks (when UI Spec provided)
 
 When a UI Spec is among the inputs, also map components and states to the tasks that implement them. This mapping is required for downstream task generation; without it the UI Spec does not reach the implementation phase.
@@ -107,25 +109,25 @@ For each component documented in the UI Spec:
 
 Record the mapping in the **UI Spec Component → Task Mapping** table (see plan template). One row per component. Components with no covering task are flagged as `gap` requiring user confirmation, identical to the Design-to-Plan Traceability rule.
 
-### 5b. Map Cross-Package Boundaries to Tasks (when implementation crosses runtime/deployment boundaries)
+### 5b. Map Boundaries to Tasks (when crossing a runtime/deployment boundary, or passing a serialized value across any boundary)
 
-When the implementation crosses a runtime or deployment boundary, build a Connection Map. This map is required so boundary context propagates to each affected task in the downstream task generation phase.
+Build a Connection Map when the implementation crosses a runtime or deployment boundary, **or when a value is serialized and re-parsed across any boundary (even within one runtime)**. This map is required so boundary context propagates to each affected task in the downstream task generation phase.
 
-**A boundary qualifies for the Connection Map only when ALL of the following hold**:
-- The two sides run in separate processes, services, or runtimes (e.g., web client ↔ HTTP server, service A ↔ service B over a network, frontend bundle ↔ backend handler)
-- A serialized contract crosses between them (HTTP request/response, message envelope, RPC call, event payload)
-- A failure on one side produces an observable signal on the other (status code, missing field, timeout, dropped message)
+**A boundary qualifies for the Connection Map when EITHER condition holds**:
+- *Cross-process*: the two sides run in separate processes, services, or runtimes (web client ↔ HTTP server, service A ↔ service B, frontend bundle ↔ backend handler); a serialized contract crosses between them (HTTP request/response, message envelope, RPC, event payload); and a failure on one side produces an observable signal on the other.
+- *Serialized in-runtime*: a value is encoded and re-parsed across a boundary even within a single runtime — through a medium such as a query string, CLI argument, environment variable, config entry, message/queue payload, storage key, or file (e.g., one component encodes a value another component or process later decodes; a value written to storage and read after a transition). The producer and consumer must agree on the exact representation.
 
 **Excluded — these are NOT boundaries for the Connection Map**:
-- A package importing a sibling utility, type definition, or shared constant from the same monorepo (in-process, no serialized contract)
-- Internal layering within the same runtime (e.g., handler → usecase → repository)
+- A package importing a sibling utility, type definition, or shared constant from the same monorepo (in-process, no serialized value)
+- Internal layering within the same runtime where values pass as typed in-memory calls (e.g., handler → usecase → repository)
 - Source code dependencies that compile/bundle into the same artifact
 
 For each qualifying boundary:
-1. Identify the boundary (e.g., `web → API gateway`, `service-A → service-B`, `frontend → shared client → backend handler`)
-2. Identify the owner module/package on each side
-3. Identify the expected signal that confirms the boundary works (e.g., HTTP 200 with schema X, message published to topic Y, row inserted in table Z)
-4. Identify the task(s) that implement either side of the boundary
+1. Identify the boundary (e.g., `service A → service B`, `producer → storage → consumer`, `component A → component B via an encoded parameter`)
+2. Identify the owner module/component on each side (producer and consumer)
+3. For a serialized boundary, record the **Serialized Format** (the exact representation the producer emits) and the **Consumer Parse Rule** (how the consumer decodes/validates it). Set both to "—" when the contract is already captured by the Expected Signal (e.g., a cross-process call whose body matches the agreed schema); fill them when producer and consumer must agree on a specific encoding of a value (query string, storage key, CLI argument, config entry, message field).
+4. Identify the expected signal that confirms the boundary works (e.g., a response matching the agreed schema; the consumer reproducing the producer's values)
+5. Identify the task(s) that implement either side of the boundary
 
 Record the mapping in the **Connection Map** table (see plan template). Omit this section entirely when no qualifying boundary exists.
 
@@ -319,11 +321,15 @@ When creating work plans, **Phase Structure Diagrams** and **Task Dependency Dia
 - [ ] Design-to-Plan Traceability table complete (all DD technical requirements categorized and mapped)
   - [ ] No `gap` entries without justification
   - [ ] All justified `gap` entries flagged for user confirmation before plan approval
+- [ ] Reference Contract Values table complete (when the Design Doc specifies binding observable values: column/label order, derived-display, state-lifecycle negative)
+  - [ ] Each value copied verbatim from the Design Doc, preserving full wording
+  - [ ] Each value mapped to a covering task
 - [ ] UI Spec Component → Task Mapping table complete (when UI Spec provided)
   - [ ] Every UI Spec component has a covering task, OR an explicit `gap` justification
   - [ ] Component reference uses the UI Spec section heading exactly as it appears in the document
-- [ ] Connection Map table complete (when implementation crosses packages/services)
+- [ ] Connection Map table complete (when crossing packages/services, or passing a serialized value across any boundary)
   - [ ] Every boundary lists owner modules and expected signal
+  - [ ] Serialized boundaries record Serialized Format and Consumer Parse Rule
   - [ ] Every boundary maps to at least one covering task on each side
 - [ ] ADR Bindings table complete (when ADR provided or referenced from Design Doc)
   - [ ] Each row represents one implementation-binding decision (placement, dependency, contract, data flow, or persistence)

--- a/dev-workflows-fullstack/skills/documentation-criteria/references/design-template.md
+++ b/dev-workflows-fullstack/skills/documentation-criteria/references/design-template.md
@@ -107,10 +107,7 @@ Keywords determine test type and reduce ambiguity.
 - [ ] **When** user clicks login button with valid credentials, the system shall authenticate and redirect to dashboard
 - [ ] **If** credentials are invalid, **then** the system shall display error message "Invalid credentials"
 - [ ] **While** user is logged in, the system shall maintain the session for configured timeout period
-
-### [Functional Requirement 2]
-
-- [ ] The system shall display data list with pagination of 10 items per page
+- [ ] (ubiquitous, no keyword) The system shall display the data list with pagination of 10 items per page
 
 ## Existing Codebase Analysis
 
@@ -174,14 +171,11 @@ No Ripple Effect:
 
 | Integration Point | Location | Old Implementation | New Implementation | Switching Method | Verification Method |
 |-------------------|----------|-------------------|-------------------|------------------|-------------------|
-| Integration Point 1 | [Class/Function] | [Existing Process] | [New Process] | [DI/Factory etc.] | [How to verify this switching works] |
-| Integration Point 2 | [Another Location] | [Existing] | [New] | [Method] | [Verification approach] |
+| [Integration Point] | [Class/Function] | [Existing Process or N/A] | [New Process] | [DI/Factory/config/etc.] | [How to verify this switching works] |
 
 ### Main Components
 
-Repeat the block below for each component.
-
-#### Component 1
+#### [Component] (repeat per component)
 
 - **Responsibility**: [Scope of responsibility for this component]
 - **Interface**: [APIs and contract definitions provided]
@@ -206,7 +200,6 @@ One entry per new in-scope element. This section records the 5-step output produ
 
 **Step 1 — Fixed Requirements**
 - [AC ID or constraint ID]: [requirement / constraint text]
-- [AC ID or constraint ID]: [requirement / constraint text]
 
 **Steps 2–3 — Alternatives Compared**
 
@@ -214,7 +207,6 @@ One entry per new in-scope element. This section records the 5-step output produ
 |---|---|---|---|---|---|---|
 | [The added element as proposed] | | | | | | |
 | [Subtractive alternative — derive / compute on demand / keep at caller / reuse existing / do not introduce new state] | | | | | | |
-| [Optional third alternative] | | | | | | |
 
 **Step 4 — Selected Alternative and Rationale**
 - **Selected**: [alternative name]
@@ -224,23 +216,17 @@ One entry per new in-scope element. This section records the 5-step output produ
 
 **Step 5 — Rejected Alternatives Log**
 - [Alternative name]: [1-2 lines on what it was and why rejected]
-- [Alternative name]: [1-2 lines on what it was and why rejected]
 
 (Repeat the Element block above for each additional in-scope element.)
 
 Mark the whole section as N/A with brief rationale when the design introduces no in-scope elements.
 
-### Contract Definitions
+### Data Contracts
 
-```
-// Record major contract/interface definitions here
-```
-
-### Data Contract
-
-#### Component 1
+#### [Component or Boundary] (repeat per component/boundary)
 
 ```yaml
+Contract: [interface / function / API / schema name]
 Input:
   Type: [Data shape, contract, or schema]
   Preconditions: [Required items, format constraints]
@@ -257,9 +243,11 @@ Invariants:
 
 ### Field Propagation Map (When Fields Cross Boundaries)
 
-| Field | Boundary | Status | Detail |
-|-------|----------|--------|--------|
-| [field name] | [Component A → B] | preserved / transformed / dropped | [logic or reason] |
+A boundary here includes a **serialized boundary** — a value encoded on one side and parsed on the other through a medium such as a query string, CLI argument, environment variable, config entry, message/queue payload, storage key, or file — not only cross-process calls. For those, record the exact encoded representation and how the consumer parses it, so producer and consumer agree.
+
+| Field | Boundary | Status | Serialized Format | Consumer Parse Rule | Detail |
+|-------|----------|--------|-------------------|---------------------|--------|
+| [field name] | [Component A → B] | preserved / transformed / dropped | [exact representation the producer emits when the boundary is serialized; "—" otherwise] | [how the consumer decodes and validates that representation; "—" when not serialized] | [logic or reason] |
 
 ### State Transitions and Invariants (When Applicable)
 
@@ -317,9 +305,7 @@ System Invariants:
 
 ### Technical Dependencies and Implementation Order
 
-#### Required Implementation Order
-
-Repeat the entry below for each component/feature, in dependency order.
+#### Required Implementation Order (in dependency order, one entry per component/feature)
 
 1. **[Component/Feature]**
    - Technical Reason: [Why this needs to be implemented at this position]
@@ -365,15 +351,11 @@ Verification Strategy defines what correctness means and how to prove it at desi
 
 ### Correctness Proof Method
 
-How will this change's correctness be demonstrated?
-
 - **Correctness definition**: [What "correct" means for this change — e.g., "output matches existing behavior", "all ACs pass in production-equivalent environment", "generated queries execute without error on target DB"]
 - **Verification method**: [Specific technique — e.g., "compare new implementation output against existing implementation", "run against staging DB", "contract test with real API"]
 - **Verification timing**: [When verification occurs — e.g., "after first vertical slice", "per repository", "at integration phase"]
 
 ### Early Verification Point
-
-What is verified first, and how, to confirm the approach is correct before scaling?
 
 - **First verification target**: [The smallest unit that proves the approach works — e.g., "first repository migration", "single API endpoint", "one screen flow"]
 - **Success criteria**: [Observable outcome — e.g., "CSV download produces identical output to legacy", "API returns 200 with expected schema"]
@@ -400,12 +382,9 @@ This section records what was **excluded** from the current design surface. Spec
 
 ## Alternative Solutions
 
-### Alternative 1
-
-- **Overview**: [Description of alternative solution]
-- **Advantages**: [Advantages]
-- **Disadvantages**: [Disadvantages]
-- **Reason for Rejection**: [Why it wasn't adopted]
+| Alternative | Overview | Advantages | Disadvantages | Reason for Rejection |
+|---|---|---|---|---|
+| [Alternative 1] | | | | |
 
 ## Risks and Mitigation
 

--- a/dev-workflows-fullstack/skills/documentation-criteria/references/plan-template.md
+++ b/dev-workflows-fullstack/skills/documentation-criteria/references/plan-template.md
@@ -51,6 +51,16 @@ Maps each Design Doc technical requirement to the covering task(s). One row per 
 
 **Gap Status values**: `covered` (task exists), `gap` (no task — requires justification in Notes, user confirmation required before plan approval)
 
+## Reference Contract Values
+
+Include this section when a Traceability row's DD Item encodes a **binding observable value** the implementation must reproduce exactly: a column/label set and order, a derived-display rule (display value derived from another field), or a state-lifecycle negative (the condition under which the state must stay unused). **Serialized boundaries** (a value encoded and re-parsed across a boundary) are owned by the Connection Map / Field Propagation Map — record those there. These are DD-derived observable contracts; ADR-derived structural decisions belong in ADR Bindings. Omit the section when none apply.
+
+The Traceability table records *that* a row is covered; this table carries the row's value *verbatim* so the covering task can be checked against the exact contract rather than a re-derived summary.
+
+| Design Doc (§ Section) | Contract Type | Required Observable Value (verbatim) | Covered By Task(s) |
+|---|---|---|---|
+| [docs/design/XXX.md (§ Section)] | structure-order / derived-display / state-lifecycle-negative | [the exact value copied from the Design Doc — e.g., "the listed fields in the specified order"; "the label shows the looked-up name in place of the raw code"; "the persisted state is applied only when an explicit restore signal is present"] | [Phase X Task Y] |
+
 ## Failure Mode Checklist
 
 Domain-independent failure categories this implementation must guard against. Enumerate all eight categories, mark which apply, and list a covering task for each that applies; keep entries free of project-specific names.
@@ -92,11 +102,13 @@ One row per binding decision. A single ADR can contribute multiple rows. A singl
 
 ## Connection Map
 
-Include this section when the implementation crosses more than one package, service, or process boundary. Document each boundary. Omit the section when the implementation stays within a single package.
+Include this section when the implementation crosses a package, service, or process boundary, **or when a value is serialized and re-parsed across a boundary even within a single runtime** — through a medium such as a query string, CLI argument, environment variable, config entry, message/queue payload, storage key, or file (the producer and consumer must agree on the exact representation). Omit the section when no such boundary exists.
 
-| Boundary | Owner (left side) | Owner (right side) | Expected Signal | Covered By Task(s) |
-|---|---|---|---|---|
-| [e.g., "web client → API gateway"] | [module/package on the request side] | [module/package on the response side] | [Observable evidence the boundary works — e.g., "HTTP 200 with response matching ContractA", "row inserted in tableB", "message published to topicC"] | [Phase X Task Y on each side] |
+For a serialized boundary, fill Serialized Format and Consumer Parse Rule. Set them to "—" when the contract is already captured by the Expected Signal (e.g., a cross-process call whose body matches the agreed schema); fill them when producer and consumer must agree on a specific encoding of a value (query string, storage key, CLI argument, config entry, message field).
+
+| Boundary | Owner (left side) | Owner (right side) | Serialized Format | Consumer Parse Rule | Expected Signal | Covered By Task(s) |
+|---|---|---|---|---|---|---|
+| [producing side → consuming side] | [module/component on the producing side] | [module/component on the consuming side] | [exact representation the producer emits; "—" if not serialized] | [how the consumer decodes/validates it; "—" if not serialized] | [Observable evidence the boundary works — e.g., a response matching the agreed contract, or the consumer reproducing the producer's values] | [Phase X Task Y on each side] |
 
 ## Objective
 [Why this change is necessary, what problem it solves]

--- a/dev-workflows-fullstack/skills/documentation-criteria/references/task-template.md
+++ b/dev-workflows-fullstack/skills/documentation-criteria/references/task-template.md
@@ -33,6 +33,15 @@ Each row is an ADR decision the implementation in this task must comply with.
 |---|---|---|---|
 | [docs/adr/ADR-XXXX.md (§ <Source Section>) — substitute the section name (`Decision` or `Implementation Guidance`) from the matching work plan row] | [Axis value copied verbatim from the work plan's ADR Bindings row] | [Binding decision copied from the work plan's ADR Bindings row] | [Y/N-answerable positive predicate that evaluates whether the planned/final implementation satisfies the decision] |
 
+## Reference Contracts
+(Include this section when the work plan's Reference Contract Values table covers this task. Omit otherwise.)
+
+Each row is a DD-derived observable contract the implementation in this task must reproduce exactly. Serialized boundaries are carried by the Boundary Context (from the work plan's Connection Map), and ADR-derived structural decisions by Binding Decisions above.
+
+| Source | Contract Type | Required Observable Value | Compliance Check |
+|---|---|---|---|
+| [Design Doc path (§ Section) copied from the matching work plan Reference Contract Values row] | [Contract Type copied from the work plan row: structure-order / derived-display / state-lifecycle-negative] | [Required Observable Value copied verbatim from the work plan row] | [Y/N-answerable positive predicate that evaluates whether the planned/final implementation reproduces the value] |
+
 ## Investigation Notes
 (Implementation observations are appended here before implementation begins. When Binding Decisions exist, record the planned implementation approach and each Compliance Check result here.)
 
@@ -79,6 +88,7 @@ Each row is an ADR decision the implementation in this task must comply with.
 - [ ] Each Proof Obligation is met: the test turns red under its primary failure mode and exercises the stated boundary
 - [ ] Deliverables created (for research/design tasks)
 - [ ] (When Binding Decisions exist) Every Compliance Check evaluates to `Y` against the final implementation, with evidence recorded in Investigation Notes (file:line, test result, or command output)
+- [ ] (When Reference Contracts exist) Every Reference Contract Compliance Check evaluates to `Y` against the final implementation, with evidence recorded in Investigation Notes
 
 ## Notes
 - Impact scope: [Areas where changes may propagate]

--- a/dev-workflows-fullstack/skills/frontend-ai-guide/SKILL.md
+++ b/dev-workflows-fullstack/skills/frontend-ai-guide/SKILL.md
@@ -178,7 +178,7 @@ Read `package.json` scripts and run them with the project's package manager (`pa
 ### Performance vs Readability
 - Prioritize readability unless React DevTools Profiler identifies a measurable bottleneck (e.g., render time exceeding 16ms, unnecessary re-renders)
 - Measure before optimizing with React DevTools Profiler
-- When React Compiler is enabled, routine memoization is automatic; manual memoization is a profiler- or identity-justified exception (measured bottleneck, or stable reference identity for third-party APIs / effect dependencies)
+- Memoization policy (React Compiler vs manual `React.memo`/`useMemo`/`useCallback`): follow the typescript-rules skill (Performance Optimization)
 - Document reason with comments when optimizing
 
 ### Granularity of Component/Type Definitions

--- a/dev-workflows/.claude-plugin/plugin.json
+++ b/dev-workflows/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflows",
   "description": "Skills + Subagents for backend development - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
-  "version": "0.20.5",
+  "version": "0.21.0",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows/agents/code-reviewer.md
+++ b/dev-workflows/agents/code-reviewer.md
@@ -45,6 +45,7 @@ Read the Design Doc **in full** and extract:
 - Architecture design and data flow
 - Interface contracts (function signatures, API endpoints, data structures)
 - Identifier specifications (resource names, endpoint paths, configuration keys, error codes, schema/model names)
+- Binding observable contracts: column/label sets and order, derived-display rules, and state-lifecycle negatives; plus Field Propagation Map rows that carry a Serialized Format + Consumer Parse Rule
 - Error handling policy
 - Non-functional requirements
 
@@ -60,7 +61,7 @@ For each acceptance criterion extracted in Step 1:
 - For behavior-changing ACs, confirm the evidence covers the boundary paths, not only the main path: where a distinct branch, state, input class, lifecycle step, or fallback governs the behavior, verify it is exercised. Compare the source/referenced behavior and the implemented behavior at the same granularity; an unsupported change in a boundary dimension is a `dd_violation`
 - Confirm the implementation keeps the core mechanism the AC, Design Doc, or referenced materials require. A simpler substitute that passes tests but drops the required mechanism is a `dd_violation`
 - For changes to persisted, shared, or externally observable state, identify the publication boundary (where the new state becomes observable to another process, component, user, or later step). State that is observable as complete while still partial, uninitialized, stale, or rollback-only is a `reliability` finding, because a downstream consumer can treat the incomplete state as complete and fail
-- When the reviewed change is classified as `bug-fix`, `regression`, `state-change`, or `boundary-change` (the task's `Change Category` field, when present, names the kind), check the cases sharing its path, contract, persisted state, or external boundary. A sibling case still carrying the same class of defect the change addressed is an `adjacent_residual` finding
+- When the reviewed change is classified as `bug-fix`, `regression`, `state-change`, or `boundary-change` (the task's `Change Category` field, when present, names the kind; when no field is present — e.g., reviewing a diff without task files — classify from the diff itself), check the cases sharing its path, contract, persisted state, or external boundary. A sibling case still carrying the same class of defect the change addressed is an `adjacent_residual` finding. When the task file is in scope, also read its Investigation Notes for residuals the executor recorded as out-of-scope, and verify each recorded residual; if it remains unfixed within the reviewed scope, report it as `adjacent_residual`, otherwise record why it is resolved or outside the review scope
 
 #### 2-2. Identifier Verification
 
@@ -81,6 +82,13 @@ Assign confidence based on evidence count:
 - **high**: 3+ sources agree
 - **medium**: 2 sources agree
 - **low**: 1 source only (implementation exists but no test or type confirmation)
+
+#### 2-4. Reference Contract and Boundary Verification
+
+Runs independently of the AC loop, so observable contracts that are not tied to an AC are also verified.
+
+1. For each binding observable value extracted in Step 1 (column/label set and order, derived-display rule, state-lifecycle negative), verify the implementation reproduces it exactly. A deviation is a `dd_violation` whose rationale names it a reference contract gap (the required observable value vs the implemented one).
+2. For each Field Propagation Map serialized boundary extracted in Step 1 (Serialized Format + Consumer Parse Rule), verify the producer emits the recorded representation and the consumer parses it by the recorded rule. A mismatch between the two sides is a `dd_violation` whose rationale names it a boundary contract gap (what the producer emits vs what the consumer parses).
 
 ### 3. Assess Code Quality
 

--- a/dev-workflows/agents/document-reviewer.md
+++ b/dev-workflows/agents/document-reviewer.md
@@ -43,7 +43,7 @@ You are an AI assistant specialized in technical document review.
 - Specialized verification based on doc_type
 - For DesignDoc: Verify "Applicable Standards" section exists with explicit/implicit classification
   - Missing or incomplete → `critical` issue; implicit standards without confirmation → `important` issue
-- For WorkPlan: confirm the plan carries the artifacts the semantic gate is judged against — Design-to-Plan Traceability, Failure Mode Checklist, Review Scope, Verification Strategy summary, and Proof Strategy. Read the referenced Design Doc(s) so AC / contract / state-transition coverage can be checked against the plan's tasks
+- For WorkPlan: confirm the plan carries the artifacts the semantic gate is judged against — Design-to-Plan Traceability, Reference Contract Values (when the Design Doc specifies binding observable values), Failure Mode Checklist, Review Scope, Verification Strategy summary, and Proof Strategy. Read the referenced Design Doc(s) so AC / contract / state-transition coverage and the content fidelity of binding observable values can be checked against the plan
 - If `code_verification` provided: extract discrepancy list and reverse coverage gaps; feed into Gate 1 as pre-verified evidence
 - If `codebase_analysis` provided: extract `focusAreas` and their `evidence` values for Gate 0 / Gate 1 Fact Disposition checks
 
@@ -108,6 +108,7 @@ For WorkPlan, additionally verify:
   - (3) Each cross-boundary, public-boundary, or persisted-state change names a task that verifies it through the real boundary — missing → `important` issue (category: `completeness`)
   - (4) Each traceability table present (Design-to-Plan, UI Spec Component, Connection Map, ADR Bindings) is filled to a granularity that resolves its target task — under-specified rows → `important` issue (category: `completeness`)
   - (5) The Failure Mode Checklist covers the plan's applicable domain-independent categories (same-value, no-op, empty input, invalid option, missing config, unavailable boundary, shared-state dependency, rollback-only visibility) — missing applicable category → `recommended` issue (category: `completeness`)
+  - (6) Binding observable values are carried with content fidelity, not only coverage: for each Design Doc observable contract that encodes a binding value (a column/label set and order, a derived-display rule, or a state-lifecycle negative), the plan's Reference Contract Values table carries the value verbatim from the Design Doc and maps it to a covering task. Re-derive each such value from the Design Doc and compare against the plan; a value reduced to a label, summarized, or absent while the Design Doc specifies it is a content-fidelity gap → `critical` issue (category: `completeness`)
   - Verdict mapping (WorkPlan): any semantic-gate `critical` issue forces the verdict to at least `needs_revision` — except a coverage gap traceable to a missing or contradictory Design Doc/input element (which re-planning cannot fix) → `rejected`; an `important`-only set caps the verdict at `approved_with_conditions`
 
 **Perspective-specific Mode**:
@@ -156,49 +157,15 @@ Complete all items before proceeding to output.
 
 ```json
 {
-  "metadata": {
-    "review_mode": "comprehensive",
-    "doc_type": "DesignDoc",
-    "target_path": "/path/to/document.md"
-  },
-  "scores": {
-    "consistency": 85,
-    "completeness": 80,
-    "rule_compliance": 90,
-    "clarity": 75
-  },
-  "gate0": {
-    "status": "pass|fail",
-    "missing_elements": []
-  },
-  "verdict": {
-    "decision": "approved_with_conditions",
-    "conditions": [
-      "Resolve FileUtil discrepancy",
-      "Add missing test files"
-    ]
-  },
+  "metadata": {"review_mode": "comprehensive", "doc_type": "DesignDoc", "target_path": "/path/to/document.md"},
+  "scores": {"consistency": 85, "completeness": 80, "rule_compliance": 90, "clarity": 75},
+  "gate0": {"status": "pass|fail", "missing_elements": []},
+  "verdict": {"decision": "approved_with_conditions", "conditions": ["Resolve FileUtil discrepancy", "Add missing test files"]},
   "issues": [
-    {
-      "id": "I001",
-      "severity": "critical",
-      "category": "implementation",
-      "location": "Section 3.2",
-      "description": "FileUtil method mismatch",
-      "suggestion": "Update document to reflect actual FileUtil usage"
-    }
+    {"id": "I001", "severity": "critical", "category": "implementation", "location": "Section 3.2", "description": "FileUtil method mismatch", "suggestion": "Update document to reflect actual FileUtil usage"}
   ],
-  "recommendations": [
-    "Priority fixes before approval",
-    "Documentation alignment with implementation"
-  ],
-  "prior_context_check": {
-    "items_received": 0,
-    "resolved": 0,
-    "partially_resolved": 0,
-    "unresolved": 0,
-    "items": []
-  }
+  "recommendations": ["Priority fixes before approval", "Documentation alignment with implementation"],
+  "prior_context_check": {"items_received": 0, "resolved": 0, "partially_resolved": 0, "unresolved": 0, "items": []}
 }
 ```
 
@@ -206,16 +173,8 @@ Complete all items before proceeding to output.
 
 ```json
 {
-  "metadata": {
-    "review_mode": "perspective",
-    "focus": "implementation",
-    "doc_type": "DesignDoc",
-    "target_path": "/path/to/document.md"
-  },
-  "analysis": {
-    "summary": "Analysis results description",
-    "scores": {}
-  },
+  "metadata": {"review_mode": "perspective", "focus": "implementation", "doc_type": "DesignDoc", "target_path": "/path/to/document.md"},
+  "analysis": {"summary": "Analysis results description", "scores": {}},
   "issues": [],
   "checklist": [
     {"item": "Check item description", "status": "pass|fail|na"}
@@ -236,12 +195,7 @@ Include in output when `prior_context_count > 0`:
     "partially_resolved": 1,
     "unresolved": 0,
     "items": [
-      {
-        "id": "D001",
-        "status": "resolved",
-        "location": "Section 3.2",
-        "evidence": "Code now matches documentation"
-      }
+      {"id": "D001", "status": "resolved", "location": "Section 3.2", "evidence": "Code now matches documentation"}
     ]
   }
 }

--- a/dev-workflows/agents/task-decomposer.md
+++ b/dev-workflows/agents/task-decomposer.md
@@ -183,7 +183,7 @@ When the work plan contains a Connection Map table, propagate boundary context t
 
 1. **Lookup by task ID**: For each row in the Connection Map, locate the task(s) listed in the "Covered By Task(s)" column
 2. **Append to Investigation Targets**: Add the boundary's owner module file paths on both sides to each matched task's Investigation Targets
-3. **Add a "Boundary Context" note in the task body**: Record the boundary identifier and expected signal verbatim from the Connection Map row, so the executor knows what observable evidence the implementation must produce
+3. **Add a "Boundary Context" note in the task body**: Record the boundary identifier and expected signal verbatim from the Connection Map row, so the executor knows what observable evidence the implementation must produce. When the row carries a **Serialized Format** and **Consumer Parse Rule** (a serialized in-runtime boundary), copy both verbatim into the note and state the roundtrip check the task must satisfy: the value the producer emits parses to the value the consumer expects.
 4. **Skip when not provided**: If the work plan has no Connection Map, skip this propagation step
 
 ## ADR Binding Propagation
@@ -213,6 +213,19 @@ When the work plan contains a Design-to-Plan Traceability table, propagate the m
 1. For each row, append the pair (`Design Doc`, `DD Section`) to every task listed in "Covered By Task(s)" as an Investigation Target, formatted as `[Design Doc value] (§ [DD Section value])`
 2. Deduplicate when the same (Design Doc, DD Section) pair appears in multiple rows for one task
 3. Apply only when the work plan contains a Design-to-Plan Traceability table
+
+## Reference Contract Propagation
+
+When the work plan contains a **Reference Contract Values** table, propagate each binding observable value to the task(s) it covers, so the executor is checked against the exact value rather than a back-pointer it must re-derive:
+
+1. **Lookup by task ID**: For each row, locate the task(s) listed in "Covered By Task(s)"
+2. **Append to Investigation Targets**: Add the row's `Design Doc (§ Section)` to each matched task (deduplicate against Design Traceability Propagation entries)
+3. **Add a Reference Contracts table row to the task**: For each matched row, add one row to the task's Reference Contracts table (see task template):
+   - **Source**: the `Design Doc (§ Section)` value
+   - **Contract Type**: copy the `Contract Type` value verbatim (structure-order / derived-display / state-lifecycle-negative)
+   - **Required Observable Value**: copy the value **verbatim** from the work plan row, preserving its exact wording and detail
+   - **Compliance Check**: write a Y/N-answerable positive predicate stating the final implementation reproduces the value (e.g., "the listed fields render in the specified order"; "the label shows the looked-up name in place of the raw code"; "the persisted state is applied only when the restore signal is present")
+4. **Apply only when provided**: Run this propagation only when the work plan contains a Reference Contract Values table. Serialized boundaries are propagated by Connection Map Propagation above, not here.
 
 ## Change Category Classification
 
@@ -333,6 +346,7 @@ Please execute decomposed tasks according to the order.
 - [ ] UI Spec Component → Task Mapping rows propagated to matching tasks (when work plan has the table)
 - [ ] Connection Map boundary rows propagated to matching tasks (when work plan has the table)
 - [ ] Design-to-Plan Traceability rows propagated to matching tasks as Investigation Targets (when work plan has the table)
+- [ ] Reference Contract Values rows propagated to matching tasks as Reference Contracts, value copied verbatim (when work plan has the table)
 - [ ] ADR Bindings rows propagated to matching tasks as Binding Decisions (when work plan has the table)
   - [ ] Source includes ADR path with section hint
   - [ ] Axis copied verbatim from the work plan row to the task's Binding Decisions table

--- a/dev-workflows/agents/task-executor.md
+++ b/dev-workflows/agents/task-executor.md
@@ -140,7 +140,7 @@ Runs after Pre-implementation Verification, before the Binding Decision Check. T
 
 1. From the Investigation Targets (the decomposition already extended them with the adjacent files), identify the cases sharing the same path, contract, persisted state, or external boundary as the change — fallback behavior, stale state, retries, and external calls related to the change.
 2. Check each for the same class of defect this task corrects.
-3. Fold adjacent residuals within the Target Files scope into this task's failing tests and implementation. Record any residual outside scope in the task file's Investigation Notes so downstream review (code-reviewer / verifier) can detect it.
+3. Plan to fold adjacent residuals within the Target Files scope into this task's failing tests and implementation during the Red phase. Record any residual outside scope in the task file's Investigation Notes so downstream review (code-reviewer) can read and detect it.
 
 #### Binding Decision Check (Required when the task file has a Binding Decisions section)
 
@@ -153,6 +153,18 @@ Runs after Pre-implementation Verification, before the TDD cycle.
    - `Y`: proceed
    - `N`: stop implementation and produce the final response with `status: "escalation_needed"` and `escalation_type: "binding_decision_violation"` with `phase: "pre_implementation"` (see Binding Decision Violation Escalation in Structured Response Specification). `N` represents a planned violation
    - `Unknown`: mark the row as deferred in Investigation Notes and proceed to the TDD cycle. The Exit Gate re-evaluates every row (including Unknown rows deferred from this step) against the final implementation and escalates if any remains `N` or `Unknown` at that point
+
+#### Reference Contract Check (Required when the task file has a Reference Contracts section)
+
+Runs after Pre-implementation Verification, alongside the Binding Decision Check.
+
+1. Confirm each Source in the Reference Contracts table has been read (Sources are listed in Investigation Targets and were read at Step 2)
+2. Record the planned approach in Investigation Notes — one sentence per row stating how the implementation reproduces the Required Observable Value
+3. Evaluate each row's Compliance Check against the planned approach. Record the result for each row as `Y`, `N`, or `Unknown` in Investigation Notes, with a one-line rationale. Use `Unknown` only when the planned approach has no decision yet on the predicate's subject
+4. Per row, branch on the evaluation:
+   - `Y`: proceed
+   - `N`: stop implementation and produce the final response with `status: "escalation_needed"` and `escalation_type: "design_compliance_violation"` (Escalation Response 2-1), populating `details.design_doc_expectation` with the Reference Contract row's Required Observable Value and `details.actual_situation` with the planned approach
+   - `Unknown`: mark the row as deferred in Investigation Notes and proceed to the TDD cycle. The Exit Gate re-evaluates every deferred row against the final implementation
 
 #### Reference Representativeness (Applied During Implementation)
 
@@ -344,6 +356,8 @@ This gate runs immediately before producing the final JSON response.
 ☐ All task checkboxes completed with evidence (or `escalation_needed` triggered earlier)
 ☐ Implementation is consistent with the Investigation Notes recorded at Step 2 (when Investigation Targets were present)
 ☐ Every Binding Decisions Compliance Check evaluates to `Y` against the final implementation, with evidence recorded in Investigation Notes (when the task file has a Binding Decisions section). Re-evaluate here even when the pre-implementation check passed, because the implementation may have diverged from the planned approach
+☐ Every Reference Contracts Compliance Check evaluates to `Y` against the final implementation, with evidence recorded in Investigation Notes (when the task file has a Reference Contracts section). Re-evaluate here even when the pre-implementation check passed
+☐ A test exercises the roundtrip — the value the producer emits parses to the value the consumer expects (when the task has a Boundary Context with a roundtrip check from the work plan's Connection Map)
 ☐ When test runs are cited as `runnableCheck` evidence, they are substantive and executable per the runnableCheck.result field spec (skipped tests, placeholder/TODO-only bodies, always-passing assertions, and 0-match runner reports do not count); non-test verification (build/typecheck/CLI) is not subject to this check
 ☐ Final response is a single JSON with `status: "completed"` or `status: "escalation_needed"` and matches the schema in Structured Response Specification
 

--- a/dev-workflows/agents/technical-designer.md
+++ b/dev-workflows/agents/technical-designer.md
@@ -49,7 +49,6 @@ The subsections below are not parallel mandates; they form four serial gates. Co
 Each subsection below carries a `[Gate N — ...]` annotation in its heading. Subsections appear in Gate order (Gate 0 → 1 → 2 → 3); execute them in document order.
 
 ### Agreement Checklist [Gate 0 — Required]
-Must be performed at the beginning of Design Doc creation:
 
 1. **List agreements with user in bullet points**
    - Scope (what to change)
@@ -66,7 +65,6 @@ Must be performed at the beginning of Design Doc creation:
 Fill the Design Doc's "External Resources Used" subsection (under Background and Context) per the external-resource-context skill (feature-tier protocol).
 
 ### Standards Identification [Gate 0 — Required]
-Must be performed before any investigation:
 
 1. **Identify Project Standards**
    - Scan project configuration, rule files, and existing code patterns
@@ -88,7 +86,6 @@ Must be performed before any investigation:
    - Deviations require documented rationale
 
 ### Existing Code Investigation [Gate 1 — Required]
-Must be performed before Design Doc creation:
 
 1. **Implementation File Path Verification**
    - First grasp overall structure using Glob with detected project patterns
@@ -187,7 +184,6 @@ Execute the 5 steps below for each in-scope element, and record the result in th
    - For each rejected alternative, record 1-2 lines: what it was, why rejected. Include in the Design Doc to prevent re-proposal in subsequent iterations or by future agents.
 
 ### Implementation Approach Decision [Gate 2 — Required]
-Must be performed when creating Design Doc:
 
 1. **Approach Selection Criteria**
    - Execute Phase 1-4 of implementation-approach skill to select strategy
@@ -210,7 +206,6 @@ Must be performed when creating Design Doc:
    - Define early verification point: what is the first thing to verify, and how, to confirm the approach is correct before scaling. For replacements/modifications, the early verification point must be an output comparison of at least one representative case
 
 ### Common ADR Process [Gate 2 — Required]
-Perform before Design Doc creation:
 1. Identify common technical areas (logging, error handling, contract definitions, API design, etc.)
 2. Search `docs/ADR/ADR-COMMON-*`, create if not found
 3. Include in Design Doc's "Prerequisite ADRs"
@@ -240,7 +235,6 @@ For each integration boundary, define the contract:
 Confirm and document conflicts with existing systems (priority, naming conventions) at each integration point.
 
 ### Change Impact Map [Gate 3 — Required]
-Must be included when creating Design Doc:
 
 ```yaml
 Change Target: [ServiceName.methodName()]
@@ -258,6 +252,9 @@ No Ripple Effect:
 When new or changed fields cross component boundaries:
 
 Document each field's status (preserved / transformed / dropped) at each boundary with rationale.
+
+When the boundary is **serialized** — the value is encoded and re-parsed across a medium such as a query string, CLI argument, environment variable, config entry, message/queue payload, storage key, or file — also fill the template's **Serialized Format** (the exact representation the producer emits) and **Consumer Parse Rule** (how the consumer decodes/validates it) columns, so producer and consumer agree on the representation. Set both to "—" for in-memory field crossings.
+
 Skip if no fields cross component boundaries.
 
 ### Interface Change Impact Analysis [Gate 3 — Required]
@@ -314,23 +311,12 @@ When conversion is required, clearly specify adapter implementation or migration
 - Follow respective templates (`template.md`)
 - For ADR, check existing numbers and use max+1, initial status is "Proposed"
 
-## ADR Responsibility Boundaries
+## Output Rules
 
-Include in ADR: Decisions, rationale, principled guidelines
-Exclude from ADR: Schedules, implementation procedures, specific code
-
-Implementation guidelines should only include principles (e.g., "Use dependency injection"), not schedules or procedures.
-
-## Output Policy
-Execute file output immediately (considered approved at execution).
-
-## Scope Boundary
-
-Test derivation itself is a downstream agent responsibility.
-
-## Implementation Sample Standards Compliance
-
-All implementation samples in ADR and Design Docs MUST follow the loaded `coding-principles` and `testing-principles` skills. Omit samples unless they clarify contracts or edge cases that prose cannot convey.
+- Execute file output immediately (considered approved at execution).
+- ADR includes decisions, rationale, and principled guidelines (e.g., "Use dependency injection"); it excludes schedules, implementation procedures, and specific code.
+- Test derivation is a downstream agent responsibility.
+- Implementation samples MUST follow the loaded `coding-principles` and `testing-principles` skills; include a sample only when it clarifies a contract or edge case prose cannot convey.
 
 ## Diagram Creation (using mermaid notation)
 

--- a/dev-workflows/agents/work-planner.md
+++ b/dev-workflows/agents/work-planner.md
@@ -96,6 +96,8 @@ Map each extracted item to a covering task. Items may be covered by a dedicated 
 
 Record the mapping in the Design-to-Plan Traceability table (see plan template). If an item has no covering task, set Gap Status to `gap` with justification in Notes. Gaps with justification require user confirmation before plan approval.
 
+**Carry binding observable values verbatim.** When a Traceability row's DD Item encodes a binding observable value — a column/label set and order, a derived-display rule (a display value derived from another field), or a state-lifecycle negative (a condition under which the state must stay unused) — copy that value **verbatim from the Design Doc** into the plan's **Reference Contract Values** table (see plan template), one row per value, mapped to the covering task(s). Preserve the full value, so the covering task is later checked against this exact value rather than a re-derived summary. This table covers DD-derived observable contracts only; serialized boundaries go in the Connection Map (step 5b) and ADR-derived structural decisions in the ADR Bindings table.
+
 ### 5a. Map UI Spec Components to Tasks (when UI Spec provided)
 
 When a UI Spec is among the inputs, also map components and states to the tasks that implement them. This mapping is required for downstream task generation; without it the UI Spec does not reach the implementation phase.
@@ -107,25 +109,25 @@ For each component documented in the UI Spec:
 
 Record the mapping in the **UI Spec Component → Task Mapping** table (see plan template). One row per component. Components with no covering task are flagged as `gap` requiring user confirmation, identical to the Design-to-Plan Traceability rule.
 
-### 5b. Map Cross-Package Boundaries to Tasks (when implementation crosses runtime/deployment boundaries)
+### 5b. Map Boundaries to Tasks (when crossing a runtime/deployment boundary, or passing a serialized value across any boundary)
 
-When the implementation crosses a runtime or deployment boundary, build a Connection Map. This map is required so boundary context propagates to each affected task in the downstream task generation phase.
+Build a Connection Map when the implementation crosses a runtime or deployment boundary, **or when a value is serialized and re-parsed across any boundary (even within one runtime)**. This map is required so boundary context propagates to each affected task in the downstream task generation phase.
 
-**A boundary qualifies for the Connection Map only when ALL of the following hold**:
-- The two sides run in separate processes, services, or runtimes (e.g., web client ↔ HTTP server, service A ↔ service B over a network, frontend bundle ↔ backend handler)
-- A serialized contract crosses between them (HTTP request/response, message envelope, RPC call, event payload)
-- A failure on one side produces an observable signal on the other (status code, missing field, timeout, dropped message)
+**A boundary qualifies for the Connection Map when EITHER condition holds**:
+- *Cross-process*: the two sides run in separate processes, services, or runtimes (web client ↔ HTTP server, service A ↔ service B, frontend bundle ↔ backend handler); a serialized contract crosses between them (HTTP request/response, message envelope, RPC, event payload); and a failure on one side produces an observable signal on the other.
+- *Serialized in-runtime*: a value is encoded and re-parsed across a boundary even within a single runtime — through a medium such as a query string, CLI argument, environment variable, config entry, message/queue payload, storage key, or file (e.g., one component encodes a value another component or process later decodes; a value written to storage and read after a transition). The producer and consumer must agree on the exact representation.
 
 **Excluded — these are NOT boundaries for the Connection Map**:
-- A package importing a sibling utility, type definition, or shared constant from the same monorepo (in-process, no serialized contract)
-- Internal layering within the same runtime (e.g., handler → usecase → repository)
+- A package importing a sibling utility, type definition, or shared constant from the same monorepo (in-process, no serialized value)
+- Internal layering within the same runtime where values pass as typed in-memory calls (e.g., handler → usecase → repository)
 - Source code dependencies that compile/bundle into the same artifact
 
 For each qualifying boundary:
-1. Identify the boundary (e.g., `web → API gateway`, `service-A → service-B`, `frontend → shared client → backend handler`)
-2. Identify the owner module/package on each side
-3. Identify the expected signal that confirms the boundary works (e.g., HTTP 200 with schema X, message published to topic Y, row inserted in table Z)
-4. Identify the task(s) that implement either side of the boundary
+1. Identify the boundary (e.g., `service A → service B`, `producer → storage → consumer`, `component A → component B via an encoded parameter`)
+2. Identify the owner module/component on each side (producer and consumer)
+3. For a serialized boundary, record the **Serialized Format** (the exact representation the producer emits) and the **Consumer Parse Rule** (how the consumer decodes/validates it). Set both to "—" when the contract is already captured by the Expected Signal (e.g., a cross-process call whose body matches the agreed schema); fill them when producer and consumer must agree on a specific encoding of a value (query string, storage key, CLI argument, config entry, message field).
+4. Identify the expected signal that confirms the boundary works (e.g., a response matching the agreed schema; the consumer reproducing the producer's values)
+5. Identify the task(s) that implement either side of the boundary
 
 Record the mapping in the **Connection Map** table (see plan template). Omit this section entirely when no qualifying boundary exists.
 
@@ -319,11 +321,15 @@ When creating work plans, **Phase Structure Diagrams** and **Task Dependency Dia
 - [ ] Design-to-Plan Traceability table complete (all DD technical requirements categorized and mapped)
   - [ ] No `gap` entries without justification
   - [ ] All justified `gap` entries flagged for user confirmation before plan approval
+- [ ] Reference Contract Values table complete (when the Design Doc specifies binding observable values: column/label order, derived-display, state-lifecycle negative)
+  - [ ] Each value copied verbatim from the Design Doc, preserving full wording
+  - [ ] Each value mapped to a covering task
 - [ ] UI Spec Component → Task Mapping table complete (when UI Spec provided)
   - [ ] Every UI Spec component has a covering task, OR an explicit `gap` justification
   - [ ] Component reference uses the UI Spec section heading exactly as it appears in the document
-- [ ] Connection Map table complete (when implementation crosses packages/services)
+- [ ] Connection Map table complete (when crossing packages/services, or passing a serialized value across any boundary)
   - [ ] Every boundary lists owner modules and expected signal
+  - [ ] Serialized boundaries record Serialized Format and Consumer Parse Rule
   - [ ] Every boundary maps to at least one covering task on each side
 - [ ] ADR Bindings table complete (when ADR provided or referenced from Design Doc)
   - [ ] Each row represents one implementation-binding decision (placement, dependency, contract, data flow, or persistence)

--- a/dev-workflows/skills/documentation-criteria/references/design-template.md
+++ b/dev-workflows/skills/documentation-criteria/references/design-template.md
@@ -107,10 +107,7 @@ Keywords determine test type and reduce ambiguity.
 - [ ] **When** user clicks login button with valid credentials, the system shall authenticate and redirect to dashboard
 - [ ] **If** credentials are invalid, **then** the system shall display error message "Invalid credentials"
 - [ ] **While** user is logged in, the system shall maintain the session for configured timeout period
-
-### [Functional Requirement 2]
-
-- [ ] The system shall display data list with pagination of 10 items per page
+- [ ] (ubiquitous, no keyword) The system shall display the data list with pagination of 10 items per page
 
 ## Existing Codebase Analysis
 
@@ -174,14 +171,11 @@ No Ripple Effect:
 
 | Integration Point | Location | Old Implementation | New Implementation | Switching Method | Verification Method |
 |-------------------|----------|-------------------|-------------------|------------------|-------------------|
-| Integration Point 1 | [Class/Function] | [Existing Process] | [New Process] | [DI/Factory etc.] | [How to verify this switching works] |
-| Integration Point 2 | [Another Location] | [Existing] | [New] | [Method] | [Verification approach] |
+| [Integration Point] | [Class/Function] | [Existing Process or N/A] | [New Process] | [DI/Factory/config/etc.] | [How to verify this switching works] |
 
 ### Main Components
 
-Repeat the block below for each component.
-
-#### Component 1
+#### [Component] (repeat per component)
 
 - **Responsibility**: [Scope of responsibility for this component]
 - **Interface**: [APIs and contract definitions provided]
@@ -206,7 +200,6 @@ One entry per new in-scope element. This section records the 5-step output produ
 
 **Step 1 — Fixed Requirements**
 - [AC ID or constraint ID]: [requirement / constraint text]
-- [AC ID or constraint ID]: [requirement / constraint text]
 
 **Steps 2–3 — Alternatives Compared**
 
@@ -214,7 +207,6 @@ One entry per new in-scope element. This section records the 5-step output produ
 |---|---|---|---|---|---|---|
 | [The added element as proposed] | | | | | | |
 | [Subtractive alternative — derive / compute on demand / keep at caller / reuse existing / do not introduce new state] | | | | | | |
-| [Optional third alternative] | | | | | | |
 
 **Step 4 — Selected Alternative and Rationale**
 - **Selected**: [alternative name]
@@ -224,23 +216,17 @@ One entry per new in-scope element. This section records the 5-step output produ
 
 **Step 5 — Rejected Alternatives Log**
 - [Alternative name]: [1-2 lines on what it was and why rejected]
-- [Alternative name]: [1-2 lines on what it was and why rejected]
 
 (Repeat the Element block above for each additional in-scope element.)
 
 Mark the whole section as N/A with brief rationale when the design introduces no in-scope elements.
 
-### Contract Definitions
+### Data Contracts
 
-```
-// Record major contract/interface definitions here
-```
-
-### Data Contract
-
-#### Component 1
+#### [Component or Boundary] (repeat per component/boundary)
 
 ```yaml
+Contract: [interface / function / API / schema name]
 Input:
   Type: [Data shape, contract, or schema]
   Preconditions: [Required items, format constraints]
@@ -257,9 +243,11 @@ Invariants:
 
 ### Field Propagation Map (When Fields Cross Boundaries)
 
-| Field | Boundary | Status | Detail |
-|-------|----------|--------|--------|
-| [field name] | [Component A → B] | preserved / transformed / dropped | [logic or reason] |
+A boundary here includes a **serialized boundary** — a value encoded on one side and parsed on the other through a medium such as a query string, CLI argument, environment variable, config entry, message/queue payload, storage key, or file — not only cross-process calls. For those, record the exact encoded representation and how the consumer parses it, so producer and consumer agree.
+
+| Field | Boundary | Status | Serialized Format | Consumer Parse Rule | Detail |
+|-------|----------|--------|-------------------|---------------------|--------|
+| [field name] | [Component A → B] | preserved / transformed / dropped | [exact representation the producer emits when the boundary is serialized; "—" otherwise] | [how the consumer decodes and validates that representation; "—" when not serialized] | [logic or reason] |
 
 ### State Transitions and Invariants (When Applicable)
 
@@ -317,9 +305,7 @@ System Invariants:
 
 ### Technical Dependencies and Implementation Order
 
-#### Required Implementation Order
-
-Repeat the entry below for each component/feature, in dependency order.
+#### Required Implementation Order (in dependency order, one entry per component/feature)
 
 1. **[Component/Feature]**
    - Technical Reason: [Why this needs to be implemented at this position]
@@ -365,15 +351,11 @@ Verification Strategy defines what correctness means and how to prove it at desi
 
 ### Correctness Proof Method
 
-How will this change's correctness be demonstrated?
-
 - **Correctness definition**: [What "correct" means for this change — e.g., "output matches existing behavior", "all ACs pass in production-equivalent environment", "generated queries execute without error on target DB"]
 - **Verification method**: [Specific technique — e.g., "compare new implementation output against existing implementation", "run against staging DB", "contract test with real API"]
 - **Verification timing**: [When verification occurs — e.g., "after first vertical slice", "per repository", "at integration phase"]
 
 ### Early Verification Point
-
-What is verified first, and how, to confirm the approach is correct before scaling?
 
 - **First verification target**: [The smallest unit that proves the approach works — e.g., "first repository migration", "single API endpoint", "one screen flow"]
 - **Success criteria**: [Observable outcome — e.g., "CSV download produces identical output to legacy", "API returns 200 with expected schema"]
@@ -400,12 +382,9 @@ This section records what was **excluded** from the current design surface. Spec
 
 ## Alternative Solutions
 
-### Alternative 1
-
-- **Overview**: [Description of alternative solution]
-- **Advantages**: [Advantages]
-- **Disadvantages**: [Disadvantages]
-- **Reason for Rejection**: [Why it wasn't adopted]
+| Alternative | Overview | Advantages | Disadvantages | Reason for Rejection |
+|---|---|---|---|---|
+| [Alternative 1] | | | | |
 
 ## Risks and Mitigation
 

--- a/dev-workflows/skills/documentation-criteria/references/plan-template.md
+++ b/dev-workflows/skills/documentation-criteria/references/plan-template.md
@@ -51,6 +51,16 @@ Maps each Design Doc technical requirement to the covering task(s). One row per 
 
 **Gap Status values**: `covered` (task exists), `gap` (no task — requires justification in Notes, user confirmation required before plan approval)
 
+## Reference Contract Values
+
+Include this section when a Traceability row's DD Item encodes a **binding observable value** the implementation must reproduce exactly: a column/label set and order, a derived-display rule (display value derived from another field), or a state-lifecycle negative (the condition under which the state must stay unused). **Serialized boundaries** (a value encoded and re-parsed across a boundary) are owned by the Connection Map / Field Propagation Map — record those there. These are DD-derived observable contracts; ADR-derived structural decisions belong in ADR Bindings. Omit the section when none apply.
+
+The Traceability table records *that* a row is covered; this table carries the row's value *verbatim* so the covering task can be checked against the exact contract rather than a re-derived summary.
+
+| Design Doc (§ Section) | Contract Type | Required Observable Value (verbatim) | Covered By Task(s) |
+|---|---|---|---|
+| [docs/design/XXX.md (§ Section)] | structure-order / derived-display / state-lifecycle-negative | [the exact value copied from the Design Doc — e.g., "the listed fields in the specified order"; "the label shows the looked-up name in place of the raw code"; "the persisted state is applied only when an explicit restore signal is present"] | [Phase X Task Y] |
+
 ## Failure Mode Checklist
 
 Domain-independent failure categories this implementation must guard against. Enumerate all eight categories, mark which apply, and list a covering task for each that applies; keep entries free of project-specific names.
@@ -92,11 +102,13 @@ One row per binding decision. A single ADR can contribute multiple rows. A singl
 
 ## Connection Map
 
-Include this section when the implementation crosses more than one package, service, or process boundary. Document each boundary. Omit the section when the implementation stays within a single package.
+Include this section when the implementation crosses a package, service, or process boundary, **or when a value is serialized and re-parsed across a boundary even within a single runtime** — through a medium such as a query string, CLI argument, environment variable, config entry, message/queue payload, storage key, or file (the producer and consumer must agree on the exact representation). Omit the section when no such boundary exists.
 
-| Boundary | Owner (left side) | Owner (right side) | Expected Signal | Covered By Task(s) |
-|---|---|---|---|---|
-| [e.g., "web client → API gateway"] | [module/package on the request side] | [module/package on the response side] | [Observable evidence the boundary works — e.g., "HTTP 200 with response matching ContractA", "row inserted in tableB", "message published to topicC"] | [Phase X Task Y on each side] |
+For a serialized boundary, fill Serialized Format and Consumer Parse Rule. Set them to "—" when the contract is already captured by the Expected Signal (e.g., a cross-process call whose body matches the agreed schema); fill them when producer and consumer must agree on a specific encoding of a value (query string, storage key, CLI argument, config entry, message field).
+
+| Boundary | Owner (left side) | Owner (right side) | Serialized Format | Consumer Parse Rule | Expected Signal | Covered By Task(s) |
+|---|---|---|---|---|---|---|
+| [producing side → consuming side] | [module/component on the producing side] | [module/component on the consuming side] | [exact representation the producer emits; "—" if not serialized] | [how the consumer decodes/validates it; "—" if not serialized] | [Observable evidence the boundary works — e.g., a response matching the agreed contract, or the consumer reproducing the producer's values] | [Phase X Task Y on each side] |
 
 ## Objective
 [Why this change is necessary, what problem it solves]

--- a/dev-workflows/skills/documentation-criteria/references/task-template.md
+++ b/dev-workflows/skills/documentation-criteria/references/task-template.md
@@ -33,6 +33,15 @@ Each row is an ADR decision the implementation in this task must comply with.
 |---|---|---|---|
 | [docs/adr/ADR-XXXX.md (§ <Source Section>) — substitute the section name (`Decision` or `Implementation Guidance`) from the matching work plan row] | [Axis value copied verbatim from the work plan's ADR Bindings row] | [Binding decision copied from the work plan's ADR Bindings row] | [Y/N-answerable positive predicate that evaluates whether the planned/final implementation satisfies the decision] |
 
+## Reference Contracts
+(Include this section when the work plan's Reference Contract Values table covers this task. Omit otherwise.)
+
+Each row is a DD-derived observable contract the implementation in this task must reproduce exactly. Serialized boundaries are carried by the Boundary Context (from the work plan's Connection Map), and ADR-derived structural decisions by Binding Decisions above.
+
+| Source | Contract Type | Required Observable Value | Compliance Check |
+|---|---|---|---|
+| [Design Doc path (§ Section) copied from the matching work plan Reference Contract Values row] | [Contract Type copied from the work plan row: structure-order / derived-display / state-lifecycle-negative] | [Required Observable Value copied verbatim from the work plan row] | [Y/N-answerable positive predicate that evaluates whether the planned/final implementation reproduces the value] |
+
 ## Investigation Notes
 (Implementation observations are appended here before implementation begins. When Binding Decisions exist, record the planned implementation approach and each Compliance Check result here.)
 
@@ -79,6 +88,7 @@ Each row is an ADR decision the implementation in this task must comply with.
 - [ ] Each Proof Obligation is met: the test turns red under its primary failure mode and exercises the stated boundary
 - [ ] Deliverables created (for research/design tasks)
 - [ ] (When Binding Decisions exist) Every Compliance Check evaluates to `Y` against the final implementation, with evidence recorded in Investigation Notes (file:line, test result, or command output)
+- [ ] (When Reference Contracts exist) Every Reference Contract Compliance Check evaluates to `Y` against the final implementation, with evidence recorded in Investigation Notes
 
 ## Notes
 - Impact scope: [Areas where changes may propagate]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-workflows",
-  "version": "0.20.5",
+  "version": "0.21.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/skills/documentation-criteria/references/design-template.md
+++ b/skills/documentation-criteria/references/design-template.md
@@ -107,10 +107,7 @@ Keywords determine test type and reduce ambiguity.
 - [ ] **When** user clicks login button with valid credentials, the system shall authenticate and redirect to dashboard
 - [ ] **If** credentials are invalid, **then** the system shall display error message "Invalid credentials"
 - [ ] **While** user is logged in, the system shall maintain the session for configured timeout period
-
-### [Functional Requirement 2]
-
-- [ ] The system shall display data list with pagination of 10 items per page
+- [ ] (ubiquitous, no keyword) The system shall display the data list with pagination of 10 items per page
 
 ## Existing Codebase Analysis
 
@@ -174,14 +171,11 @@ No Ripple Effect:
 
 | Integration Point | Location | Old Implementation | New Implementation | Switching Method | Verification Method |
 |-------------------|----------|-------------------|-------------------|------------------|-------------------|
-| Integration Point 1 | [Class/Function] | [Existing Process] | [New Process] | [DI/Factory etc.] | [How to verify this switching works] |
-| Integration Point 2 | [Another Location] | [Existing] | [New] | [Method] | [Verification approach] |
+| [Integration Point] | [Class/Function] | [Existing Process or N/A] | [New Process] | [DI/Factory/config/etc.] | [How to verify this switching works] |
 
 ### Main Components
 
-Repeat the block below for each component.
-
-#### Component 1
+#### [Component] (repeat per component)
 
 - **Responsibility**: [Scope of responsibility for this component]
 - **Interface**: [APIs and contract definitions provided]
@@ -206,7 +200,6 @@ One entry per new in-scope element. This section records the 5-step output produ
 
 **Step 1 — Fixed Requirements**
 - [AC ID or constraint ID]: [requirement / constraint text]
-- [AC ID or constraint ID]: [requirement / constraint text]
 
 **Steps 2–3 — Alternatives Compared**
 
@@ -214,7 +207,6 @@ One entry per new in-scope element. This section records the 5-step output produ
 |---|---|---|---|---|---|---|
 | [The added element as proposed] | | | | | | |
 | [Subtractive alternative — derive / compute on demand / keep at caller / reuse existing / do not introduce new state] | | | | | | |
-| [Optional third alternative] | | | | | | |
 
 **Step 4 — Selected Alternative and Rationale**
 - **Selected**: [alternative name]
@@ -224,23 +216,17 @@ One entry per new in-scope element. This section records the 5-step output produ
 
 **Step 5 — Rejected Alternatives Log**
 - [Alternative name]: [1-2 lines on what it was and why rejected]
-- [Alternative name]: [1-2 lines on what it was and why rejected]
 
 (Repeat the Element block above for each additional in-scope element.)
 
 Mark the whole section as N/A with brief rationale when the design introduces no in-scope elements.
 
-### Contract Definitions
+### Data Contracts
 
-```
-// Record major contract/interface definitions here
-```
-
-### Data Contract
-
-#### Component 1
+#### [Component or Boundary] (repeat per component/boundary)
 
 ```yaml
+Contract: [interface / function / API / schema name]
 Input:
   Type: [Data shape, contract, or schema]
   Preconditions: [Required items, format constraints]
@@ -257,9 +243,11 @@ Invariants:
 
 ### Field Propagation Map (When Fields Cross Boundaries)
 
-| Field | Boundary | Status | Detail |
-|-------|----------|--------|--------|
-| [field name] | [Component A → B] | preserved / transformed / dropped | [logic or reason] |
+A boundary here includes a **serialized boundary** — a value encoded on one side and parsed on the other through a medium such as a query string, CLI argument, environment variable, config entry, message/queue payload, storage key, or file — not only cross-process calls. For those, record the exact encoded representation and how the consumer parses it, so producer and consumer agree.
+
+| Field | Boundary | Status | Serialized Format | Consumer Parse Rule | Detail |
+|-------|----------|--------|-------------------|---------------------|--------|
+| [field name] | [Component A → B] | preserved / transformed / dropped | [exact representation the producer emits when the boundary is serialized; "—" otherwise] | [how the consumer decodes and validates that representation; "—" when not serialized] | [logic or reason] |
 
 ### State Transitions and Invariants (When Applicable)
 
@@ -317,9 +305,7 @@ System Invariants:
 
 ### Technical Dependencies and Implementation Order
 
-#### Required Implementation Order
-
-Repeat the entry below for each component/feature, in dependency order.
+#### Required Implementation Order (in dependency order, one entry per component/feature)
 
 1. **[Component/Feature]**
    - Technical Reason: [Why this needs to be implemented at this position]
@@ -365,15 +351,11 @@ Verification Strategy defines what correctness means and how to prove it at desi
 
 ### Correctness Proof Method
 
-How will this change's correctness be demonstrated?
-
 - **Correctness definition**: [What "correct" means for this change — e.g., "output matches existing behavior", "all ACs pass in production-equivalent environment", "generated queries execute without error on target DB"]
 - **Verification method**: [Specific technique — e.g., "compare new implementation output against existing implementation", "run against staging DB", "contract test with real API"]
 - **Verification timing**: [When verification occurs — e.g., "after first vertical slice", "per repository", "at integration phase"]
 
 ### Early Verification Point
-
-What is verified first, and how, to confirm the approach is correct before scaling?
 
 - **First verification target**: [The smallest unit that proves the approach works — e.g., "first repository migration", "single API endpoint", "one screen flow"]
 - **Success criteria**: [Observable outcome — e.g., "CSV download produces identical output to legacy", "API returns 200 with expected schema"]
@@ -400,12 +382,9 @@ This section records what was **excluded** from the current design surface. Spec
 
 ## Alternative Solutions
 
-### Alternative 1
-
-- **Overview**: [Description of alternative solution]
-- **Advantages**: [Advantages]
-- **Disadvantages**: [Disadvantages]
-- **Reason for Rejection**: [Why it wasn't adopted]
+| Alternative | Overview | Advantages | Disadvantages | Reason for Rejection |
+|---|---|---|---|---|
+| [Alternative 1] | | | | |
 
 ## Risks and Mitigation
 

--- a/skills/documentation-criteria/references/plan-template.md
+++ b/skills/documentation-criteria/references/plan-template.md
@@ -51,6 +51,16 @@ Maps each Design Doc technical requirement to the covering task(s). One row per 
 
 **Gap Status values**: `covered` (task exists), `gap` (no task — requires justification in Notes, user confirmation required before plan approval)
 
+## Reference Contract Values
+
+Include this section when a Traceability row's DD Item encodes a **binding observable value** the implementation must reproduce exactly: a column/label set and order, a derived-display rule (display value derived from another field), or a state-lifecycle negative (the condition under which the state must stay unused). **Serialized boundaries** (a value encoded and re-parsed across a boundary) are owned by the Connection Map / Field Propagation Map — record those there. These are DD-derived observable contracts; ADR-derived structural decisions belong in ADR Bindings. Omit the section when none apply.
+
+The Traceability table records *that* a row is covered; this table carries the row's value *verbatim* so the covering task can be checked against the exact contract rather than a re-derived summary.
+
+| Design Doc (§ Section) | Contract Type | Required Observable Value (verbatim) | Covered By Task(s) |
+|---|---|---|---|
+| [docs/design/XXX.md (§ Section)] | structure-order / derived-display / state-lifecycle-negative | [the exact value copied from the Design Doc — e.g., "the listed fields in the specified order"; "the label shows the looked-up name in place of the raw code"; "the persisted state is applied only when an explicit restore signal is present"] | [Phase X Task Y] |
+
 ## Failure Mode Checklist
 
 Domain-independent failure categories this implementation must guard against. Enumerate all eight categories, mark which apply, and list a covering task for each that applies; keep entries free of project-specific names.
@@ -92,11 +102,13 @@ One row per binding decision. A single ADR can contribute multiple rows. A singl
 
 ## Connection Map
 
-Include this section when the implementation crosses more than one package, service, or process boundary. Document each boundary. Omit the section when the implementation stays within a single package.
+Include this section when the implementation crosses a package, service, or process boundary, **or when a value is serialized and re-parsed across a boundary even within a single runtime** — through a medium such as a query string, CLI argument, environment variable, config entry, message/queue payload, storage key, or file (the producer and consumer must agree on the exact representation). Omit the section when no such boundary exists.
 
-| Boundary | Owner (left side) | Owner (right side) | Expected Signal | Covered By Task(s) |
-|---|---|---|---|---|
-| [e.g., "web client → API gateway"] | [module/package on the request side] | [module/package on the response side] | [Observable evidence the boundary works — e.g., "HTTP 200 with response matching ContractA", "row inserted in tableB", "message published to topicC"] | [Phase X Task Y on each side] |
+For a serialized boundary, fill Serialized Format and Consumer Parse Rule. Set them to "—" when the contract is already captured by the Expected Signal (e.g., a cross-process call whose body matches the agreed schema); fill them when producer and consumer must agree on a specific encoding of a value (query string, storage key, CLI argument, config entry, message field).
+
+| Boundary | Owner (left side) | Owner (right side) | Serialized Format | Consumer Parse Rule | Expected Signal | Covered By Task(s) |
+|---|---|---|---|---|---|---|
+| [producing side → consuming side] | [module/component on the producing side] | [module/component on the consuming side] | [exact representation the producer emits; "—" if not serialized] | [how the consumer decodes/validates it; "—" if not serialized] | [Observable evidence the boundary works — e.g., a response matching the agreed contract, or the consumer reproducing the producer's values] | [Phase X Task Y on each side] |
 
 ## Objective
 [Why this change is necessary, what problem it solves]

--- a/skills/documentation-criteria/references/task-template.md
+++ b/skills/documentation-criteria/references/task-template.md
@@ -33,6 +33,15 @@ Each row is an ADR decision the implementation in this task must comply with.
 |---|---|---|---|
 | [docs/adr/ADR-XXXX.md (§ <Source Section>) — substitute the section name (`Decision` or `Implementation Guidance`) from the matching work plan row] | [Axis value copied verbatim from the work plan's ADR Bindings row] | [Binding decision copied from the work plan's ADR Bindings row] | [Y/N-answerable positive predicate that evaluates whether the planned/final implementation satisfies the decision] |
 
+## Reference Contracts
+(Include this section when the work plan's Reference Contract Values table covers this task. Omit otherwise.)
+
+Each row is a DD-derived observable contract the implementation in this task must reproduce exactly. Serialized boundaries are carried by the Boundary Context (from the work plan's Connection Map), and ADR-derived structural decisions by Binding Decisions above.
+
+| Source | Contract Type | Required Observable Value | Compliance Check |
+|---|---|---|---|
+| [Design Doc path (§ Section) copied from the matching work plan Reference Contract Values row] | [Contract Type copied from the work plan row: structure-order / derived-display / state-lifecycle-negative] | [Required Observable Value copied verbatim from the work plan row] | [Y/N-answerable positive predicate that evaluates whether the planned/final implementation reproduces the value] |
+
 ## Investigation Notes
 (Implementation observations are appended here before implementation begins. When Binding Decisions exist, record the planned implementation approach and each Compliance Check result here.)
 
@@ -79,6 +88,7 @@ Each row is an ADR decision the implementation in this task must comply with.
 - [ ] Each Proof Obligation is met: the test turns red under its primary failure mode and exercises the stated boundary
 - [ ] Deliverables created (for research/design tasks)
 - [ ] (When Binding Decisions exist) Every Compliance Check evaluates to `Y` against the final implementation, with evidence recorded in Investigation Notes (file:line, test result, or command output)
+- [ ] (When Reference Contracts exist) Every Reference Contract Compliance Check evaluates to `Y` against the final implementation, with evidence recorded in Investigation Notes
 
 ## Notes
 - Impact scope: [Areas where changes may propagate]

--- a/skills/frontend-ai-guide/SKILL.md
+++ b/skills/frontend-ai-guide/SKILL.md
@@ -178,7 +178,7 @@ Read `package.json` scripts and run them with the project's package manager (`pa
 ### Performance vs Readability
 - Prioritize readability unless React DevTools Profiler identifies a measurable bottleneck (e.g., render time exceeding 16ms, unnecessary re-renders)
 - Measure before optimizing with React DevTools Profiler
-- When React Compiler is enabled, routine memoization is automatic; manual memoization is a profiler- or identity-justified exception (measured bottleneck, or stable reference identity for third-party APIs / effect dependencies)
+- Memoization policy (React Compiler vs manual `React.memo`/`useMemo`/`useCallback`): follow the typescript-rules skill (Performance Optimization)
 - Document reason with comments when optimizing
 
 ### Granularity of Component/Type Definitions


### PR DESCRIPTION
## Summary

Promotes Design Doc **observable contracts** from "coverage tracking" (is there a task?) to an **enforced propagation lane** (does the task carry the exact contract value?). Previously these contracts were compressed to short labels at extraction and re-derived downstream, where details could be silently lost. They now travel verbatim across `plan → task → executor → review`, mirroring the existing ADR Bindings mechanism end-to-end.

## What changed

### Observable-contract fidelity (primary)
- **Reference Contracts** — binding observable values (column/label set and order, derived-display rules, state-lifecycle negatives) are copied verbatim from the Design Doc into the plan (`Reference Contract Values`) and the task (`Reference Contracts`), each with a Y/N compliance check. Enforced by an executor pre-check + exit-gate re-evaluation, a content-fidelity check in `document-reviewer`, and detection in `code-reviewer` (reported as `dd_violation`, independent of the AC loop).
- **Serialized boundaries** — the Connection Map / Field Propagation Map now also cover in-runtime serialized boundaries (query string, route param, form post, storage key, CLI argument, config entry, message payload, file), recording the producer's serialized format and the consumer's parse rule, with a roundtrip exit-gate check and boundary-contract detection in `code-reviewer`.

### Review-loop & consistency fixes
- `code-reviewer` classifies `adjacent_residual` from the diff itself when no `Change Category` field is present, and reads the executor's recorded out-of-scope residuals when the task file is in scope.
- De-duplicate React Compiler memoization guidance: canonical in `typescript-rules`, cross-referenced from `frontend-ai-guide`.

### Lossless size reduction (no behavioral change)
- Compress JSON examples in `document-reviewer` to the in-repo compact style.
- Remove redundant filler and merge short output sections in the design agents, and trim duplicate examples / merge adjacent contract sections in the Design Doc template — without dropping any contract section, field, or execution trigger.

### Packaging
- Bump local plugins to **0.21.0** and re-sync all distributions.

## Design notes
- Reuses `dd_violation` / `design_compliance_violation` instead of adding new reviewer enum values (avoids schema churn and duplication).
- Serialized boundaries are owned by the Connection Map / Field Propagation Map; Reference Contracts cover the non-serialized observable contracts. ADR-derived structural decisions remain on the ADR Bindings lane.
- All additions are language- and model-agnostic; the React/TypeScript-specific layer is left to its own plugin.

## Verification
- `pnpm check:skills-index` — all 11 skills consistent
- `pnpm sync:check` — no drift across distributions
- `claude plugin validate --strict` — marketplace + all 4 local plugins pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
