### PR TITLE
refine: remove cross-skill load-bearing reference in frontend-ai-guide

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "dev-workflows",
       "source": "./dev-workflows",
       "strict": true,
-      "version": "0.21.0",
+      "version": "0.21.1",
       "description": "Skills + Subagents for backend development - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
       "author": {
         "name": "Shinsuke Kagawa",
@@ -81,7 +81,7 @@
       "name": "dev-workflows-frontend",
       "source": "./dev-workflows-frontend",
       "strict": true,
-      "version": "0.21.0",
+      "version": "0.21.1",
       "description": "Skills + Subagents for React/TypeScript - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
       "author": {
         "name": "Shinsuke Kagawa",
@@ -152,7 +152,7 @@
       "name": "dev-workflows-fullstack",
       "source": "./dev-workflows-fullstack",
       "strict": true,
-      "version": "0.21.0",
+      "version": "0.21.1",
       "description": "Skills + Subagents for fullstack development (backend + React/TypeScript) - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
       "author": {
         "name": "Shinsuke Kagawa",
@@ -240,7 +240,7 @@
       "name": "dev-skills",
       "source": "./dev-skills",
       "strict": true,
-      "version": "0.21.0",
+      "version": "0.21.1",
       "description": "Lightweight skills for users with existing workflows - coding best practices, testing principles, and design guidelines without recipe workflows or agents",
       "author": {
         "name": "Shinsuke Kagawa",

--- a/dev-skills/.claude-plugin/plugin.json
+++ b/dev-skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-skills",
   "description": "Lightweight skills for users with existing workflows - coding best practices, testing principles, and design guidelines without recipe workflows or agents",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-skills/skills/frontend-ai-guide/SKILL.md
+++ b/dev-skills/skills/frontend-ai-guide/SKILL.md
@@ -178,7 +178,6 @@ Read `package.json` scripts and run them with the project's package manager (`pa
 ### Performance vs Readability
 - Prioritize readability unless React DevTools Profiler identifies a measurable bottleneck (e.g., render time exceeding 16ms, unnecessary re-renders)
 - Measure before optimizing with React DevTools Profiler
-- Memoization policy (React Compiler vs manual `React.memo`/`useMemo`/`useCallback`): follow the typescript-rules skill (Performance Optimization)
 - Document reason with comments when optimizing
 
 ### Granularity of Component/Type Definitions

--- a/dev-workflows-frontend/.claude-plugin/plugin.json
+++ b/dev-workflows-frontend/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflows-frontend",
   "description": "Skills + Subagents for React/TypeScript - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows-frontend/skills/frontend-ai-guide/SKILL.md
+++ b/dev-workflows-frontend/skills/frontend-ai-guide/SKILL.md
@@ -178,7 +178,6 @@ Read `package.json` scripts and run them with the project's package manager (`pa
 ### Performance vs Readability
 - Prioritize readability unless React DevTools Profiler identifies a measurable bottleneck (e.g., render time exceeding 16ms, unnecessary re-renders)
 - Measure before optimizing with React DevTools Profiler
-- Memoization policy (React Compiler vs manual `React.memo`/`useMemo`/`useCallback`): follow the typescript-rules skill (Performance Optimization)
 - Document reason with comments when optimizing
 
 ### Granularity of Component/Type Definitions

--- a/dev-workflows-frontend/skills/recipe-front-adjust/SKILL.md
+++ b/dev-workflows-frontend/skills/recipe-front-adjust/SKILL.md
@@ -72,6 +72,8 @@ Run the hearing protocol per the external-resource-context skill (frontend domai
 
 ### Step 3: Scale Judgment
 
+Execute Skill: documentation-criteria (loads the Creation Decision Matrix and ADR Creation Conditions used in this step and in the Escalation Boundary).
+
 1. Read `candidateWriteSet[]` from ui-analyzer output.
 2. Present the candidate list to the user via AskUserQuestion: "Confirmed write set for this adjustment? (a) accept high-confidence entries / (b) accept all entries / (c) edit list manually". On `c`, send a follow-up plain message asking the user to paste the edited file list, then proceed with that list.
 3. Apply the Creation Decision Matrix from the documentation-criteria skill to the **confirmed write set count**:

--- a/dev-workflows-fullstack/.claude-plugin/plugin.json
+++ b/dev-workflows-fullstack/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflows-fullstack",
   "description": "Skills + Subagents for fullstack development (backend + React/TypeScript) - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows-fullstack/skills/frontend-ai-guide/SKILL.md
+++ b/dev-workflows-fullstack/skills/frontend-ai-guide/SKILL.md
@@ -178,7 +178,6 @@ Read `package.json` scripts and run them with the project's package manager (`pa
 ### Performance vs Readability
 - Prioritize readability unless React DevTools Profiler identifies a measurable bottleneck (e.g., render time exceeding 16ms, unnecessary re-renders)
 - Measure before optimizing with React DevTools Profiler
-- Memoization policy (React Compiler vs manual `React.memo`/`useMemo`/`useCallback`): follow the typescript-rules skill (Performance Optimization)
 - Document reason with comments when optimizing
 
 ### Granularity of Component/Type Definitions

--- a/dev-workflows-fullstack/skills/recipe-front-adjust/SKILL.md
+++ b/dev-workflows-fullstack/skills/recipe-front-adjust/SKILL.md
@@ -72,6 +72,8 @@ Run the hearing protocol per the external-resource-context skill (frontend domai
 
 ### Step 3: Scale Judgment
 
+Execute Skill: documentation-criteria (loads the Creation Decision Matrix and ADR Creation Conditions used in this step and in the Escalation Boundary).
+
 1. Read `candidateWriteSet[]` from ui-analyzer output.
 2. Present the candidate list to the user via AskUserQuestion: "Confirmed write set for this adjustment? (a) accept high-confidence entries / (b) accept all entries / (c) edit list manually". On `c`, send a follow-up plain message asking the user to paste the edited file list, then proceed with that list.
 3. Apply the Creation Decision Matrix from the documentation-criteria skill to the **confirmed write set count**:

--- a/dev-workflows/.claude-plugin/plugin.json
+++ b/dev-workflows/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflows",
   "description": "Skills + Subagents for backend development - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-workflows",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "private": true,
   "type": "module",
   "engines": {

--- a/skills/frontend-ai-guide/SKILL.md
+++ b/skills/frontend-ai-guide/SKILL.md
@@ -178,7 +178,6 @@ Read `package.json` scripts and run them with the project's package manager (`pa
 ### Performance vs Readability
 - Prioritize readability unless React DevTools Profiler identifies a measurable bottleneck (e.g., render time exceeding 16ms, unnecessary re-renders)
 - Measure before optimizing with React DevTools Profiler
-- Memoization policy (React Compiler vs manual `React.memo`/`useMemo`/`useCallback`): follow the typescript-rules skill (Performance Optimization)
 - Document reason with comments when optimizing
 
 ### Granularity of Component/Type Definitions

--- a/skills/recipe-front-adjust/SKILL.md
+++ b/skills/recipe-front-adjust/SKILL.md
@@ -72,6 +72,8 @@ Run the hearing protocol per the external-resource-context skill (frontend domai
 
 ### Step 3: Scale Judgment
 
+Execute Skill: documentation-criteria (loads the Creation Decision Matrix and ADR Creation Conditions used in this step and in the Escalation Boundary).
+
 1. Read `candidateWriteSet[]` from ui-analyzer output.
 2. Present the candidate list to the user via AskUserQuestion: "Confirmed write set for this adjustment? (a) accept high-confidence entries / (b) accept all entries / (c) edit list manually". On `c`, send a follow-up plain message asking the user to paste the edited file list, then proceed with that list.
 3. Apply the Creation Decision Matrix from the documentation-criteria skill to the **confirmed write set count**:


### PR DESCRIPTION
## Summary

Skills load non-deterministically — a skill cannot rely on another skill being loaded. The recent `eb49ad1` deduplication turned frontend-ai-guide's memoization policy into a cross-skill pointer (`follow the typescript-rules skill`), which becomes a dangling instruction whenever typescript-rules is not loaded. This PR removes that dependency and fixes the one analogous gap in recipe-front-adjust.

A repo-wide scan confirmed these were the only load-bearing skill→skill references among content skills (orchestrator/selector skills like subagents-orchestration-guide and task-analyzer are exempt by design, as are recipes that explicitly `Execute Skill`).

## Changes

- **frontend-ai-guide**: drop the memoization-policy bullet from "Performance vs Readability". Memoization mechanism (React Compiler vs manual `React.memo`/`useMemo`/`useCallback`) is an implementation rule owned by typescript-rules (Performance Optimization), off the decision-criteria altitude of this section. The remaining bullets — measure first, prioritize readability, document the reason — keep the section self-sufficient with no duplication and no cross-reference.
- **recipe-front-adjust**: it applied documentation-criteria's Creation Decision Matrix and ADR Creation Conditions without loading the skill, unlike recipe-review / recipe-add-integration-tests which `Execute Skill: documentation-criteria` first. Add an explicit `Execute Skill: documentation-criteria` at the start of Step 3 so the referenced content is deterministically loaded before use.
- Bump local plugins `0.21.0` → `0.21.1` and re-sync all distributions.

## Verification

- `pnpm sync:check` — all in-repo plugin subdirectories in sync
- `claude plugin validate --strict` — all 4 plugins + marketplace manifest pass
- `check-skills-index` — all 11 skills consistent
- No remaining `follow the typescript-rules skill` references

🤖 Generated with [Claude Code](https://claude.com/claude-code)