### PR TITLE
Add pr-review external plugin to the marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -301,6 +301,17 @@
       "description": "Turns requirements into structured Linear tasks — validates before decomposing, so downstream design starts clean",
       "category": "workflow-orchestration",
       "homepage": "https://github.com/shinpr/linear-prism"
+    },
+    {
+      "name": "pr-review",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/shinpr/pr-review-skill.git",
+        "path": "plugins/pr-review"
+      },
+      "description": "Reviews GitHub PRs with Claude Code or Codex reviewers on deterministic PR snapshots, repo-specific quality criteria, and severity-gated posting with approval",
+      "category": "quality-enforcement",
+      "homepage": "https://github.com/shinpr/pr-review-skill"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -63,11 +63,13 @@ These optional plugins cover adjacent stages in the workflow:
 - [claude-code-discover](https://github.com/shinpr/claude-code-discover): turns feature ideas into evidence-backed PRDs.
 - [metronome](https://github.com/shinpr/metronome): detects shortcut-taking behavior and nudges Claude to proceed step by step.
 - [linear-prism](https://github.com/shinpr/linear-prism): turns requirements into structured Linear tasks. Validates before decomposing, so downstream design starts clean.
+- [pr-review](https://github.com/shinpr/pr-review-skill): reviews GitHub PRs with Claude Code or Codex reviewers on deterministic PR snapshots, repo-specific quality criteria, and severity-gated posting with approval.
 
 ```bash
 /plugin install discover@claude-code-workflows
 /plugin install metronome@claude-code-workflows
 /plugin install linear-prism@claude-code-workflows
+/plugin install pr-review@claude-code-workflows
 ```
 
 ### Skills only


### PR DESCRIPTION
## External Plugin Submission

### Plugin

- **Name**: pr-review
- **Repository**: https://github.com/shinpr/pr-review-skill

### What does this plugin do?

Reviews GitHub pull requests with Claude Code or Codex reviewers running on a deterministic PR snapshot (metadata, changed files, diff, prior comments, repository context). It produces structured, schema-validated findings, applies a repository-specific quality profile, and posts findings as GitHub comments only after showing a posting summary and asking for approval. Posting severities are configurable.

### Why does it fit this marketplace's focus?

It sits in the verification / quality-enforcement part of the lifecycle. Reviews run against a repeatable snapshot, findings are validated against a JSON schema, posting is gated by configurable severities and an explicit approval step, and duplicate prevention runs at posting time. It complements rather than duplicates the existing plugins: the in-repo workflows review local implementation against design docs, whereas this reviews arbitrary GitHub PRs and returns/posts structured findings — a stage not otherwise covered here.

### How have you tested it?

- The plugin repository ships a `pytest` suite covering config, context collection, review running, posting/guard, and metadata, and runs it in CI (GitHub Actions).
- For this submission I verified marketplace integration end to end: `claude plugin validate` passes on the plugin manifest, the plugin repo's marketplace manifest, and this marketplace's manifest. Loading this repo as a local marketplace and running `claude plugin install pr-review@claude-code-workflows` resolves the `git-subdir` source, sparse-fetches `plugins/pr-review/`, and loads the `recipe-pr-review` skill (SKILL.md + scripts present in the plugin cache).

### Source resolution note

The plugin repo is itself structured as a marketplace (required for Codex plugin compatibility), with the plugin under `plugins/pr-review/`. It is therefore referenced via a `git-subdir` source with `path: plugins/pr-review`, rather than the plain `url` form used by the other external plugins.

`pr-review` is the same plugin name whether installed from this marketplace or the standalone `pr-review-tools` marketplace; install it from only one to avoid a name collision.

### Checklist

- [x] `/plugin validate` passes on your plugin repository
- [x] Plugin is installable and testable (verified via `claude plugin install` resolving the `git-subdir` source)
- [x] Public repository with README
- [x] Added entry to `.claude-plugin/marketplace.json`
- [x] Added entry to **External Plugins** section in `README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)