### PR TITLE
fix: resolve lines.indexOf bug and safe string replacement pattern bugs in scripts

### DIFF
--- a/scripts/check-skills-index.mjs
+++ b/scripts/check-skills-index.mjs
@@ -14,11 +14,12 @@ function parseSkillsIndex(content) {
   let currentSkill = null
   let inSections = false
 
-  for (const line of lines) {
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
     const skillMatch = /^ {2}([\w-]+):\s*$/.exec(line)
     if (skillMatch) {
       currentSkill = skillMatch[1]
-      skills[currentSkill] = { sections: [], lineNumber: lines.indexOf(line) + 1 }
+      skills[currentSkill] = { sections: [], lineNumber: i + 1 }
       inSections = false
       continue
     }

--- a/scripts/sync-plugins.mjs
+++ b/scripts/sync-plugins.mjs
@@ -203,8 +203,10 @@ function injectDeprecationNotice(content, notice, label) {
   if (currentDesc.startsWith(notice)) {
     return content
   }
-  const newFm = fm.replace(/^description:[ \t]*(.*)$/m, `description: ${notice}${currentDesc}`)
-  return content.replace(fmMatch[0], `---\n${newFm}\n---`)
+  const newFm = fm.replace(/^description:[ \t]*(.*)$/m, (_, matchedDesc) => {
+    return `description: ${notice}${matchedDesc}`
+  })
+  return content.replace(fmMatch[0], () => `---\n${newFm}\n---`)
 }
 
 async function loadLocalPlugins() {


### PR DESCRIPTION
This change fixes two critical bugs in the project's helper scripts:

1. In `scripts/check-skills-index.mjs`, the method `parseSkillsIndex` previously utilized `lines.indexOf(line)` to obtain the line number of the skill entry in the `skills-index.yaml` file. If there were identical lines in the file (such as identical formatting, sections, or comments), `indexOf` would yield the index of the first occurrence instead of the active loop index. This is resolved by iterating over lines using a standard index-based loop and computing the line number directly from the loop variable index.

2. In `scripts/sync-plugins.mjs`, the method `injectDeprecationNotice` used string replacement with dynamic arguments (`notice`, `currentDesc`, and `newFm`). Because JS `String.prototype.replace` treats `$` as a special replacement pattern prefix (e.g., matching `$&` to duplicate the match), any occurrence of `$` in the description or deprecation notice would be improperly parsed and expand to arbitrary matched substrings. This is corrected by supplying replacement callback functions to the `replace` calls, preventing pattern expansion bugs.