### PR TITLE
refine: harden task-executor dependency handling and escalation details

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "dev-workflows",
       "source": "./dev-workflows",
       "strict": true,
-      "version": "0.22.0",
+      "version": "0.22.1",
       "description": "Skills + Subagents for backend development - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
       "author": {
         "name": "Shinsuke Kagawa",
@@ -82,7 +82,7 @@
       "name": "dev-workflows-frontend",
       "source": "./dev-workflows-frontend",
       "strict": true,
-      "version": "0.22.0",
+      "version": "0.22.1",
       "description": "Skills + Subagents for React/TypeScript - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
       "author": {
         "name": "Shinsuke Kagawa",
@@ -154,7 +154,7 @@
       "name": "dev-workflows-fullstack",
       "source": "./dev-workflows-fullstack",
       "strict": true,
-      "version": "0.22.0",
+      "version": "0.22.1",
       "description": "Skills + Subagents for fullstack development (backend + React/TypeScript) - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
       "author": {
         "name": "Shinsuke Kagawa",
@@ -243,7 +243,7 @@
       "name": "dev-skills",
       "source": "./dev-skills",
       "strict": true,
-      "version": "0.22.0",
+      "version": "0.22.1",
       "description": "Lightweight skills for users with existing workflows - coding best practices, testing principles, and design guidelines without recipe workflows or agents",
       "author": {
         "name": "Shinsuke Kagawa",

--- a/agents/task-executor-frontend.md
+++ b/agents/task-executor-frontend.md
@@ -139,6 +139,15 @@ This gate triggers only when the Investigation Targets section lists at least on
 #### Pre-implementation Verification (Duplication Check — Pattern 5 from frontend-ai-guide)
 Read relevant Design Doc sections accurately; investigate existing implementations (similar components/hooks in same domain/responsibility); determine continue/escalation per "Mandatory Judgment Criteria" above.
 
+#### Unimplemented Dependency Handling
+
+Applies when Pre-implementation Verification finds a dependency this task requires is absent or unimplemented (e.g., a Design Doc component marked "requires new creation"). A missing dependency is a stop condition only when it prevents preserving the required contract and no local, reversible construct can satisfy it.
+
+1. Determine whether a local, reversible construct — a local slice, or a contract-preserving stub/adapter scoped to the Target Files — preserves the required contract.
+2. Branch on the result:
+   - One local, reversible approach preserves the contract → proceed with it and record the integration handoff (what the real dependency must later provide, and where it connects) in Investigation Notes.
+   - No local construct preserves the contract, or several valid constructs differ on an architectural trade-off (placement, dependency direction, contract shape) → stop and escalate with `escalation_type: "design_compliance_violation"` (see Design Doc Deviation Escalation in Structured Response Specification; populate every `details` field that schema requires). Map the Design Doc requirement for the dependency to `details.design_doc_expectation`, and the absent/unimplemented dependency with the exact undecided decision to `details.actual_situation`.
+
 #### Adjacent Case Sweep (Required when the task file has a `Change Category` field set to one or more of `bug-fix`, `regression`, `state-change`, `boundary-change`)
 
 Runs after Pre-implementation Verification, before the Binding Decision Check. This step fires on the field value the task decomposition wrote — read the field value and treat it as authoritative for whether the sweep applies.
@@ -168,7 +177,7 @@ Runs after Pre-implementation Verification, alongside the Binding Decision Check
 3. Evaluate each row's Compliance Check against the planned approach. Record the result for each row as `Y`, `N`, or `Unknown` in Investigation Notes, with a one-line rationale. Use `Unknown` only when the planned approach has no decision yet on the predicate's subject
 4. Per row, branch on the evaluation:
    - `Y`: proceed
-   - `N`: stop implementation and produce the final response with `status: "escalation_needed"` and `escalation_type: "design_compliance_violation"` (Escalation Response 2-1), populating `details.design_doc_expectation` with the Reference Contract row's Required Observable Value and `details.actual_situation` with the planned approach
+   - `N`: stop implementation and produce the final response with `status: "escalation_needed"` and `escalation_type: "design_compliance_violation"` (see Design Doc Deviation Escalation in Structured Response Specification; populate every `details` field that schema requires). Map the Reference Contract row's Required Observable Value to `details.design_doc_expectation` and the planned approach to `details.actual_situation`
    - `Unknown`: mark the row as deferred in Investigation Notes and proceed to the TDD cycle. The Exit Gate re-evaluates every deferred row against the final implementation
 
 #### Reference Representativeness (Applied During Implementation)

--- a/agents/task-executor.md
+++ b/agents/task-executor.md
@@ -134,6 +134,15 @@ This gate triggers only when the Investigation Targets section lists at least on
 #### Pre-implementation Verification (Pattern 5 Compliant)
 Read relevant Design Doc sections (interface contracts, data structures, dependency constraints); investigate existing implementations in the same domain/responsibility; determine continue/escalation per "Mandatory Judgment Criteria" above.
 
+#### Unimplemented Dependency Handling
+
+Applies when Pre-implementation Verification finds a dependency this task requires is absent or unimplemented (e.g., a Design Doc component marked "requires new creation"). A missing dependency is a stop condition only when it prevents preserving the required contract and no local, reversible construct can satisfy it.
+
+1. Determine whether a local, reversible construct — a local slice, or a contract-preserving stub/adapter scoped to the Target Files — preserves the required contract.
+2. Branch on the result:
+   - One local, reversible approach preserves the contract → proceed with it and record the integration handoff (what the real dependency must later provide, and where it connects) in Investigation Notes.
+   - No local construct preserves the contract, or several valid constructs differ on an architectural trade-off (placement, dependency direction, contract shape) → stop and escalate with `escalation_type: "design_compliance_violation"` (see Design Doc Deviation Escalation in Structured Response Specification; populate every `details` field that schema requires). Map the Design Doc requirement for the dependency to `details.design_doc_expectation`, and the absent/unimplemented dependency with the exact undecided decision to `details.actual_situation`.
+
 #### Adjacent Case Sweep (Required when the task file has a `Change Category` field set to one or more of `bug-fix`, `regression`, `state-change`, `boundary-change`)
 
 Runs after Pre-implementation Verification, before the Binding Decision Check. This step fires on the field value the task decomposition wrote — read the field value and treat it as authoritative for whether the sweep applies.
@@ -163,7 +172,7 @@ Runs after Pre-implementation Verification, alongside the Binding Decision Check
 3. Evaluate each row's Compliance Check against the planned approach. Record the result for each row as `Y`, `N`, or `Unknown` in Investigation Notes, with a one-line rationale. Use `Unknown` only when the planned approach has no decision yet on the predicate's subject
 4. Per row, branch on the evaluation:
    - `Y`: proceed
-   - `N`: stop implementation and produce the final response with `status: "escalation_needed"` and `escalation_type: "design_compliance_violation"` (Escalation Response 2-1), populating `details.design_doc_expectation` with the Reference Contract row's Required Observable Value and `details.actual_situation` with the planned approach
+   - `N`: stop implementation and produce the final response with `status: "escalation_needed"` and `escalation_type: "design_compliance_violation"` (see Design Doc Deviation Escalation in Structured Response Specification; populate every `details` field that schema requires). Map the Reference Contract row's Required Observable Value to `details.design_doc_expectation` and the planned approach to `details.actual_situation`
    - `Unknown`: mark the row as deferred in Investigation Notes and proceed to the TDD cycle. The Exit Gate re-evaluates every deferred row against the final implementation
 
 #### Reference Representativeness (Applied During Implementation)

--- a/dev-skills/.claude-plugin/plugin.json
+++ b/dev-skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-skills",
   "description": "Lightweight skills for users with existing workflows - coding best practices, testing principles, and design guidelines without recipe workflows or agents",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows-frontend/.claude-plugin/plugin.json
+++ b/dev-workflows-frontend/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflows-frontend",
   "description": "Skills + Subagents for React/TypeScript - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows-frontend/agents/task-executor-frontend.md
+++ b/dev-workflows-frontend/agents/task-executor-frontend.md
@@ -139,6 +139,15 @@ This gate triggers only when the Investigation Targets section lists at least on
 #### Pre-implementation Verification (Duplication Check — Pattern 5 from frontend-ai-guide)
 Read relevant Design Doc sections accurately; investigate existing implementations (similar components/hooks in same domain/responsibility); determine continue/escalation per "Mandatory Judgment Criteria" above.
 
+#### Unimplemented Dependency Handling
+
+Applies when Pre-implementation Verification finds a dependency this task requires is absent or unimplemented (e.g., a Design Doc component marked "requires new creation"). A missing dependency is a stop condition only when it prevents preserving the required contract and no local, reversible construct can satisfy it.
+
+1. Determine whether a local, reversible construct — a local slice, or a contract-preserving stub/adapter scoped to the Target Files — preserves the required contract.
+2. Branch on the result:
+   - One local, reversible approach preserves the contract → proceed with it and record the integration handoff (what the real dependency must later provide, and where it connects) in Investigation Notes.
+   - No local construct preserves the contract, or several valid constructs differ on an architectural trade-off (placement, dependency direction, contract shape) → stop and escalate with `escalation_type: "design_compliance_violation"` (see Design Doc Deviation Escalation in Structured Response Specification; populate every `details` field that schema requires). Map the Design Doc requirement for the dependency to `details.design_doc_expectation`, and the absent/unimplemented dependency with the exact undecided decision to `details.actual_situation`.
+
 #### Adjacent Case Sweep (Required when the task file has a `Change Category` field set to one or more of `bug-fix`, `regression`, `state-change`, `boundary-change`)
 
 Runs after Pre-implementation Verification, before the Binding Decision Check. This step fires on the field value the task decomposition wrote — read the field value and treat it as authoritative for whether the sweep applies.
@@ -168,7 +177,7 @@ Runs after Pre-implementation Verification, alongside the Binding Decision Check
 3. Evaluate each row's Compliance Check against the planned approach. Record the result for each row as `Y`, `N`, or `Unknown` in Investigation Notes, with a one-line rationale. Use `Unknown` only when the planned approach has no decision yet on the predicate's subject
 4. Per row, branch on the evaluation:
    - `Y`: proceed
-   - `N`: stop implementation and produce the final response with `status: "escalation_needed"` and `escalation_type: "design_compliance_violation"` (Escalation Response 2-1), populating `details.design_doc_expectation` with the Reference Contract row's Required Observable Value and `details.actual_situation` with the planned approach
+   - `N`: stop implementation and produce the final response with `status: "escalation_needed"` and `escalation_type: "design_compliance_violation"` (see Design Doc Deviation Escalation in Structured Response Specification; populate every `details` field that schema requires). Map the Reference Contract row's Required Observable Value to `details.design_doc_expectation` and the planned approach to `details.actual_situation`
    - `Unknown`: mark the row as deferred in Investigation Notes and proceed to the TDD cycle. The Exit Gate re-evaluates every deferred row against the final implementation
 
 #### Reference Representativeness (Applied During Implementation)

--- a/dev-workflows-fullstack/.claude-plugin/plugin.json
+++ b/dev-workflows-fullstack/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflows-fullstack",
   "description": "Skills + Subagents for fullstack development (backend + React/TypeScript) - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows-fullstack/agents/task-executor-frontend.md
+++ b/dev-workflows-fullstack/agents/task-executor-frontend.md
@@ -139,6 +139,15 @@ This gate triggers only when the Investigation Targets section lists at least on
 #### Pre-implementation Verification (Duplication Check — Pattern 5 from frontend-ai-guide)
 Read relevant Design Doc sections accurately; investigate existing implementations (similar components/hooks in same domain/responsibility); determine continue/escalation per "Mandatory Judgment Criteria" above.
 
+#### Unimplemented Dependency Handling
+
+Applies when Pre-implementation Verification finds a dependency this task requires is absent or unimplemented (e.g., a Design Doc component marked "requires new creation"). A missing dependency is a stop condition only when it prevents preserving the required contract and no local, reversible construct can satisfy it.
+
+1. Determine whether a local, reversible construct — a local slice, or a contract-preserving stub/adapter scoped to the Target Files — preserves the required contract.
+2. Branch on the result:
+   - One local, reversible approach preserves the contract → proceed with it and record the integration handoff (what the real dependency must later provide, and where it connects) in Investigation Notes.
+   - No local construct preserves the contract, or several valid constructs differ on an architectural trade-off (placement, dependency direction, contract shape) → stop and escalate with `escalation_type: "design_compliance_violation"` (see Design Doc Deviation Escalation in Structured Response Specification; populate every `details` field that schema requires). Map the Design Doc requirement for the dependency to `details.design_doc_expectation`, and the absent/unimplemented dependency with the exact undecided decision to `details.actual_situation`.
+
 #### Adjacent Case Sweep (Required when the task file has a `Change Category` field set to one or more of `bug-fix`, `regression`, `state-change`, `boundary-change`)
 
 Runs after Pre-implementation Verification, before the Binding Decision Check. This step fires on the field value the task decomposition wrote — read the field value and treat it as authoritative for whether the sweep applies.
@@ -168,7 +177,7 @@ Runs after Pre-implementation Verification, alongside the Binding Decision Check
 3. Evaluate each row's Compliance Check against the planned approach. Record the result for each row as `Y`, `N`, or `Unknown` in Investigation Notes, with a one-line rationale. Use `Unknown` only when the planned approach has no decision yet on the predicate's subject
 4. Per row, branch on the evaluation:
    - `Y`: proceed
-   - `N`: stop implementation and produce the final response with `status: "escalation_needed"` and `escalation_type: "design_compliance_violation"` (Escalation Response 2-1), populating `details.design_doc_expectation` with the Reference Contract row's Required Observable Value and `details.actual_situation` with the planned approach
+   - `N`: stop implementation and produce the final response with `status: "escalation_needed"` and `escalation_type: "design_compliance_violation"` (see Design Doc Deviation Escalation in Structured Response Specification; populate every `details` field that schema requires). Map the Reference Contract row's Required Observable Value to `details.design_doc_expectation` and the planned approach to `details.actual_situation`
    - `Unknown`: mark the row as deferred in Investigation Notes and proceed to the TDD cycle. The Exit Gate re-evaluates every deferred row against the final implementation
 
 #### Reference Representativeness (Applied During Implementation)

--- a/dev-workflows-fullstack/agents/task-executor.md
+++ b/dev-workflows-fullstack/agents/task-executor.md
@@ -134,6 +134,15 @@ This gate triggers only when the Investigation Targets section lists at least on
 #### Pre-implementation Verification (Pattern 5 Compliant)
 Read relevant Design Doc sections (interface contracts, data structures, dependency constraints); investigate existing implementations in the same domain/responsibility; determine continue/escalation per "Mandatory Judgment Criteria" above.
 
+#### Unimplemented Dependency Handling
+
+Applies when Pre-implementation Verification finds a dependency this task requires is absent or unimplemented (e.g., a Design Doc component marked "requires new creation"). A missing dependency is a stop condition only when it prevents preserving the required contract and no local, reversible construct can satisfy it.
+
+1. Determine whether a local, reversible construct — a local slice, or a contract-preserving stub/adapter scoped to the Target Files — preserves the required contract.
+2. Branch on the result:
+   - One local, reversible approach preserves the contract → proceed with it and record the integration handoff (what the real dependency must later provide, and where it connects) in Investigation Notes.
+   - No local construct preserves the contract, or several valid constructs differ on an architectural trade-off (placement, dependency direction, contract shape) → stop and escalate with `escalation_type: "design_compliance_violation"` (see Design Doc Deviation Escalation in Structured Response Specification; populate every `details` field that schema requires). Map the Design Doc requirement for the dependency to `details.design_doc_expectation`, and the absent/unimplemented dependency with the exact undecided decision to `details.actual_situation`.
+
 #### Adjacent Case Sweep (Required when the task file has a `Change Category` field set to one or more of `bug-fix`, `regression`, `state-change`, `boundary-change`)
 
 Runs after Pre-implementation Verification, before the Binding Decision Check. This step fires on the field value the task decomposition wrote — read the field value and treat it as authoritative for whether the sweep applies.
@@ -163,7 +172,7 @@ Runs after Pre-implementation Verification, alongside the Binding Decision Check
 3. Evaluate each row's Compliance Check against the planned approach. Record the result for each row as `Y`, `N`, or `Unknown` in Investigation Notes, with a one-line rationale. Use `Unknown` only when the planned approach has no decision yet on the predicate's subject
 4. Per row, branch on the evaluation:
    - `Y`: proceed
-   - `N`: stop implementation and produce the final response with `status: "escalation_needed"` and `escalation_type: "design_compliance_violation"` (Escalation Response 2-1), populating `details.design_doc_expectation` with the Reference Contract row's Required Observable Value and `details.actual_situation` with the planned approach
+   - `N`: stop implementation and produce the final response with `status: "escalation_needed"` and `escalation_type: "design_compliance_violation"` (see Design Doc Deviation Escalation in Structured Response Specification; populate every `details` field that schema requires). Map the Reference Contract row's Required Observable Value to `details.design_doc_expectation` and the planned approach to `details.actual_situation`
    - `Unknown`: mark the row as deferred in Investigation Notes and proceed to the TDD cycle. The Exit Gate re-evaluates every deferred row against the final implementation
 
 #### Reference Representativeness (Applied During Implementation)

--- a/dev-workflows/.claude-plugin/plugin.json
+++ b/dev-workflows/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflows",
   "description": "Skills + Subagents for backend development - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows/agents/task-executor.md
+++ b/dev-workflows/agents/task-executor.md
@@ -134,6 +134,15 @@ This gate triggers only when the Investigation Targets section lists at least on
 #### Pre-implementation Verification (Pattern 5 Compliant)
 Read relevant Design Doc sections (interface contracts, data structures, dependency constraints); investigate existing implementations in the same domain/responsibility; determine continue/escalation per "Mandatory Judgment Criteria" above.
 
+#### Unimplemented Dependency Handling
+
+Applies when Pre-implementation Verification finds a dependency this task requires is absent or unimplemented (e.g., a Design Doc component marked "requires new creation"). A missing dependency is a stop condition only when it prevents preserving the required contract and no local, reversible construct can satisfy it.
+
+1. Determine whether a local, reversible construct — a local slice, or a contract-preserving stub/adapter scoped to the Target Files — preserves the required contract.
+2. Branch on the result:
+   - One local, reversible approach preserves the contract → proceed with it and record the integration handoff (what the real dependency must later provide, and where it connects) in Investigation Notes.
+   - No local construct preserves the contract, or several valid constructs differ on an architectural trade-off (placement, dependency direction, contract shape) → stop and escalate with `escalation_type: "design_compliance_violation"` (see Design Doc Deviation Escalation in Structured Response Specification; populate every `details` field that schema requires). Map the Design Doc requirement for the dependency to `details.design_doc_expectation`, and the absent/unimplemented dependency with the exact undecided decision to `details.actual_situation`.
+
 #### Adjacent Case Sweep (Required when the task file has a `Change Category` field set to one or more of `bug-fix`, `regression`, `state-change`, `boundary-change`)
 
 Runs after Pre-implementation Verification, before the Binding Decision Check. This step fires on the field value the task decomposition wrote — read the field value and treat it as authoritative for whether the sweep applies.
@@ -163,7 +172,7 @@ Runs after Pre-implementation Verification, alongside the Binding Decision Check
 3. Evaluate each row's Compliance Check against the planned approach. Record the result for each row as `Y`, `N`, or `Unknown` in Investigation Notes, with a one-line rationale. Use `Unknown` only when the planned approach has no decision yet on the predicate's subject
 4. Per row, branch on the evaluation:
    - `Y`: proceed
-   - `N`: stop implementation and produce the final response with `status: "escalation_needed"` and `escalation_type: "design_compliance_violation"` (Escalation Response 2-1), populating `details.design_doc_expectation` with the Reference Contract row's Required Observable Value and `details.actual_situation` with the planned approach
+   - `N`: stop implementation and produce the final response with `status: "escalation_needed"` and `escalation_type: "design_compliance_violation"` (see Design Doc Deviation Escalation in Structured Response Specification; populate every `details` field that schema requires). Map the Reference Contract row's Required Observable Value to `details.design_doc_expectation` and the planned approach to `details.actual_situation`
    - `Unknown`: mark the row as deferred in Investigation Notes and proceed to the TDD cycle. The Exit Gate re-evaluates every deferred row against the final implementation
 
 #### Reference Representativeness (Applied During Implementation)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-workflows",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary

Two related fidelity improvements to the `task-executor` agents (generic + frontend variants), plus a patch version bump.

### 1. Unimplemented Dependency Handling rule (new)

Adds an explicit rule for what the executor does when a dependency the task requires is absent or unimplemented. A missing dependency is a **stop condition only when** it prevents preserving the required contract **and** no local, reversible construct (a local slice, or a contract-preserving stub/adapter scoped to the Target Files) can satisfy it.

- One viable local approach → proceed and record the integration handoff in Investigation Notes.
- No local construct preserves the contract, or several valid constructs differ on an architectural trade-off → escalate, naming the exact undecided decision.

This prevents over-eager blocking on every missing dependency while still escalating genuine architectural decisions. It reuses the existing `design_compliance_violation` escalation type (no new enum value).

### 2. Escalation `details` completeness + correct field mapping (fix)

The Reference Contract `N` branch previously named only a subset of the `details` fields required by the Design Doc Deviation Escalation schema, which could yield under-populated escalation JSON. Both this branch and the new dependency rule now point to the schema and require every field to be populated, with the source-specific fields mapped explicitly:

- Design Doc requirement → `design_doc_expectation`
- absent/unimplemented dependency and undecided decision → `actual_situation`

(`why_cannot_implement` / `attempted_approaches` are left to the schema definition to avoid duplication.)

### Packaging

- Bumped to **0.22.1** (`package.json`, `marketplace.json`).
- `pnpm sync` re-synced all four plugin distributions; `pnpm sync:check` clean; `claude plugin validate --strict` passes for all plugins.

## Scope notes

Edits are in the canonical `agents/` files; distribution copies are sync-generated. Pre-existing escalation-schema consistency items elsewhere in the file (Core Mechanism check, Exit Gate enforcement) are intentionally out of scope and tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)