### PR TITLE
refine: enforce fresh subagent invocation in orchestration guide

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "dev-workflows",
       "source": "./dev-workflows",
       "strict": true,
-      "version": "0.22.1",
+      "version": "0.22.2",
       "description": "Skills + Subagents for backend development - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
       "author": {
         "name": "Shinsuke Kagawa",
@@ -82,7 +82,7 @@
       "name": "dev-workflows-frontend",
       "source": "./dev-workflows-frontend",
       "strict": true,
-      "version": "0.22.1",
+      "version": "0.22.2",
       "description": "Skills + Subagents for React/TypeScript - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
       "author": {
         "name": "Shinsuke Kagawa",
@@ -154,7 +154,7 @@
       "name": "dev-workflows-fullstack",
       "source": "./dev-workflows-fullstack",
       "strict": true,
-      "version": "0.22.1",
+      "version": "0.22.2",
       "description": "Skills + Subagents for fullstack development (backend + React/TypeScript) - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
       "author": {
         "name": "Shinsuke Kagawa",
@@ -243,7 +243,7 @@
       "name": "dev-skills",
       "source": "./dev-skills",
       "strict": true,
-      "version": "0.22.1",
+      "version": "0.22.2",
       "description": "Lightweight skills for users with existing workflows - coding best practices, testing principles, and design guidelines without recipe workflows or agents",
       "author": {
         "name": "Shinsuke Kagawa",

--- a/dev-skills/.claude-plugin/plugin.json
+++ b/dev-skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-skills",
   "description": "Lightweight skills for users with existing workflows - coding best practices, testing principles, and design guidelines without recipe workflows or agents",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows-frontend/.claude-plugin/plugin.json
+++ b/dev-workflows-frontend/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflows-frontend",
   "description": "Skills + Subagents for React/TypeScript - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows-frontend/skills/subagents-orchestration-guide/SKILL.md
+++ b/dev-workflows-frontend/skills/subagents-orchestration-guide/SKILL.md
@@ -124,7 +124,7 @@ Autonomous execution MUST stop and wait for user input at these points.
 ## How to Call Subagents
 
 ### Execution Method
-All subagent invocation uses the **Agent tool** with:
+Each subagent invocation is a **fresh Agent tool** call, isolating each phase's context; a SendMessage resume reuses the prior agent's context and breaks that isolation. Each call uses:
 - `subagent_type`: Agent name (e.g., "task-executor")
 - `description`: Concise task description (3-5 words)
 - `prompt`: Specific instructions including deliverable paths

--- a/dev-workflows-fullstack/.claude-plugin/plugin.json
+++ b/dev-workflows-fullstack/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflows-fullstack",
   "description": "Skills + Subagents for fullstack development (backend + React/TypeScript) - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows-fullstack/skills/subagents-orchestration-guide/SKILL.md
+++ b/dev-workflows-fullstack/skills/subagents-orchestration-guide/SKILL.md
@@ -124,7 +124,7 @@ Autonomous execution MUST stop and wait for user input at these points.
 ## How to Call Subagents
 
 ### Execution Method
-All subagent invocation uses the **Agent tool** with:
+Each subagent invocation is a **fresh Agent tool** call, isolating each phase's context; a SendMessage resume reuses the prior agent's context and breaks that isolation. Each call uses:
 - `subagent_type`: Agent name (e.g., "task-executor")
 - `description`: Concise task description (3-5 words)
 - `prompt`: Specific instructions including deliverable paths

--- a/dev-workflows/.claude-plugin/plugin.json
+++ b/dev-workflows/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflows",
   "description": "Skills + Subagents for backend development - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows/skills/subagents-orchestration-guide/SKILL.md
+++ b/dev-workflows/skills/subagents-orchestration-guide/SKILL.md
@@ -124,7 +124,7 @@ Autonomous execution MUST stop and wait for user input at these points.
 ## How to Call Subagents
 
 ### Execution Method
-All subagent invocation uses the **Agent tool** with:
+Each subagent invocation is a **fresh Agent tool** call, isolating each phase's context; a SendMessage resume reuses the prior agent's context and breaks that isolation. Each call uses:
 - `subagent_type`: Agent name (e.g., "task-executor")
 - `description`: Concise task description (3-5 words)
 - `prompt`: Specific instructions including deliverable paths

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-workflows",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "private": true,
   "type": "module",
   "engines": {

--- a/skills/subagents-orchestration-guide/SKILL.md
+++ b/skills/subagents-orchestration-guide/SKILL.md
@@ -124,7 +124,7 @@ Autonomous execution MUST stop and wait for user input at these points.
 ## How to Call Subagents
 
 ### Execution Method
-All subagent invocation uses the **Agent tool** with:
+Each subagent invocation is a **fresh Agent tool** call, isolating each phase's context; a SendMessage resume reuses the prior agent's context and breaks that isolation. Each call uses:
 - `subagent_type`: Agent name (e.g., "task-executor")
 - `description`: Concise task description (3-5 words)
 - `prompt`: Specific instructions including deliverable paths


### PR DESCRIPTION
## Summary

Closes a gap in `subagents-orchestration-guide` that let the orchestrator continue a completed subagent via the harness's `SendMessage` resume path, which silently re-entered stale context and broke the workflow's per-phase isolation.

The guide's `Execution Method` section now states that **each subagent invocation is a fresh Agent tool call**, with the rationale made explicit: every phase runs in an isolated context, and a `SendMessage` resume reuses the prior agent's context and breaks that isolation.

## Why this wording

- **Positive form first.** The instruction leads with what to do (a fresh Agent call) rather than a prohibition, keeping it aligned with the project's prompt principles.
- **Names the failure mode with a reason.** `SendMessage` is named because the harness actively advertises it as the continuation mechanism; closing that door requires an explicit, reasoned counter rather than relying on inference.
- **Context isolation is the rationale.** Subagents exist for context separation (bias removal) and context-window conservation — resume negates both, so isolation is the precise justification.
- **Minimal footprint.** A single sentence, edited in place. The orchestration guide is long and read by every `recipe-*` workflow, so the addition is kept necessary-and-sufficient.

## Changes

- `skills/subagents-orchestration-guide/SKILL.md`: revised `Execution Method` line (single source).
- Synced to `dev-workflows`, `dev-workflows-frontend`, `dev-workflows-fullstack` (dev-skills does not bundle this guide).
- Version bump `0.22.1` → `0.22.2` (package.json + marketplace.json + generated plugin.json).

## Validation

- `claude plugin validate .` → passed
- `sync:check` → no drift
- pre-commit hooks (sync, validate, skills-index) → all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)