### PR TITLE
refine: convert agent skills frontmatter to YAML list format

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "dev-workflows",
       "source": "./dev-workflows",
       "strict": true,
-      "version": "0.22.3",
+      "version": "0.22.4",
       "description": "Skills + Subagents for backend development - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
       "author": {
         "name": "Shinsuke Kagawa",
@@ -82,7 +82,7 @@
       "name": "dev-workflows-frontend",
       "source": "./dev-workflows-frontend",
       "strict": true,
-      "version": "0.22.3",
+      "version": "0.22.4",
       "description": "Skills + Subagents for React/TypeScript - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
       "author": {
         "name": "Shinsuke Kagawa",
@@ -154,7 +154,7 @@
       "name": "dev-workflows-fullstack",
       "source": "./dev-workflows-fullstack",
       "strict": true,
-      "version": "0.22.3",
+      "version": "0.22.4",
       "description": "Skills + Subagents for fullstack development (backend + React/TypeScript) - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
       "author": {
         "name": "Shinsuke Kagawa",
@@ -243,7 +243,7 @@
       "name": "dev-skills",
       "source": "./dev-skills",
       "strict": true,
-      "version": "0.22.3",
+      "version": "0.22.4",
       "description": "Lightweight skills for users with existing workflows - coding best practices, testing principles, and design guidelines without recipe workflows or agents",
       "author": {
         "name": "Shinsuke Kagawa",

--- a/agents/acceptance-test-generator.md
+++ b/agents/acceptance-test-generator.md
@@ -2,7 +2,11 @@
 name: acceptance-test-generator
 description: Generates integration/E2E test skeletons from Design Doc ACs using ROI-based selection and journey-based E2E reservation. Use when Design Doc is complete and test design is needed, or when "test skeleton/AC/acceptance criteria" is mentioned. Behavior-first approach for minimal tests with maximum coverage.
 tools: Read, Write, Glob, LS, TaskCreate, TaskUpdate, Grep
-skills: testing-principles, documentation-criteria, integration-e2e-testing, llm-friendly-context
+skills:
+  - testing-principles
+  - documentation-criteria
+  - integration-e2e-testing
+  - llm-friendly-context
 ---
 
 You are a specialized AI that generates minimal, high-quality test skeletons from Design Doc Acceptance Criteria (ACs) and optional UI Spec. Your goal is **maximum coverage with minimum tests** through strategic selection, not exhaustive generation.

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -2,7 +2,10 @@
 name: code-reviewer
 description: Validates Design Doc compliance and implementation completeness from third-party perspective. Use PROACTIVELY after implementation completes or when "review/implementation check/compliance" is mentioned. Provides acceptance criteria validation and quality reports.
 tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate
-skills: ai-development-guide, coding-principles, testing-principles
+skills:
+  - ai-development-guide
+  - coding-principles
+  - testing-principles
 ---
 
 You are a code review AI assistant specializing in Design Doc compliance validation.

--- a/agents/code-verifier.md
+++ b/agents/code-verifier.md
@@ -2,7 +2,10 @@
 name: code-verifier
 description: Validates consistency between PRD/Design Doc and code implementation. Use PROACTIVELY after implementation completes, or when "document consistency/implementation gap/as specified" is mentioned. Uses multi-source evidence matching to identify discrepancies.
 tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate
-skills: documentation-criteria, ai-development-guide, coding-principles
+skills:
+  - documentation-criteria
+  - ai-development-guide
+  - coding-principles
 ---
 
 You are an AI assistant specializing in document-code consistency verification.

--- a/agents/codebase-analyzer.md
+++ b/agents/codebase-analyzer.md
@@ -2,7 +2,10 @@
 name: codebase-analyzer
 description: Analyzes existing codebase objectively for facts about implementation, user behavior patterns, and technical architecture. Use when existing code needs to be understood without hypothesis bias. Invoked before Design Doc creation to produce focused guidance for technical designers.
 tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate
-skills: ai-development-guide, coding-principles, llm-friendly-context
+skills:
+  - ai-development-guide
+  - coding-principles
+  - llm-friendly-context
 ---
 
 You are an AI assistant specializing in existing codebase analysis for technical design preparation.

--- a/agents/design-sync.md
+++ b/agents/design-sync.md
@@ -2,7 +2,10 @@
 name: design-sync
 description: Detects conflicts across multiple Design Docs and provides structured reports. Use when multiple Design Docs exist, or when "consistency/conflict/sync/between documents" is mentioned. Focuses on detection and reporting only, no modifications.
 tools: Read, Grep, Glob, LS, TaskCreate, TaskUpdate
-skills: documentation-criteria, coding-principles, llm-friendly-context
+skills:
+  - documentation-criteria
+  - coding-principles
+  - llm-friendly-context
 ---
 
 You are an AI assistant specializing in consistency verification between Design Docs.

--- a/agents/document-reviewer.md
+++ b/agents/document-reviewer.md
@@ -2,7 +2,11 @@
 name: document-reviewer
 description: Reviews document consistency and completeness, providing approval decisions. Use PROACTIVELY after PRD/UI Spec/Design Doc/work plan creation, or when "document review/approval/check" is mentioned. Detects contradictions and rule violations with improvement suggestions.
 tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
-skills: documentation-criteria, coding-principles, testing-principles, llm-friendly-context
+skills:
+  - documentation-criteria
+  - coding-principles
+  - testing-principles
+  - llm-friendly-context
 ---
 
 You are an AI assistant specialized in technical document review.

--- a/agents/integration-test-reviewer.md
+++ b/agents/integration-test-reviewer.md
@@ -2,7 +2,9 @@
 name: integration-test-reviewer
 description: Verifies consistency between test skeleton comments and implementation code. Use PROACTIVELY after test implementation completes, or when "test review/skeleton verification" is mentioned. Returns quality reports with failing items and fix instructions.
 tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate
-skills: testing-principles, integration-e2e-testing
+skills:
+  - testing-principles
+  - integration-e2e-testing
 ---
 
 You are an AI assistant specializing in integration and E2E test quality review.

--- a/agents/investigator.md
+++ b/agents/investigator.md
@@ -2,7 +2,9 @@
 name: investigator
 description: Comprehensively collects problem-related information and creates evidence matrix. Use PROACTIVELY when bug/error/issue/defect/not working/strange behavior is reported. Reports only observations without proposing solutions.
 tools: Read, Grep, Glob, LS, Bash, WebSearch, TaskCreate, TaskUpdate
-skills: ai-development-guide, coding-principles
+skills:
+  - ai-development-guide
+  - coding-principles
 ---
 
 You are an AI assistant specializing in problem investigation.

--- a/agents/prd-creator.md
+++ b/agents/prd-creator.md
@@ -2,7 +2,9 @@
 name: prd-creator
 description: Creates PRD and structures business requirements. Use when new feature/project starts, or when "PRD/requirements definition/user story/what to build" is mentioned. Defines user value and success metrics.
 tools: Read, Write, Edit, MultiEdit, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
-skills: documentation-criteria, llm-friendly-context
+skills:
+  - documentation-criteria
+  - llm-friendly-context
 ---
 
 You are a specialized AI assistant for creating Product Requirements Documents (PRD).

--- a/agents/quality-fixer-frontend.md
+++ b/agents/quality-fixer-frontend.md
@@ -2,7 +2,11 @@
 name: quality-fixer-frontend
 description: Specialized agent for fixing quality issues in frontend React projects. Executes all verification and fixing tasks including React Testing Library tests in a completely self-contained manner. Takes responsibility for fixing all quality errors until all checks pass. MUST BE USED PROACTIVELY when any quality-related keywords appear (quality/check/verify/test/build/lint/format/type/fix) or after code changes. Handles all verification and fixing tasks autonomously.
 tools: Bash, Read, Edit, MultiEdit, TaskCreate, TaskUpdate
-skills: typescript-rules, test-implement, frontend-ai-guide, external-resource-context
+skills:
+  - typescript-rules
+  - test-implement
+  - frontend-ai-guide
+  - external-resource-context
 ---
 
 You are an AI assistant specialized in quality assurance for frontend React projects.

--- a/agents/quality-fixer.md
+++ b/agents/quality-fixer.md
@@ -2,7 +2,11 @@
 name: quality-fixer
 description: Specialized agent for fixing quality issues in software projects. Executes all verification and fixing tasks related to code quality, correctness guarantees, testing, and building in a completely self-contained manner. Takes responsibility for fixing all quality errors until all tests pass. MUST BE USED PROACTIVELY when any quality-related keywords appear (quality/check/verify/test/build/lint/format/correctness/fix) or after code changes. Handles all verification and fixing tasks autonomously.
 tools: Bash, Read, Edit, MultiEdit, TaskCreate, TaskUpdate
-skills: coding-principles, testing-principles, ai-development-guide, external-resource-context
+skills:
+  - coding-principles
+  - testing-principles
+  - ai-development-guide
+  - external-resource-context
 ---
 
 You are an AI assistant specialized in quality assurance for software projects.

--- a/agents/requirement-analyzer.md
+++ b/agents/requirement-analyzer.md
@@ -2,7 +2,9 @@
 name: requirement-analyzer
 description: Performs requirements analysis and work scale determination. Use PROACTIVELY when new feature requests or change requests are received, or when "requirements/scope/where to start" is mentioned. Extracts user requirement essence and proposes development approaches.
 tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
-skills: ai-development-guide, documentation-criteria
+skills:
+  - ai-development-guide
+  - documentation-criteria
 ---
 
 You are a specialized AI assistant for requirements analysis and work scale determination.

--- a/agents/rule-advisor.md
+++ b/agents/rule-advisor.md
@@ -2,7 +2,8 @@
 name: rule-advisor
 description: Selects optimal rulesets for tasks and performs metacognitive analysis. Use PROACTIVELY before implementation tasks start, or when "rules/ruleset/coding standards" is mentioned. Returns structured JSON with recommended skills and rationale.
 tools: Read, Grep, LS
-skills: task-analyzer
+skills:
+  - task-analyzer
 ---
 
 You are an AI assistant specialized in rule selection. You analyze task nature using metacognitive approaches and return comprehensive, structured skill contents to maximize AI execution accuracy.

--- a/agents/scope-discoverer.md
+++ b/agents/scope-discoverer.md
@@ -2,7 +2,12 @@
 name: scope-discoverer
 description: Discovers functional scope from existing codebase for reverse documentation. Identifies targets through multi-source discovery combining user-value and technical perspectives. Use when "reverse engineering/existing code analysis/scope discovery" is mentioned.
 tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate
-skills: documentation-criteria, ai-development-guide, coding-principles, implementation-approach, llm-friendly-context
+skills:
+  - documentation-criteria
+  - ai-development-guide
+  - coding-principles
+  - implementation-approach
+  - llm-friendly-context
 ---
 
 You are an AI assistant specializing in codebase scope discovery for reverse documentation.

--- a/agents/security-reviewer.md
+++ b/agents/security-reviewer.md
@@ -2,7 +2,8 @@
 name: security-reviewer
 description: Reviews implementation for security compliance against Design Doc security considerations. Use PROACTIVELY after all implementation tasks complete, or when "security review/security check/vulnerability check" is mentioned. Returns structured findings with risk classification and fix suggestions.
 tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
-skills: coding-principles
+skills:
+  - coding-principles
 ---
 
 You are an AI assistant specializing in security review of implemented code.

--- a/agents/solver.md
+++ b/agents/solver.md
@@ -2,7 +2,10 @@
 name: solver
 description: Derives multiple solutions for verified causes and analyzes tradeoffs. Use when root cause verification has concluded, or when "solution/how to fix/fix method/remedy" is mentioned. Focuses on solutions from given conclusions without investigation.
 tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
-skills: ai-development-guide, coding-principles, implementation-approach
+skills:
+  - ai-development-guide
+  - coding-principles
+  - implementation-approach
 ---
 
 You are an AI assistant specializing in solution derivation.

--- a/agents/task-decomposer.md
+++ b/agents/task-decomposer.md
@@ -2,7 +2,13 @@
 name: task-decomposer
 description: Reads work plan documents from docs/plans and decomposes them into independent, single-commit granularity tasks placed in docs/plans/tasks. PROACTIVELY proposes task decomposition when work plans are created.
 tools: Read, Write, LS, Bash, TaskCreate, TaskUpdate
-skills: ai-development-guide, documentation-criteria, testing-principles, coding-principles, implementation-approach, llm-friendly-context
+skills:
+  - ai-development-guide
+  - documentation-criteria
+  - testing-principles
+  - coding-principles
+  - implementation-approach
+  - llm-friendly-context
 ---
 
 You are an AI assistant specialized in decomposing work plans into executable tasks.

--- a/agents/task-executor-frontend.md
+++ b/agents/task-executor-frontend.md
@@ -2,7 +2,12 @@
 name: task-executor-frontend
 description: Executes React implementation completely self-contained following frontend task files. Use when frontend task files exist, or when "frontend implementation/React implementation/component creation" is mentioned. Asks no questions, executes consistently from investigation to implementation.
 tools: Read, Edit, Write, MultiEdit, Bash, Grep, Glob, LS, TaskCreate, TaskUpdate
-skills: typescript-rules, test-implement, frontend-ai-guide, implementation-approach, external-resource-context
+skills:
+  - typescript-rules
+  - test-implement
+  - frontend-ai-guide
+  - implementation-approach
+  - external-resource-context
 ---
 
 You are a specialized AI assistant for reliably executing frontend implementation tasks.

--- a/agents/task-executor.md
+++ b/agents/task-executor.md
@@ -2,7 +2,12 @@
 name: task-executor
 description: Executes implementation completely self-contained following task files. Use when task files exist in docs/plans/tasks/, or when "execute task/implement task/start implementation" is mentioned. Asks no questions, executes consistently from investigation to implementation.
 tools: Read, Edit, Write, MultiEdit, Bash, Grep, Glob, LS, TaskCreate, TaskUpdate
-skills: coding-principles, testing-principles, ai-development-guide, implementation-approach, external-resource-context
+skills:
+  - coding-principles
+  - testing-principles
+  - ai-development-guide
+  - implementation-approach
+  - external-resource-context
 ---
 
 You are a specialized AI assistant for reliably executing individual tasks.

--- a/agents/technical-designer-frontend.md
+++ b/agents/technical-designer-frontend.md
@@ -2,7 +2,15 @@
 name: technical-designer-frontend
 description: Creates frontend ADR and Design Docs to evaluate React technical choices. Use when frontend PRD is complete and technical design is needed, or when "frontend design/React design/UI design/component design" is mentioned.
 tools: Read, Write, Edit, MultiEdit, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
-skills: documentation-criteria, coding-principles, typescript-rules, frontend-ai-guide, implementation-approach, testing-principles, llm-friendly-context, external-resource-context
+skills:
+  - documentation-criteria
+  - coding-principles
+  - typescript-rules
+  - frontend-ai-guide
+  - implementation-approach
+  - testing-principles
+  - llm-friendly-context
+  - external-resource-context
 ---
 
 You are a frontend technical design specialist AI assistant for creating Architecture Decision Records (ADR) and Design Documents.

--- a/agents/technical-designer.md
+++ b/agents/technical-designer.md
@@ -2,7 +2,14 @@
 name: technical-designer
 description: Creates ADR and Design Docs to evaluate technical choices and implementation approaches. Use when PRD is complete and technical design is needed, or when "ADR/design doc/technical design/architecture" is mentioned.
 tools: Read, Write, Edit, MultiEdit, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
-skills: documentation-criteria, coding-principles, testing-principles, ai-development-guide, implementation-approach, llm-friendly-context, external-resource-context
+skills:
+  - documentation-criteria
+  - coding-principles
+  - testing-principles
+  - ai-development-guide
+  - implementation-approach
+  - llm-friendly-context
+  - external-resource-context
 ---
 
 You are a technical design specialist AI assistant for creating Architecture Decision Records (ADR) and Design Documents.

--- a/agents/ui-analyzer.md
+++ b/agents/ui-analyzer.md
@@ -2,7 +2,11 @@
 name: ui-analyzer
 description: Gathers UI-related facts by reading the project's external-resources file, fetching external sources (design origin, design system, guidelines) via MCP or URL, and analyzing the existing UI codebase. Use when frontend design or adjustment work needs a single consolidated UI context (external sources + code) before document creation or implementation.
 disallowedTools: Write, Edit, MultiEdit, NotebookEdit
-skills: typescript-rules, frontend-ai-guide, llm-friendly-context, external-resource-context
+skills:
+  - typescript-rules
+  - frontend-ai-guide
+  - llm-friendly-context
+  - external-resource-context
 ---
 
 You are an AI assistant specializing in UI fact gathering for frontend design and adjustment preparation.

--- a/agents/ui-spec-designer.md
+++ b/agents/ui-spec-designer.md
@@ -2,7 +2,12 @@
 name: ui-spec-designer
 description: Creates UI Specifications from PRD and optional prototype code. Use when PRD is complete and frontend UI design is needed, or when "UI spec/screen design/component decomposition/UI specification" is mentioned.
 tools: Read, Write, Edit, MultiEdit, Glob, LS, Bash, TaskCreate, TaskUpdate
-skills: documentation-criteria, typescript-rules, frontend-ai-guide, llm-friendly-context, external-resource-context
+skills:
+  - documentation-criteria
+  - typescript-rules
+  - frontend-ai-guide
+  - llm-friendly-context
+  - external-resource-context
 ---
 
 You are a UI specification specialist AI assistant for creating UI Specification documents.

--- a/agents/verifier.md
+++ b/agents/verifier.md
@@ -2,7 +2,9 @@
 name: verifier
 description: Critically evaluates investigation results, checks path coverage, and validates failure points using Devil's Advocate method. Use when investigation has completed, or when "verify/validate/double-check/confirm findings" is mentioned. Focuses on verification and conclusion derivation.
 tools: Read, Grep, Glob, LS, Bash, WebSearch, TaskCreate, TaskUpdate
-skills: ai-development-guide, coding-principles
+skills:
+  - ai-development-guide
+  - coding-principles
 ---
 
 You are an AI assistant specializing in investigation result verification.

--- a/agents/work-planner.md
+++ b/agents/work-planner.md
@@ -2,7 +2,13 @@
 name: work-planner
 description: Creates work plan documents with trackable execution plans. Use when Design Doc is complete and implementation planning is needed, or when "work plan/implementation plan/task planning" is mentioned.
 tools: Read, Write, Edit, MultiEdit, Glob, LS, TaskCreate, TaskUpdate
-skills: ai-development-guide, documentation-criteria, coding-principles, testing-principles, implementation-approach, llm-friendly-context
+skills:
+  - ai-development-guide
+  - documentation-criteria
+  - coding-principles
+  - testing-principles
+  - implementation-approach
+  - llm-friendly-context
 ---
 
 You are a specialized AI assistant for creating work plan documents.

--- a/dev-skills/.claude-plugin/plugin.json
+++ b/dev-skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-skills",
   "description": "Lightweight skills for users with existing workflows - coding best practices, testing principles, and design guidelines without recipe workflows or agents",
-  "version": "0.22.3",
+  "version": "0.22.4",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows-frontend/.claude-plugin/plugin.json
+++ b/dev-workflows-frontend/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflows-frontend",
   "description": "Skills + Subagents for React/TypeScript - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
-  "version": "0.22.3",
+  "version": "0.22.4",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows-frontend/agents/acceptance-test-generator.md
+++ b/dev-workflows-frontend/agents/acceptance-test-generator.md
@@ -2,7 +2,11 @@
 name: acceptance-test-generator
 description: Generates integration/E2E test skeletons from Design Doc ACs using ROI-based selection and journey-based E2E reservation. Use when Design Doc is complete and test design is needed, or when "test skeleton/AC/acceptance criteria" is mentioned. Behavior-first approach for minimal tests with maximum coverage.
 tools: Read, Write, Glob, LS, TaskCreate, TaskUpdate, Grep
-skills: testing-principles, documentation-criteria, integration-e2e-testing, llm-friendly-context
+skills:
+  - testing-principles
+  - documentation-criteria
+  - integration-e2e-testing
+  - llm-friendly-context
 ---
 
 You are a specialized AI that generates minimal, high-quality test skeletons from Design Doc Acceptance Criteria (ACs) and optional UI Spec. Your goal is **maximum coverage with minimum tests** through strategic selection, not exhaustive generation.

--- a/dev-workflows-frontend/agents/code-reviewer.md
+++ b/dev-workflows-frontend/agents/code-reviewer.md
@@ -2,7 +2,10 @@
 name: code-reviewer
 description: Validates Design Doc compliance and implementation completeness from third-party perspective. Use PROACTIVELY after implementation completes or when "review/implementation check/compliance" is mentioned. Provides acceptance criteria validation and quality reports.
 tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate
-skills: ai-development-guide, coding-principles, testing-principles
+skills:
+  - ai-development-guide
+  - coding-principles
+  - testing-principles
 ---
 
 You are a code review AI assistant specializing in Design Doc compliance validation.

--- a/dev-workflows-frontend/agents/code-verifier.md
+++ b/dev-workflows-frontend/agents/code-verifier.md
@@ -2,7 +2,10 @@
 name: code-verifier
 description: Validates consistency between PRD/Design Doc and code implementation. Use PROACTIVELY after implementation completes, or when "document consistency/implementation gap/as specified" is mentioned. Uses multi-source evidence matching to identify discrepancies.
 tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate
-skills: documentation-criteria, ai-development-guide, coding-principles
+skills:
+  - documentation-criteria
+  - ai-development-guide
+  - coding-principles
 ---
 
 You are an AI assistant specializing in document-code consistency verification.

--- a/dev-workflows-frontend/agents/codebase-analyzer.md
+++ b/dev-workflows-frontend/agents/codebase-analyzer.md
@@ -2,7 +2,10 @@
 name: codebase-analyzer
 description: Analyzes existing codebase objectively for facts about implementation, user behavior patterns, and technical architecture. Use when existing code needs to be understood without hypothesis bias. Invoked before Design Doc creation to produce focused guidance for technical designers.
 tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate
-skills: ai-development-guide, coding-principles, llm-friendly-context
+skills:
+  - ai-development-guide
+  - coding-principles
+  - llm-friendly-context
 ---
 
 You are an AI assistant specializing in existing codebase analysis for technical design preparation.

--- a/dev-workflows-frontend/agents/design-sync.md
+++ b/dev-workflows-frontend/agents/design-sync.md
@@ -2,7 +2,10 @@
 name: design-sync
 description: Detects conflicts across multiple Design Docs and provides structured reports. Use when multiple Design Docs exist, or when "consistency/conflict/sync/between documents" is mentioned. Focuses on detection and reporting only, no modifications.
 tools: Read, Grep, Glob, LS, TaskCreate, TaskUpdate
-skills: documentation-criteria, coding-principles, llm-friendly-context
+skills:
+  - documentation-criteria
+  - coding-principles
+  - llm-friendly-context
 ---
 
 You are an AI assistant specializing in consistency verification between Design Docs.

--- a/dev-workflows-frontend/agents/document-reviewer.md
+++ b/dev-workflows-frontend/agents/document-reviewer.md
@@ -2,7 +2,11 @@
 name: document-reviewer
 description: Reviews document consistency and completeness, providing approval decisions. Use PROACTIVELY after PRD/UI Spec/Design Doc/work plan creation, or when "document review/approval/check" is mentioned. Detects contradictions and rule violations with improvement suggestions.
 tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
-skills: documentation-criteria, coding-principles, testing-principles, llm-friendly-context
+skills:
+  - documentation-criteria
+  - coding-principles
+  - testing-principles
+  - llm-friendly-context
 ---
 
 You are an AI assistant specialized in technical document review.

--- a/dev-workflows-frontend/agents/integration-test-reviewer.md
+++ b/dev-workflows-frontend/agents/integration-test-reviewer.md
@@ -2,7 +2,9 @@
 name: integration-test-reviewer
 description: Verifies consistency between test skeleton comments and implementation code. Use PROACTIVELY after test implementation completes, or when "test review/skeleton verification" is mentioned. Returns quality reports with failing items and fix instructions.
 tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate
-skills: testing-principles, integration-e2e-testing
+skills:
+  - testing-principles
+  - integration-e2e-testing
 ---
 
 You are an AI assistant specializing in integration and E2E test quality review.

--- a/dev-workflows-frontend/agents/investigator.md
+++ b/dev-workflows-frontend/agents/investigator.md
@@ -2,7 +2,9 @@
 name: investigator
 description: Comprehensively collects problem-related information and creates evidence matrix. Use PROACTIVELY when bug/error/issue/defect/not working/strange behavior is reported. Reports only observations without proposing solutions.
 tools: Read, Grep, Glob, LS, Bash, WebSearch, TaskCreate, TaskUpdate
-skills: ai-development-guide, coding-principles
+skills:
+  - ai-development-guide
+  - coding-principles
 ---
 
 You are an AI assistant specializing in problem investigation.

--- a/dev-workflows-frontend/agents/prd-creator.md
+++ b/dev-workflows-frontend/agents/prd-creator.md
@@ -2,7 +2,9 @@
 name: prd-creator
 description: Creates PRD and structures business requirements. Use when new feature/project starts, or when "PRD/requirements definition/user story/what to build" is mentioned. Defines user value and success metrics.
 tools: Read, Write, Edit, MultiEdit, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
-skills: documentation-criteria, llm-friendly-context
+skills:
+  - documentation-criteria
+  - llm-friendly-context
 ---
 
 You are a specialized AI assistant for creating Product Requirements Documents (PRD).

--- a/dev-workflows-frontend/agents/quality-fixer-frontend.md
+++ b/dev-workflows-frontend/agents/quality-fixer-frontend.md
@@ -2,7 +2,11 @@
 name: quality-fixer-frontend
 description: Specialized agent for fixing quality issues in frontend React projects. Executes all verification and fixing tasks including React Testing Library tests in a completely self-contained manner. Takes responsibility for fixing all quality errors until all checks pass. MUST BE USED PROACTIVELY when any quality-related keywords appear (quality/check/verify/test/build/lint/format/type/fix) or after code changes. Handles all verification and fixing tasks autonomously.
 tools: Bash, Read, Edit, MultiEdit, TaskCreate, TaskUpdate
-skills: typescript-rules, test-implement, frontend-ai-guide, external-resource-context
+skills:
+  - typescript-rules
+  - test-implement
+  - frontend-ai-guide
+  - external-resource-context
 ---
 
 You are an AI assistant specialized in quality assurance for frontend React projects.

--- a/dev-workflows-frontend/agents/requirement-analyzer.md
+++ b/dev-workflows-frontend/agents/requirement-analyzer.md
@@ -2,7 +2,9 @@
 name: requirement-analyzer
 description: Performs requirements analysis and work scale determination. Use PROACTIVELY when new feature requests or change requests are received, or when "requirements/scope/where to start" is mentioned. Extracts user requirement essence and proposes development approaches.
 tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
-skills: ai-development-guide, documentation-criteria
+skills:
+  - ai-development-guide
+  - documentation-criteria
 ---
 
 You are a specialized AI assistant for requirements analysis and work scale determination.

--- a/dev-workflows-frontend/agents/rule-advisor.md
+++ b/dev-workflows-frontend/agents/rule-advisor.md
@@ -2,7 +2,8 @@
 name: rule-advisor
 description: Selects optimal rulesets for tasks and performs metacognitive analysis. Use PROACTIVELY before implementation tasks start, or when "rules/ruleset/coding standards" is mentioned. Returns structured JSON with recommended skills and rationale.
 tools: Read, Grep, LS
-skills: task-analyzer
+skills:
+  - task-analyzer
 ---
 
 You are an AI assistant specialized in rule selection. You analyze task nature using metacognitive approaches and return comprehensive, structured skill contents to maximize AI execution accuracy.

--- a/dev-workflows-frontend/agents/security-reviewer.md
+++ b/dev-workflows-frontend/agents/security-reviewer.md
@@ -2,7 +2,8 @@
 name: security-reviewer
 description: Reviews implementation for security compliance against Design Doc security considerations. Use PROACTIVELY after all implementation tasks complete, or when "security review/security check/vulnerability check" is mentioned. Returns structured findings with risk classification and fix suggestions.
 tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
-skills: coding-principles
+skills:
+  - coding-principles
 ---
 
 You are an AI assistant specializing in security review of implemented code.

--- a/dev-workflows-frontend/agents/solver.md
+++ b/dev-workflows-frontend/agents/solver.md
@@ -2,7 +2,10 @@
 name: solver
 description: Derives multiple solutions for verified causes and analyzes tradeoffs. Use when root cause verification has concluded, or when "solution/how to fix/fix method/remedy" is mentioned. Focuses on solutions from given conclusions without investigation.
 tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
-skills: ai-development-guide, coding-principles, implementation-approach
+skills:
+  - ai-development-guide
+  - coding-principles
+  - implementation-approach
 ---
 
 You are an AI assistant specializing in solution derivation.

--- a/dev-workflows-frontend/agents/task-decomposer.md
+++ b/dev-workflows-frontend/agents/task-decomposer.md
@@ -2,7 +2,13 @@
 name: task-decomposer
 description: Reads work plan documents from docs/plans and decomposes them into independent, single-commit granularity tasks placed in docs/plans/tasks. PROACTIVELY proposes task decomposition when work plans are created.
 tools: Read, Write, LS, Bash, TaskCreate, TaskUpdate
-skills: ai-development-guide, documentation-criteria, testing-principles, coding-principles, implementation-approach, llm-friendly-context
+skills:
+  - ai-development-guide
+  - documentation-criteria
+  - testing-principles
+  - coding-principles
+  - implementation-approach
+  - llm-friendly-context
 ---
 
 You are an AI assistant specialized in decomposing work plans into executable tasks.

--- a/dev-workflows-frontend/agents/task-executor-frontend.md
+++ b/dev-workflows-frontend/agents/task-executor-frontend.md
@@ -2,7 +2,12 @@
 name: task-executor-frontend
 description: Executes React implementation completely self-contained following frontend task files. Use when frontend task files exist, or when "frontend implementation/React implementation/component creation" is mentioned. Asks no questions, executes consistently from investigation to implementation.
 tools: Read, Edit, Write, MultiEdit, Bash, Grep, Glob, LS, TaskCreate, TaskUpdate
-skills: typescript-rules, test-implement, frontend-ai-guide, implementation-approach, external-resource-context
+skills:
+  - typescript-rules
+  - test-implement
+  - frontend-ai-guide
+  - implementation-approach
+  - external-resource-context
 ---
 
 You are a specialized AI assistant for reliably executing frontend implementation tasks.

--- a/dev-workflows-frontend/agents/technical-designer-frontend.md
+++ b/dev-workflows-frontend/agents/technical-designer-frontend.md
@@ -2,7 +2,15 @@
 name: technical-designer-frontend
 description: Creates frontend ADR and Design Docs to evaluate React technical choices. Use when frontend PRD is complete and technical design is needed, or when "frontend design/React design/UI design/component design" is mentioned.
 tools: Read, Write, Edit, MultiEdit, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
-skills: documentation-criteria, coding-principles, typescript-rules, frontend-ai-guide, implementation-approach, testing-principles, llm-friendly-context, external-resource-context
+skills:
+  - documentation-criteria
+  - coding-principles
+  - typescript-rules
+  - frontend-ai-guide
+  - implementation-approach
+  - testing-principles
+  - llm-friendly-context
+  - external-resource-context
 ---
 
 You are a frontend technical design specialist AI assistant for creating Architecture Decision Records (ADR) and Design Documents.

--- a/dev-workflows-frontend/agents/ui-analyzer.md
+++ b/dev-workflows-frontend/agents/ui-analyzer.md
@@ -2,7 +2,11 @@
 name: ui-analyzer
 description: Gathers UI-related facts by reading the project's external-resources file, fetching external sources (design origin, design system, guidelines) via MCP or URL, and analyzing the existing UI codebase. Use when frontend design or adjustment work needs a single consolidated UI context (external sources + code) before document creation or implementation.
 disallowedTools: Write, Edit, MultiEdit, NotebookEdit
-skills: typescript-rules, frontend-ai-guide, llm-friendly-context, external-resource-context
+skills:
+  - typescript-rules
+  - frontend-ai-guide
+  - llm-friendly-context
+  - external-resource-context
 ---
 
 You are an AI assistant specializing in UI fact gathering for frontend design and adjustment preparation.

--- a/dev-workflows-frontend/agents/ui-spec-designer.md
+++ b/dev-workflows-frontend/agents/ui-spec-designer.md
@@ -2,7 +2,12 @@
 name: ui-spec-designer
 description: Creates UI Specifications from PRD and optional prototype code. Use when PRD is complete and frontend UI design is needed, or when "UI spec/screen design/component decomposition/UI specification" is mentioned.
 tools: Read, Write, Edit, MultiEdit, Glob, LS, Bash, TaskCreate, TaskUpdate
-skills: documentation-criteria, typescript-rules, frontend-ai-guide, llm-friendly-context, external-resource-context
+skills:
+  - documentation-criteria
+  - typescript-rules
+  - frontend-ai-guide
+  - llm-friendly-context
+  - external-resource-context
 ---
 
 You are a UI specification specialist AI assistant for creating UI Specification documents.

--- a/dev-workflows-frontend/agents/verifier.md
+++ b/dev-workflows-frontend/agents/verifier.md
@@ -2,7 +2,9 @@
 name: verifier
 description: Critically evaluates investigation results, checks path coverage, and validates failure points using Devil's Advocate method. Use when investigation has completed, or when "verify/validate/double-check/confirm findings" is mentioned. Focuses on verification and conclusion derivation.
 tools: Read, Grep, Glob, LS, Bash, WebSearch, TaskCreate, TaskUpdate
-skills: ai-development-guide, coding-principles
+skills:
+  - ai-development-guide
+  - coding-principles
 ---
 
 You are an AI assistant specializing in investigation result verification.

--- a/dev-workflows-frontend/agents/work-planner.md
+++ b/dev-workflows-frontend/agents/work-planner.md
@@ -2,7 +2,13 @@
 name: work-planner
 description: Creates work plan documents with trackable execution plans. Use when Design Doc is complete and implementation planning is needed, or when "work plan/implementation plan/task planning" is mentioned.
 tools: Read, Write, Edit, MultiEdit, Glob, LS, TaskCreate, TaskUpdate
-skills: ai-development-guide, documentation-criteria, coding-principles, testing-principles, implementation-approach, llm-friendly-context
+skills:
+  - ai-development-guide
+  - documentation-criteria
+  - coding-principles
+  - testing-principles
+  - implementation-approach
+  - llm-friendly-context
 ---
 
 You are a specialized AI assistant for creating work plan documents.

--- a/dev-workflows-fullstack/.claude-plugin/plugin.json
+++ b/dev-workflows-fullstack/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflows-fullstack",
   "description": "Skills + Subagents for fullstack development (backend + React/TypeScript) - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
-  "version": "0.22.3",
+  "version": "0.22.4",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows-fullstack/agents/acceptance-test-generator.md
+++ b/dev-workflows-fullstack/agents/acceptance-test-generator.md
@@ -2,7 +2,11 @@
 name: acceptance-test-generator
 description: Generates integration/E2E test skeletons from Design Doc ACs using ROI-based selection and journey-based E2E reservation. Use when Design Doc is complete and test design is needed, or when "test skeleton/AC/acceptance criteria" is mentioned. Behavior-first approach for minimal tests with maximum coverage.
 tools: Read, Write, Glob, LS, TaskCreate, TaskUpdate, Grep
-skills: testing-principles, documentation-criteria, integration-e2e-testing, llm-friendly-context
+skills:
+  - testing-principles
+  - documentation-criteria
+  - integration-e2e-testing
+  - llm-friendly-context
 ---
 
 You are a specialized AI that generates minimal, high-quality test skeletons from Design Doc Acceptance Criteria (ACs) and optional UI Spec. Your goal is **maximum coverage with minimum tests** through strategic selection, not exhaustive generation.

--- a/dev-workflows-fullstack/agents/code-reviewer.md
+++ b/dev-workflows-fullstack/agents/code-reviewer.md
@@ -2,7 +2,10 @@
 name: code-reviewer
 description: Validates Design Doc compliance and implementation completeness from third-party perspective. Use PROACTIVELY after implementation completes or when "review/implementation check/compliance" is mentioned. Provides acceptance criteria validation and quality reports.
 tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate
-skills: ai-development-guide, coding-principles, testing-principles
+skills:
+  - ai-development-guide
+  - coding-principles
+  - testing-principles
 ---
 
 You are a code review AI assistant specializing in Design Doc compliance validation.

--- a/dev-workflows-fullstack/agents/code-verifier.md
+++ b/dev-workflows-fullstack/agents/code-verifier.md
@@ -2,7 +2,10 @@
 name: code-verifier
 description: Validates consistency between PRD/Design Doc and code implementation. Use PROACTIVELY after implementation completes, or when "document consistency/implementation gap/as specified" is mentioned. Uses multi-source evidence matching to identify discrepancies.
 tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate
-skills: documentation-criteria, ai-development-guide, coding-principles
+skills:
+  - documentation-criteria
+  - ai-development-guide
+  - coding-principles
 ---
 
 You are an AI assistant specializing in document-code consistency verification.

--- a/dev-workflows-fullstack/agents/codebase-analyzer.md
+++ b/dev-workflows-fullstack/agents/codebase-analyzer.md
@@ -2,7 +2,10 @@
 name: codebase-analyzer
 description: Analyzes existing codebase objectively for facts about implementation, user behavior patterns, and technical architecture. Use when existing code needs to be understood without hypothesis bias. Invoked before Design Doc creation to produce focused guidance for technical designers.
 tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate
-skills: ai-development-guide, coding-principles, llm-friendly-context
+skills:
+  - ai-development-guide
+  - coding-principles
+  - llm-friendly-context
 ---
 
 You are an AI assistant specializing in existing codebase analysis for technical design preparation.

--- a/dev-workflows-fullstack/agents/design-sync.md
+++ b/dev-workflows-fullstack/agents/design-sync.md
@@ -2,7 +2,10 @@
 name: design-sync
 description: Detects conflicts across multiple Design Docs and provides structured reports. Use when multiple Design Docs exist, or when "consistency/conflict/sync/between documents" is mentioned. Focuses on detection and reporting only, no modifications.
 tools: Read, Grep, Glob, LS, TaskCreate, TaskUpdate
-skills: documentation-criteria, coding-principles, llm-friendly-context
+skills:
+  - documentation-criteria
+  - coding-principles
+  - llm-friendly-context
 ---
 
 You are an AI assistant specializing in consistency verification between Design Docs.

--- a/dev-workflows-fullstack/agents/document-reviewer.md
+++ b/dev-workflows-fullstack/agents/document-reviewer.md
@@ -2,7 +2,11 @@
 name: document-reviewer
 description: Reviews document consistency and completeness, providing approval decisions. Use PROACTIVELY after PRD/UI Spec/Design Doc/work plan creation, or when "document review/approval/check" is mentioned. Detects contradictions and rule violations with improvement suggestions.
 tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
-skills: documentation-criteria, coding-principles, testing-principles, llm-friendly-context
+skills:
+  - documentation-criteria
+  - coding-principles
+  - testing-principles
+  - llm-friendly-context
 ---
 
 You are an AI assistant specialized in technical document review.

--- a/dev-workflows-fullstack/agents/integration-test-reviewer.md
+++ b/dev-workflows-fullstack/agents/integration-test-reviewer.md
@@ -2,7 +2,9 @@
 name: integration-test-reviewer
 description: Verifies consistency between test skeleton comments and implementation code. Use PROACTIVELY after test implementation completes, or when "test review/skeleton verification" is mentioned. Returns quality reports with failing items and fix instructions.
 tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate
-skills: testing-principles, integration-e2e-testing
+skills:
+  - testing-principles
+  - integration-e2e-testing
 ---
 
 You are an AI assistant specializing in integration and E2E test quality review.

--- a/dev-workflows-fullstack/agents/investigator.md
+++ b/dev-workflows-fullstack/agents/investigator.md
@@ -2,7 +2,9 @@
 name: investigator
 description: Comprehensively collects problem-related information and creates evidence matrix. Use PROACTIVELY when bug/error/issue/defect/not working/strange behavior is reported. Reports only observations without proposing solutions.
 tools: Read, Grep, Glob, LS, Bash, WebSearch, TaskCreate, TaskUpdate
-skills: ai-development-guide, coding-principles
+skills:
+  - ai-development-guide
+  - coding-principles
 ---
 
 You are an AI assistant specializing in problem investigation.

--- a/dev-workflows-fullstack/agents/prd-creator.md
+++ b/dev-workflows-fullstack/agents/prd-creator.md
@@ -2,7 +2,9 @@
 name: prd-creator
 description: Creates PRD and structures business requirements. Use when new feature/project starts, or when "PRD/requirements definition/user story/what to build" is mentioned. Defines user value and success metrics.
 tools: Read, Write, Edit, MultiEdit, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
-skills: documentation-criteria, llm-friendly-context
+skills:
+  - documentation-criteria
+  - llm-friendly-context
 ---
 
 You are a specialized AI assistant for creating Product Requirements Documents (PRD).

--- a/dev-workflows-fullstack/agents/quality-fixer-frontend.md
+++ b/dev-workflows-fullstack/agents/quality-fixer-frontend.md
@@ -2,7 +2,11 @@
 name: quality-fixer-frontend
 description: Specialized agent for fixing quality issues in frontend React projects. Executes all verification and fixing tasks including React Testing Library tests in a completely self-contained manner. Takes responsibility for fixing all quality errors until all checks pass. MUST BE USED PROACTIVELY when any quality-related keywords appear (quality/check/verify/test/build/lint/format/type/fix) or after code changes. Handles all verification and fixing tasks autonomously.
 tools: Bash, Read, Edit, MultiEdit, TaskCreate, TaskUpdate
-skills: typescript-rules, test-implement, frontend-ai-guide, external-resource-context
+skills:
+  - typescript-rules
+  - test-implement
+  - frontend-ai-guide
+  - external-resource-context
 ---
 
 You are an AI assistant specialized in quality assurance for frontend React projects.

--- a/dev-workflows-fullstack/agents/quality-fixer.md
+++ b/dev-workflows-fullstack/agents/quality-fixer.md
@@ -2,7 +2,11 @@
 name: quality-fixer
 description: Specialized agent for fixing quality issues in software projects. Executes all verification and fixing tasks related to code quality, correctness guarantees, testing, and building in a completely self-contained manner. Takes responsibility for fixing all quality errors until all tests pass. MUST BE USED PROACTIVELY when any quality-related keywords appear (quality/check/verify/test/build/lint/format/correctness/fix) or after code changes. Handles all verification and fixing tasks autonomously.
 tools: Bash, Read, Edit, MultiEdit, TaskCreate, TaskUpdate
-skills: coding-principles, testing-principles, ai-development-guide, external-resource-context
+skills:
+  - coding-principles
+  - testing-principles
+  - ai-development-guide
+  - external-resource-context
 ---
 
 You are an AI assistant specialized in quality assurance for software projects.

--- a/dev-workflows-fullstack/agents/requirement-analyzer.md
+++ b/dev-workflows-fullstack/agents/requirement-analyzer.md
@@ -2,7 +2,9 @@
 name: requirement-analyzer
 description: Performs requirements analysis and work scale determination. Use PROACTIVELY when new feature requests or change requests are received, or when "requirements/scope/where to start" is mentioned. Extracts user requirement essence and proposes development approaches.
 tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
-skills: ai-development-guide, documentation-criteria
+skills:
+  - ai-development-guide
+  - documentation-criteria
 ---
 
 You are a specialized AI assistant for requirements analysis and work scale determination.

--- a/dev-workflows-fullstack/agents/rule-advisor.md
+++ b/dev-workflows-fullstack/agents/rule-advisor.md
@@ -2,7 +2,8 @@
 name: rule-advisor
 description: Selects optimal rulesets for tasks and performs metacognitive analysis. Use PROACTIVELY before implementation tasks start, or when "rules/ruleset/coding standards" is mentioned. Returns structured JSON with recommended skills and rationale.
 tools: Read, Grep, LS
-skills: task-analyzer
+skills:
+  - task-analyzer
 ---
 
 You are an AI assistant specialized in rule selection. You analyze task nature using metacognitive approaches and return comprehensive, structured skill contents to maximize AI execution accuracy.

--- a/dev-workflows-fullstack/agents/scope-discoverer.md
+++ b/dev-workflows-fullstack/agents/scope-discoverer.md
@@ -2,7 +2,12 @@
 name: scope-discoverer
 description: Discovers functional scope from existing codebase for reverse documentation. Identifies targets through multi-source discovery combining user-value and technical perspectives. Use when "reverse engineering/existing code analysis/scope discovery" is mentioned.
 tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate
-skills: documentation-criteria, ai-development-guide, coding-principles, implementation-approach, llm-friendly-context
+skills:
+  - documentation-criteria
+  - ai-development-guide
+  - coding-principles
+  - implementation-approach
+  - llm-friendly-context
 ---
 
 You are an AI assistant specializing in codebase scope discovery for reverse documentation.

--- a/dev-workflows-fullstack/agents/security-reviewer.md
+++ b/dev-workflows-fullstack/agents/security-reviewer.md
@@ -2,7 +2,8 @@
 name: security-reviewer
 description: Reviews implementation for security compliance against Design Doc security considerations. Use PROACTIVELY after all implementation tasks complete, or when "security review/security check/vulnerability check" is mentioned. Returns structured findings with risk classification and fix suggestions.
 tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
-skills: coding-principles
+skills:
+  - coding-principles
 ---
 
 You are an AI assistant specializing in security review of implemented code.

--- a/dev-workflows-fullstack/agents/solver.md
+++ b/dev-workflows-fullstack/agents/solver.md
@@ -2,7 +2,10 @@
 name: solver
 description: Derives multiple solutions for verified causes and analyzes tradeoffs. Use when root cause verification has concluded, or when "solution/how to fix/fix method/remedy" is mentioned. Focuses on solutions from given conclusions without investigation.
 tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
-skills: ai-development-guide, coding-principles, implementation-approach
+skills:
+  - ai-development-guide
+  - coding-principles
+  - implementation-approach
 ---
 
 You are an AI assistant specializing in solution derivation.

--- a/dev-workflows-fullstack/agents/task-decomposer.md
+++ b/dev-workflows-fullstack/agents/task-decomposer.md
@@ -2,7 +2,13 @@
 name: task-decomposer
 description: Reads work plan documents from docs/plans and decomposes them into independent, single-commit granularity tasks placed in docs/plans/tasks. PROACTIVELY proposes task decomposition when work plans are created.
 tools: Read, Write, LS, Bash, TaskCreate, TaskUpdate
-skills: ai-development-guide, documentation-criteria, testing-principles, coding-principles, implementation-approach, llm-friendly-context
+skills:
+  - ai-development-guide
+  - documentation-criteria
+  - testing-principles
+  - coding-principles
+  - implementation-approach
+  - llm-friendly-context
 ---
 
 You are an AI assistant specialized in decomposing work plans into executable tasks.

--- a/dev-workflows-fullstack/agents/task-executor-frontend.md
+++ b/dev-workflows-fullstack/agents/task-executor-frontend.md
@@ -2,7 +2,12 @@
 name: task-executor-frontend
 description: Executes React implementation completely self-contained following frontend task files. Use when frontend task files exist, or when "frontend implementation/React implementation/component creation" is mentioned. Asks no questions, executes consistently from investigation to implementation.
 tools: Read, Edit, Write, MultiEdit, Bash, Grep, Glob, LS, TaskCreate, TaskUpdate
-skills: typescript-rules, test-implement, frontend-ai-guide, implementation-approach, external-resource-context
+skills:
+  - typescript-rules
+  - test-implement
+  - frontend-ai-guide
+  - implementation-approach
+  - external-resource-context
 ---
 
 You are a specialized AI assistant for reliably executing frontend implementation tasks.

--- a/dev-workflows-fullstack/agents/task-executor.md
+++ b/dev-workflows-fullstack/agents/task-executor.md
@@ -2,7 +2,12 @@
 name: task-executor
 description: Executes implementation completely self-contained following task files. Use when task files exist in docs/plans/tasks/, or when "execute task/implement task/start implementation" is mentioned. Asks no questions, executes consistently from investigation to implementation.
 tools: Read, Edit, Write, MultiEdit, Bash, Grep, Glob, LS, TaskCreate, TaskUpdate
-skills: coding-principles, testing-principles, ai-development-guide, implementation-approach, external-resource-context
+skills:
+  - coding-principles
+  - testing-principles
+  - ai-development-guide
+  - implementation-approach
+  - external-resource-context
 ---
 
 You are a specialized AI assistant for reliably executing individual tasks.

--- a/dev-workflows-fullstack/agents/technical-designer-frontend.md
+++ b/dev-workflows-fullstack/agents/technical-designer-frontend.md
@@ -2,7 +2,15 @@
 name: technical-designer-frontend
 description: Creates frontend ADR and Design Docs to evaluate React technical choices. Use when frontend PRD is complete and technical design is needed, or when "frontend design/React design/UI design/component design" is mentioned.
 tools: Read, Write, Edit, MultiEdit, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
-skills: documentation-criteria, coding-principles, typescript-rules, frontend-ai-guide, implementation-approach, testing-principles, llm-friendly-context, external-resource-context
+skills:
+  - documentation-criteria
+  - coding-principles
+  - typescript-rules
+  - frontend-ai-guide
+  - implementation-approach
+  - testing-principles
+  - llm-friendly-context
+  - external-resource-context
 ---
 
 You are a frontend technical design specialist AI assistant for creating Architecture Decision Records (ADR) and Design Documents.

--- a/dev-workflows-fullstack/agents/technical-designer.md
+++ b/dev-workflows-fullstack/agents/technical-designer.md
@@ -2,7 +2,14 @@
 name: technical-designer
 description: Creates ADR and Design Docs to evaluate technical choices and implementation approaches. Use when PRD is complete and technical design is needed, or when "ADR/design doc/technical design/architecture" is mentioned.
 tools: Read, Write, Edit, MultiEdit, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
-skills: documentation-criteria, coding-principles, testing-principles, ai-development-guide, implementation-approach, llm-friendly-context, external-resource-context
+skills:
+  - documentation-criteria
+  - coding-principles
+  - testing-principles
+  - ai-development-guide
+  - implementation-approach
+  - llm-friendly-context
+  - external-resource-context
 ---
 
 You are a technical design specialist AI assistant for creating Architecture Decision Records (ADR) and Design Documents.

--- a/dev-workflows-fullstack/agents/ui-analyzer.md
+++ b/dev-workflows-fullstack/agents/ui-analyzer.md
@@ -2,7 +2,11 @@
 name: ui-analyzer
 description: Gathers UI-related facts by reading the project's external-resources file, fetching external sources (design origin, design system, guidelines) via MCP or URL, and analyzing the existing UI codebase. Use when frontend design or adjustment work needs a single consolidated UI context (external sources + code) before document creation or implementation.
 disallowedTools: Write, Edit, MultiEdit, NotebookEdit
-skills: typescript-rules, frontend-ai-guide, llm-friendly-context, external-resource-context
+skills:
+  - typescript-rules
+  - frontend-ai-guide
+  - llm-friendly-context
+  - external-resource-context
 ---
 
 You are an AI assistant specializing in UI fact gathering for frontend design and adjustment preparation.

--- a/dev-workflows-fullstack/agents/ui-spec-designer.md
+++ b/dev-workflows-fullstack/agents/ui-spec-designer.md
@@ -2,7 +2,12 @@
 name: ui-spec-designer
 description: Creates UI Specifications from PRD and optional prototype code. Use when PRD is complete and frontend UI design is needed, or when "UI spec/screen design/component decomposition/UI specification" is mentioned.
 tools: Read, Write, Edit, MultiEdit, Glob, LS, Bash, TaskCreate, TaskUpdate
-skills: documentation-criteria, typescript-rules, frontend-ai-guide, llm-friendly-context, external-resource-context
+skills:
+  - documentation-criteria
+  - typescript-rules
+  - frontend-ai-guide
+  - llm-friendly-context
+  - external-resource-context
 ---
 
 You are a UI specification specialist AI assistant for creating UI Specification documents.

--- a/dev-workflows-fullstack/agents/verifier.md
+++ b/dev-workflows-fullstack/agents/verifier.md
@@ -2,7 +2,9 @@
 name: verifier
 description: Critically evaluates investigation results, checks path coverage, and validates failure points using Devil's Advocate method. Use when investigation has completed, or when "verify/validate/double-check/confirm findings" is mentioned. Focuses on verification and conclusion derivation.
 tools: Read, Grep, Glob, LS, Bash, WebSearch, TaskCreate, TaskUpdate
-skills: ai-development-guide, coding-principles
+skills:
+  - ai-development-guide
+  - coding-principles
 ---
 
 You are an AI assistant specializing in investigation result verification.

--- a/dev-workflows-fullstack/agents/work-planner.md
+++ b/dev-workflows-fullstack/agents/work-planner.md
@@ -2,7 +2,13 @@
 name: work-planner
 description: Creates work plan documents with trackable execution plans. Use when Design Doc is complete and implementation planning is needed, or when "work plan/implementation plan/task planning" is mentioned.
 tools: Read, Write, Edit, MultiEdit, Glob, LS, TaskCreate, TaskUpdate
-skills: ai-development-guide, documentation-criteria, coding-principles, testing-principles, implementation-approach, llm-friendly-context
+skills:
+  - ai-development-guide
+  - documentation-criteria
+  - coding-principles
+  - testing-principles
+  - implementation-approach
+  - llm-friendly-context
 ---
 
 You are a specialized AI assistant for creating work plan documents.

--- a/dev-workflows/.claude-plugin/plugin.json
+++ b/dev-workflows/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflows",
   "description": "Skills + Subagents for backend development - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
-  "version": "0.22.3",
+  "version": "0.22.4",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows/agents/acceptance-test-generator.md
+++ b/dev-workflows/agents/acceptance-test-generator.md
@@ -2,7 +2,11 @@
 name: acceptance-test-generator
 description: Generates integration/E2E test skeletons from Design Doc ACs using ROI-based selection and journey-based E2E reservation. Use when Design Doc is complete and test design is needed, or when "test skeleton/AC/acceptance criteria" is mentioned. Behavior-first approach for minimal tests with maximum coverage.
 tools: Read, Write, Glob, LS, TaskCreate, TaskUpdate, Grep
-skills: testing-principles, documentation-criteria, integration-e2e-testing, llm-friendly-context
+skills:
+  - testing-principles
+  - documentation-criteria
+  - integration-e2e-testing
+  - llm-friendly-context
 ---
 
 You are a specialized AI that generates minimal, high-quality test skeletons from Design Doc Acceptance Criteria (ACs) and optional UI Spec. Your goal is **maximum coverage with minimum tests** through strategic selection, not exhaustive generation.

--- a/dev-workflows/agents/code-reviewer.md
+++ b/dev-workflows/agents/code-reviewer.md
@@ -2,7 +2,10 @@
 name: code-reviewer
 description: Validates Design Doc compliance and implementation completeness from third-party perspective. Use PROACTIVELY after implementation completes or when "review/implementation check/compliance" is mentioned. Provides acceptance criteria validation and quality reports.
 tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate
-skills: ai-development-guide, coding-principles, testing-principles
+skills:
+  - ai-development-guide
+  - coding-principles
+  - testing-principles
 ---
 
 You are a code review AI assistant specializing in Design Doc compliance validation.

--- a/dev-workflows/agents/code-verifier.md
+++ b/dev-workflows/agents/code-verifier.md
@@ -2,7 +2,10 @@
 name: code-verifier
 description: Validates consistency between PRD/Design Doc and code implementation. Use PROACTIVELY after implementation completes, or when "document consistency/implementation gap/as specified" is mentioned. Uses multi-source evidence matching to identify discrepancies.
 tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate
-skills: documentation-criteria, ai-development-guide, coding-principles
+skills:
+  - documentation-criteria
+  - ai-development-guide
+  - coding-principles
 ---
 
 You are an AI assistant specializing in document-code consistency verification.

--- a/dev-workflows/agents/codebase-analyzer.md
+++ b/dev-workflows/agents/codebase-analyzer.md
@@ -2,7 +2,10 @@
 name: codebase-analyzer
 description: Analyzes existing codebase objectively for facts about implementation, user behavior patterns, and technical architecture. Use when existing code needs to be understood without hypothesis bias. Invoked before Design Doc creation to produce focused guidance for technical designers.
 tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate
-skills: ai-development-guide, coding-principles, llm-friendly-context
+skills:
+  - ai-development-guide
+  - coding-principles
+  - llm-friendly-context
 ---
 
 You are an AI assistant specializing in existing codebase analysis for technical design preparation.

--- a/dev-workflows/agents/design-sync.md
+++ b/dev-workflows/agents/design-sync.md
@@ -2,7 +2,10 @@
 name: design-sync
 description: Detects conflicts across multiple Design Docs and provides structured reports. Use when multiple Design Docs exist, or when "consistency/conflict/sync/between documents" is mentioned. Focuses on detection and reporting only, no modifications.
 tools: Read, Grep, Glob, LS, TaskCreate, TaskUpdate
-skills: documentation-criteria, coding-principles, llm-friendly-context
+skills:
+  - documentation-criteria
+  - coding-principles
+  - llm-friendly-context
 ---
 
 You are an AI assistant specializing in consistency verification between Design Docs.

--- a/dev-workflows/agents/document-reviewer.md
+++ b/dev-workflows/agents/document-reviewer.md
@@ -2,7 +2,11 @@
 name: document-reviewer
 description: Reviews document consistency and completeness, providing approval decisions. Use PROACTIVELY after PRD/UI Spec/Design Doc/work plan creation, or when "document review/approval/check" is mentioned. Detects contradictions and rule violations with improvement suggestions.
 tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
-skills: documentation-criteria, coding-principles, testing-principles, llm-friendly-context
+skills:
+  - documentation-criteria
+  - coding-principles
+  - testing-principles
+  - llm-friendly-context
 ---
 
 You are an AI assistant specialized in technical document review.

--- a/dev-workflows/agents/integration-test-reviewer.md
+++ b/dev-workflows/agents/integration-test-reviewer.md
@@ -2,7 +2,9 @@
 name: integration-test-reviewer
 description: Verifies consistency between test skeleton comments and implementation code. Use PROACTIVELY after test implementation completes, or when "test review/skeleton verification" is mentioned. Returns quality reports with failing items and fix instructions.
 tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate
-skills: testing-principles, integration-e2e-testing
+skills:
+  - testing-principles
+  - integration-e2e-testing
 ---
 
 You are an AI assistant specializing in integration and E2E test quality review.

--- a/dev-workflows/agents/investigator.md
+++ b/dev-workflows/agents/investigator.md
@@ -2,7 +2,9 @@
 name: investigator
 description: Comprehensively collects problem-related information and creates evidence matrix. Use PROACTIVELY when bug/error/issue/defect/not working/strange behavior is reported. Reports only observations without proposing solutions.
 tools: Read, Grep, Glob, LS, Bash, WebSearch, TaskCreate, TaskUpdate
-skills: ai-development-guide, coding-principles
+skills:
+  - ai-development-guide
+  - coding-principles
 ---
 
 You are an AI assistant specializing in problem investigation.

--- a/dev-workflows/agents/prd-creator.md
+++ b/dev-workflows/agents/prd-creator.md
@@ -2,7 +2,9 @@
 name: prd-creator
 description: Creates PRD and structures business requirements. Use when new feature/project starts, or when "PRD/requirements definition/user story/what to build" is mentioned. Defines user value and success metrics.
 tools: Read, Write, Edit, MultiEdit, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
-skills: documentation-criteria, llm-friendly-context
+skills:
+  - documentation-criteria
+  - llm-friendly-context
 ---
 
 You are a specialized AI assistant for creating Product Requirements Documents (PRD).

--- a/dev-workflows/agents/quality-fixer.md
+++ b/dev-workflows/agents/quality-fixer.md
@@ -2,7 +2,11 @@
 name: quality-fixer
 description: Specialized agent for fixing quality issues in software projects. Executes all verification and fixing tasks related to code quality, correctness guarantees, testing, and building in a completely self-contained manner. Takes responsibility for fixing all quality errors until all tests pass. MUST BE USED PROACTIVELY when any quality-related keywords appear (quality/check/verify/test/build/lint/format/correctness/fix) or after code changes. Handles all verification and fixing tasks autonomously.
 tools: Bash, Read, Edit, MultiEdit, TaskCreate, TaskUpdate
-skills: coding-principles, testing-principles, ai-development-guide, external-resource-context
+skills:
+  - coding-principles
+  - testing-principles
+  - ai-development-guide
+  - external-resource-context
 ---
 
 You are an AI assistant specialized in quality assurance for software projects.

--- a/dev-workflows/agents/requirement-analyzer.md
+++ b/dev-workflows/agents/requirement-analyzer.md
@@ -2,7 +2,9 @@
 name: requirement-analyzer
 description: Performs requirements analysis and work scale determination. Use PROACTIVELY when new feature requests or change requests are received, or when "requirements/scope/where to start" is mentioned. Extracts user requirement essence and proposes development approaches.
 tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
-skills: ai-development-guide, documentation-criteria
+skills:
+  - ai-development-guide
+  - documentation-criteria
 ---
 
 You are a specialized AI assistant for requirements analysis and work scale determination.

--- a/dev-workflows/agents/rule-advisor.md
+++ b/dev-workflows/agents/rule-advisor.md
@@ -2,7 +2,8 @@
 name: rule-advisor
 description: Selects optimal rulesets for tasks and performs metacognitive analysis. Use PROACTIVELY before implementation tasks start, or when "rules/ruleset/coding standards" is mentioned. Returns structured JSON with recommended skills and rationale.
 tools: Read, Grep, LS
-skills: task-analyzer
+skills:
+  - task-analyzer
 ---
 
 You are an AI assistant specialized in rule selection. You analyze task nature using metacognitive approaches and return comprehensive, structured skill contents to maximize AI execution accuracy.

--- a/dev-workflows/agents/scope-discoverer.md
+++ b/dev-workflows/agents/scope-discoverer.md
@@ -2,7 +2,12 @@
 name: scope-discoverer
 description: Discovers functional scope from existing codebase for reverse documentation. Identifies targets through multi-source discovery combining user-value and technical perspectives. Use when "reverse engineering/existing code analysis/scope discovery" is mentioned.
 tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate
-skills: documentation-criteria, ai-development-guide, coding-principles, implementation-approach, llm-friendly-context
+skills:
+  - documentation-criteria
+  - ai-development-guide
+  - coding-principles
+  - implementation-approach
+  - llm-friendly-context
 ---
 
 You are an AI assistant specializing in codebase scope discovery for reverse documentation.

--- a/dev-workflows/agents/security-reviewer.md
+++ b/dev-workflows/agents/security-reviewer.md
@@ -2,7 +2,8 @@
 name: security-reviewer
 description: Reviews implementation for security compliance against Design Doc security considerations. Use PROACTIVELY after all implementation tasks complete, or when "security review/security check/vulnerability check" is mentioned. Returns structured findings with risk classification and fix suggestions.
 tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
-skills: coding-principles
+skills:
+  - coding-principles
 ---
 
 You are an AI assistant specializing in security review of implemented code.

--- a/dev-workflows/agents/solver.md
+++ b/dev-workflows/agents/solver.md
@@ -2,7 +2,10 @@
 name: solver
 description: Derives multiple solutions for verified causes and analyzes tradeoffs. Use when root cause verification has concluded, or when "solution/how to fix/fix method/remedy" is mentioned. Focuses on solutions from given conclusions without investigation.
 tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
-skills: ai-development-guide, coding-principles, implementation-approach
+skills:
+  - ai-development-guide
+  - coding-principles
+  - implementation-approach
 ---
 
 You are an AI assistant specializing in solution derivation.

--- a/dev-workflows/agents/task-decomposer.md
+++ b/dev-workflows/agents/task-decomposer.md
@@ -2,7 +2,13 @@
 name: task-decomposer
 description: Reads work plan documents from docs/plans and decomposes them into independent, single-commit granularity tasks placed in docs/plans/tasks. PROACTIVELY proposes task decomposition when work plans are created.
 tools: Read, Write, LS, Bash, TaskCreate, TaskUpdate
-skills: ai-development-guide, documentation-criteria, testing-principles, coding-principles, implementation-approach, llm-friendly-context
+skills:
+  - ai-development-guide
+  - documentation-criteria
+  - testing-principles
+  - coding-principles
+  - implementation-approach
+  - llm-friendly-context
 ---
 
 You are an AI assistant specialized in decomposing work plans into executable tasks.

--- a/dev-workflows/agents/task-executor.md
+++ b/dev-workflows/agents/task-executor.md
@@ -2,7 +2,12 @@
 name: task-executor
 description: Executes implementation completely self-contained following task files. Use when task files exist in docs/plans/tasks/, or when "execute task/implement task/start implementation" is mentioned. Asks no questions, executes consistently from investigation to implementation.
 tools: Read, Edit, Write, MultiEdit, Bash, Grep, Glob, LS, TaskCreate, TaskUpdate
-skills: coding-principles, testing-principles, ai-development-guide, implementation-approach, external-resource-context
+skills:
+  - coding-principles
+  - testing-principles
+  - ai-development-guide
+  - implementation-approach
+  - external-resource-context
 ---
 
 You are a specialized AI assistant for reliably executing individual tasks.

--- a/dev-workflows/agents/technical-designer.md
+++ b/dev-workflows/agents/technical-designer.md
@@ -2,7 +2,14 @@
 name: technical-designer
 description: Creates ADR and Design Docs to evaluate technical choices and implementation approaches. Use when PRD is complete and technical design is needed, or when "ADR/design doc/technical design/architecture" is mentioned.
 tools: Read, Write, Edit, MultiEdit, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
-skills: documentation-criteria, coding-principles, testing-principles, ai-development-guide, implementation-approach, llm-friendly-context, external-resource-context
+skills:
+  - documentation-criteria
+  - coding-principles
+  - testing-principles
+  - ai-development-guide
+  - implementation-approach
+  - llm-friendly-context
+  - external-resource-context
 ---
 
 You are a technical design specialist AI assistant for creating Architecture Decision Records (ADR) and Design Documents.

--- a/dev-workflows/agents/verifier.md
+++ b/dev-workflows/agents/verifier.md
@@ -2,7 +2,9 @@
 name: verifier
 description: Critically evaluates investigation results, checks path coverage, and validates failure points using Devil's Advocate method. Use when investigation has completed, or when "verify/validate/double-check/confirm findings" is mentioned. Focuses on verification and conclusion derivation.
 tools: Read, Grep, Glob, LS, Bash, WebSearch, TaskCreate, TaskUpdate
-skills: ai-development-guide, coding-principles
+skills:
+  - ai-development-guide
+  - coding-principles
 ---
 
 You are an AI assistant specializing in investigation result verification.

--- a/dev-workflows/agents/work-planner.md
+++ b/dev-workflows/agents/work-planner.md
@@ -2,7 +2,13 @@
 name: work-planner
 description: Creates work plan documents with trackable execution plans. Use when Design Doc is complete and implementation planning is needed, or when "work plan/implementation plan/task planning" is mentioned.
 tools: Read, Write, Edit, MultiEdit, Glob, LS, TaskCreate, TaskUpdate
-skills: ai-development-guide, documentation-criteria, coding-principles, testing-principles, implementation-approach, llm-friendly-context
+skills:
+  - ai-development-guide
+  - documentation-criteria
+  - coding-principles
+  - testing-principles
+  - implementation-approach
+  - llm-friendly-context
 ---
 
 You are a specialized AI assistant for creating work plan documents.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-workflows",
-  "version": "0.22.3",
+  "version": "0.22.4",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary

Converts the `skills` field in every agent definition from a comma-separated scalar to a YAML list, aligning with the format documented for subagent frontmatter in the Claude Code docs. The `tools` field is intentionally left comma-separated, per its own documented form.

## Why

Both forms load today, but the official subagent docs present `skills` as a YAML list while `tools` is shown comma-separated. Matching each field to its documented canonical form is the safer choice if parsing is ever tightened.

## Changes

- Canonical `agents/*.md` (25 files): `skills` rewritten as a YAML list. Skill names are unchanged — a purely mechanical comma → list conversion.
- Plugin subdirectories (`dev-workflows`, `dev-workflows-frontend`, `dev-workflows-fullstack`, `dev-skills`) regenerated via `npm run sync`.
- Patch version bumped `0.22.3 → 0.22.4` in `package.json` and `.claude-plugin/marketplace.json`.

## Verification

- Static: all 25 canonical files parse as well-formed YAML lists; every value is identical to the previous comma-separated values (no loss/reorder/mangle).
- Runtime: confirmed skills load and are applied in live subagent sessions for both a multi-item list (`requirement-analyzer`: `ai-development-guide`, `documentation-criteria`) and a single-item list (`rule-advisor`: `task-analyzer`).
- `npm run sync:check` clean; `claude plugin validate` passes for the marketplace and all four plugins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)