### PR TITLE
Simplify review status convergence

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "dev-workflows",
       "source": "./dev-workflows",
       "strict": true,
-      "version": "0.24.1",
+      "version": "0.24.2",
       "description": "Skills + Subagents for backend development - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
       "author": {
         "name": "Shinsuke Kagawa",
@@ -82,7 +82,7 @@
       "name": "dev-workflows-frontend",
       "source": "./dev-workflows-frontend",
       "strict": true,
-      "version": "0.24.1",
+      "version": "0.24.2",
       "description": "Skills + Subagents for React/TypeScript - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
       "author": {
         "name": "Shinsuke Kagawa",
@@ -155,7 +155,7 @@
       "name": "dev-workflows-fullstack",
       "source": "./dev-workflows-fullstack",
       "strict": true,
-      "version": "0.24.1",
+      "version": "0.24.2",
       "description": "Skills + Subagents for fullstack development (backend + React/TypeScript) - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
       "author": {
         "name": "Shinsuke Kagawa",
@@ -244,7 +244,7 @@
       "name": "dev-skills",
       "source": "./dev-skills",
       "strict": true,
-      "version": "0.24.1",
+      "version": "0.24.2",
       "description": "Lightweight skills for users with existing workflows - coding best practices, testing principles, and design guidelines without recipe workflows or agents",
       "author": {
         "name": "Shinsuke Kagawa",

--- a/agents/acceptance-test-generator.md
+++ b/agents/acceptance-test-generator.md
@@ -19,7 +19,7 @@ Operates in an independent context, executing autonomously until task completion
 
 ### Implementation Approach Compliance
 - **Test Code Generation**: MUST strictly comply with Design Doc implementation patterns (function vs class selection)
-- **Contract Safety**: MUST enforce testing-principles skill mock creation and contract definition rules without exception
+- **Contract Safety**: Apply the testing-principles skill mock creation and contract definition rules to every generated skeleton
 
 ## Input Parameters
 
@@ -50,7 +50,7 @@ Test type definitions, budgets, and ROI calculations are specified in **integrat
 | **System Context** | Requires full system integration? | Skip | [UNIT_LEVEL] |
 | **Upstream Scope** | In Include list? | Skip | [OUT_OF_SCOPE] |
 
-**AC Include/Exclude Criteria**:
+**AC Selection Criteria**:
 
 **Include** (High automation ROI):
 - Business logic correctness (calculations, state transitions, data transformations)
@@ -58,7 +58,7 @@ Test type definitions, budgets, and ROI calculations are specified in **integrat
 - User-visible functionality completeness
 - Error handling behavior (what user sees/experiences)
 
-**Exclude** (Low ROI in LLM/CI/CD environment):
+**Use alternative verification** (Low ROI in LLM/CI/CD environment):
 - External service real connections → Use contract/interface verification instead
 - Performance metrics → Non-deterministic in CI, defer to load testing
 - Implementation details → Focus on observable behavior
@@ -116,7 +116,7 @@ ROI calculation formula and cost table are defined in **integration-e2e-testing 
      - A downstream service receives a real event/message (e.g., topic publish, queue enqueue, webhook call)
      - An external service receives a real API call with the expected payload
      - Transactional consistency across services (e.g., two-phase commit, saga compensation)
-5. **Sort by ROI** within each lane using the score and tie-break order from integration-e2e-testing skill — this is the single ranking step; Phase 4 budget enforcement consumes this ranked list directly without re-sorting.
+5. **Sort by ROI** within each lane using the score and tie-break order from integration-e2e-testing skill — this is the single ranking step, and Phase 4 budget enforcement processes the ranked list in the order produced here.
 
 **Output**: Ranked, deduplicated candidate list with lane assigned per E2E candidate.
 

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -124,7 +124,7 @@ For each function/method in implementation files, check against coding-principle
 #### 3-3. Test Coverage for Acceptance Criteria
 - For each AC marked fulfilled: Glob/Grep for corresponding test cases
 - Record which ACs have test coverage and which do not
-- For each test claimed as AC coverage, inspect the test body and confirm at least one assertion exercises the AC's observable behavior. Tests that are `skip`/`xit`-marked (on tests that should run), contain only TODO/placeholder bodies, or use always-true assertions (e.g., `expect(true).toBe(true)`, `expect(arr.length).toBeGreaterThanOrEqual(0)`) do not count as AC coverage even when grep finds them; record those as `coverage_gap` with rationale explaining the substance issue. Tests verifying intentional absence (e.g., empty list, null result) are substantive when the absence is the AC's expectation.
+- For each test claimed as AC coverage, inspect the test body and count it as coverage only when at least one assertion exercises the AC's observable behavior. Record `skip`/`xit`-marked tests that should run, TODO/placeholder-only bodies, and always-true assertions (e.g., `expect(true).toBe(true)`, `expect(arr.length).toBeGreaterThanOrEqual(0)`) as `coverage_gap` even when grep finds them, with rationale explaining the substance issue. Tests verifying intentional absence (e.g., empty list, null result) are substantive when the absence is the AC's expectation.
 - Beyond substance, confirm each AC test exercises the claimed boundary and would turn red if the promised behavior regressed. When a task file is in scope, verify its Operation Verification Methods and optional Verification Focus. Missing required evidence is a `coverage_gap`.
 
 #### Finding Classification

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -71,7 +71,7 @@ When `prior_feedback` is present, complete the correction re-review here:
 
 For each acceptance criterion extracted in Step 1:
 - Search implementation files for the corresponding code
-- Determine status: fulfilled / partially fulfilled / unfulfilled
+- Mark it `fulfilled` only when evidence covers every governing boundary path; otherwise mark it `unfulfilled` and name each uncovered path in `gap`
 - Record the file path and relevant code location
 - Note any deviations from the Design Doc specification
 - For behavior-changing ACs, confirm the evidence covers the boundary paths, not only the main path: where a distinct branch, state, input class, lifecycle step, or fallback governs the behavior, verify it is exercised. Compare the source/referenced behavior and the implemented behavior at the same granularity; an unsupported change in a boundary dimension is a `dd_violation`
@@ -185,13 +185,13 @@ Verify against the Design Doc architecture:
 verdict:              string ("pass" | "needs-improvement" | "needs-redesign")
 
 acceptanceCriteria[].item:        string
-acceptanceCriteria[].id:          string (required only when status is not fulfilled; stable within this review chain)
-acceptanceCriteria[].status:      string ("fulfilled" | "partially_fulfilled" | "unfulfilled")
+acceptanceCriteria[].id:          string (required only when status is unfulfilled; stable within this review chain)
+acceptanceCriteria[].status:      string ("fulfilled" | "unfulfilled")
 acceptanceCriteria[].confidence:  string ("high" | "medium" | "low")
 acceptanceCriteria[].location:    string (file:line; null if unimplemented)
 acceptanceCriteria[].evidence:    string[] (each "source: file:line")
-acceptanceCriteria[].gap:         string (null when fully fulfilled)
-acceptanceCriteria[].suggestion:  string (null when fully fulfilled)
+acceptanceCriteria[].gap:         string (null when status is fulfilled)
+acceptanceCriteria[].suggestion:  string (null when status is fulfilled)
 
 identifierVerification[].identifier:    string
 identifierVerification[].id:            string (required only when match is false; stable within this review chain)

--- a/agents/code-verifier.md
+++ b/agents/code-verifier.md
@@ -54,9 +54,9 @@ Stop expanding the search when additional evidence cannot change a discrepancy o
 - `conflict`: Observed behavior or a governing contract contradicts the document.
 - `unverified`: Available evidence cannot establish the claim; state the exact limitation and effect.
 
-Use `critical` only when the issue makes approved scope incorrect, non-executable, or non-verifiable. Use `major` for a material correction and `minor` for non-blocking precision. Group locations that share one cause and correction into one discrepancy.
+Emit a discrepancy only when leaving it unresolved can change scope, feasibility, implementation, a contract, or verification. Group locations that share one cause and correction into one discrepancy.
 
-Use `unverified` only for a specific material document claim whose unresolved truth can change scope, feasibility, implementation, a contract, or verification; assign it `critical` or `major`. Use `limitations` only for an evidence-access or coverage constraint that does not itself identify a material document claim. Record a fact in one place, not both; a material limitation becomes an `unverified` discrepancy.
+Use `unverified` only for a specific material document claim whose unresolved truth can change scope, feasibility, implementation, a contract, or verification. Use `limitations` only for an evidence-access or coverage constraint that does not itself identify a material document claim. Record a fact in one place, not both; a material limitation becomes an `unverified` discrepancy.
 
 ## Output
 
@@ -64,11 +64,11 @@ Return exactly one JSON object:
 
 ```json
 {
-  "summary": {"docType": "design-doc", "documentPath": "docs/design/example.md", "status": "consistent|mostly_consistent|needs_review|inconsistent|blocked"},
+  "summary": {"docType": "design-doc", "documentPath": "docs/design/example.md", "status": "consistent|needs_review|inconsistent|blocked"},
   "blockingReason": null,
   "inventoryCoverage": null,
   "discrepancies": [
-    {"id": "D001", "status": "drift|gap|conflict|unverified", "severity": "critical|major|minor", "claim": "document claim", "documentLocation": "section or line", "codeLocation": "file:line or null", "relatedLocations": ["other location with the same cause"], "evidence": "observed fact", "effect": "why this changes scope, feasibility, implementation, contract, or verification"}
+    {"id": "D001", "status": "drift|gap|conflict|unverified", "claim": "document claim", "documentLocation": "section or line", "codeLocation": "file:line or null", "relatedLocations": ["other location with the same cause"], "evidence": "observed fact", "effect": "why this changes scope, feasibility, implementation, contract, or verification"}
   ],
   "limitations": ["exact evidence-access or coverage constraint and its verification effect"]
 }
@@ -86,12 +86,11 @@ When `unit_inventory` is supplied, replace `inventoryCoverage: null` with this o
 
 For each inventory category, `accountedCount + excluded.length + unaccounted.length` equals `inputCount`. Report every unaccounted item as one cause-grouped `gap` discrepancy.
 
-An unaccounted inventory item makes `consistent` and `mostly_consistent` invalid; use at least `needs_review`. When the supplied inventory cannot be parsed or the counts cannot be made balanced from it, use `blocked` and state the exact input defect.
+An unaccounted inventory item makes `consistent` invalid; use at least `needs_review`. When the supplied inventory cannot be parsed or the counts cannot be made balanced from it, use `blocked` and state the exact input defect.
 
 Status rules:
 
-- `consistent`: no discrepancy or material limitation exists;
-- `mostly_consistent`: only minor precision issues or non-material coverage limitations remain, and inventory has no unaccounted item;
+- `consistent`: no discrepancy exists;
 - `needs_review`: a repairable material discrepancy, including any `unverified` discrepancy, exists;
 - `inconsistent`: governing evidence contradicts the selected outcome or contract;
 - `blocked`: required input or repository evidence is unusable for the requested verification.

--- a/agents/integration-test-reviewer.md
+++ b/agents/integration-test-reviewer.md
@@ -78,7 +78,7 @@ Evaluate each test for:
 - Clear Arrange section (setup)
 - Single Act (action)
 - Meaningful Assert (verification)
-- Substantive assertion: each test must execute at least one assertion that observes the AC's behavior. Always-true assertions (e.g., `expect(true).toBe(true)`, `expect(arr.length).toBeGreaterThanOrEqual(0)`), TODO-only bodies, or leftover `skip`/`xit` markers on tests that should run do not count as substantive evidence. Tests verifying intentional absence (e.g., `expect(queryAllBy*).toHaveLength(0)`) are substantive when the absence is the AC's expectation
+- Substantive assertion: classify a test as substantive only when it executes at least one assertion that observes the AC's behavior. Classify always-true assertions (e.g., `expect(true).toBe(true)`, `expect(arr.length).toBeGreaterThanOrEqual(0)`), TODO-only bodies, and leftover `skip`/`xit` markers on tests that should run as insufficient evidence. Tests verifying intentional absence (e.g., `expect(queryAllBy*).toHaveLength(0)`) are substantive when the absence is the AC's expectation
 - Isolated state per test (reset in beforeEach)
 - Deterministic execution (mock time/random sources when needed)
 

--- a/agents/investigator.md
+++ b/agents/investigator.md
@@ -1,6 +1,6 @@
 ---
 name: investigator
-description: Comprehensively collects problem-related information and creates evidence matrix. Use PROACTIVELY when bug/error/issue/defect/not working/strange behavior is reported. Reports only observations without proposing solutions.
+description: Comprehensively collects problem-related information and creates evidence matrix. Use PROACTIVELY when bug/error/issue/defect/not working/strange behavior is reported. Reports observations and evidence for downstream cause verification.
 tools: Read, Grep, Glob, LS, Bash, WebSearch, TaskCreate, TaskUpdate
 skills:
   - ai-development-guide
@@ -79,7 +79,7 @@ For each node listed in the path map, check whether there is a fault. A node is 
 - It contains an inconsistency that can explain the user-reported symptom
 
 If a fault is found, record it as a failure point with the required fields (see Output Format).
-- **Do NOT stop after finding the first fault** — check all remaining nodes on all mapped paths
+- After finding a fault, continue through every remaining node on all mapped paths
 - A single symptom can have multiple failure points at different layers
 
 For each failure point found:
@@ -129,7 +129,7 @@ Disclose unexplored areas and investigation limitations.
     {
       "type": "code|history|dependency|config|document|external",
       "location": "Location investigated",
-      "findings": "Facts discovered (without interpretation)"
+      "findings": "Observed facts"
     }
   ],
   "externalResearch": [

--- a/agents/quality-fixer-frontend.md
+++ b/agents/quality-fixer-frontend.md
@@ -52,7 +52,7 @@ Use the indicators below for this review.
 - Functions with TODO comments but whose current logic is functionally correct
 - Legitimate empty returns or default values that match the expected behavior
 
-**If any incomplete implementation is found**: Stop immediately. Return `status: "stub_detected"` without proceeding to quality checks (see Output Format).
+**If any incomplete implementation is found**: Stop at Step 1 and return `status: "stub_detected"` (see Output Format).
 
 **If no incomplete implementation is found**: Proceed to Step 2.
 

--- a/agents/quality-fixer.md
+++ b/agents/quality-fixer.md
@@ -46,7 +46,7 @@ Use the indicators below for this review.
 
 **Legitimate patterns** (treat as complete; proceed to Step 2): intentionally minimal implementations, functions with TODO comments but functionally correct logic, and legitimate empty/default returns that match the expected behavior.
 
-**If any incomplete implementation is found**: Stop immediately. Return `status: "stub_detected"` without proceeding to quality checks (see Output Format).
+**If any incomplete implementation is found**: Stop at Step 1 and return `status: "stub_detected"` (see Output Format).
 
 **If no incomplete implementation is found**: Proceed to Step 2.
 

--- a/agents/scope-discoverer.md
+++ b/agents/scope-discoverer.md
@@ -247,7 +247,7 @@ Includes additional fields:
 Run each item below before producing the final JSON. When any item is unsatisfied, return to the relevant Step and complete it before producing the JSON output.
 
 - [ ] Output is limited to scope discovery (no PRD or Design Doc content generated)
-- [ ] Every discovery is backed by evidence (no assumptions without sources)
+- [ ] Every discovery cites its source evidence
 - [ ] Low-confidence discoveries are reported with appropriate confidence markers
 - [ ] Triangulation strength reflects actual source count (weak noted when single-source)
 - [ ] Saturation check was performed before concluding discovery

--- a/agents/security-reviewer.md
+++ b/agents/security-reviewer.md
@@ -91,18 +91,14 @@ Consolidate all findings, remove duplicates, and classify each finding into one 
 
 | Category | Definition | Examples |
 |----------|-----------|----------|
-| **confirmed_risk** | Attack surface is exploitable as-is, post-filter conclusion with high confidence | Missing authentication on endpoint, arbitrary file access, SQL injection via string concatenation |
-| **suspected_risk** | Attack surface plausible but exploitability uncertain or partially mitigated; downgrade target from confirmed_risk when confidence drops | Potential SSRF behind a network ACL of unknown coverage; auth bypass possible only under specific framework configuration |
-| **defense_gap** | Not immediately exploitable, but a defensive layer is thin or absent | Runtime type validation missing (framework may catch it), unnecessary capability enabled |
-| **hardening** | Improvement to reduce attack surface or exposure | Reducing log verbosity, tightening error response content |
-| **policy** | Organizational or operational practice concern | Dependency version pinning strategy, CI security scanning coverage |
+| **confirmed_risk** | Attack surface is exploitable as-is, post-filter conclusion | Missing authentication on endpoint, arbitrary file access, SQL injection via string concatenation |
+| **defense_gap** | A governing security requirement or in-scope security boundary lacks a required defensive control | Runtime type validation missing at an input boundary, unnecessary capability enabled |
 
 Evaluate every finding against the project's runtime environment, framework protections, and existing mitigations. Apply the following rules per category:
 
-- For findings initially judged as `confirmed_risk` whose exploitability becomes uncertain or partially mitigated by existing defenses: downgrade to `defense_gap` or `suspected_risk` instead of discarding. Attach a `confidence` field (`high` / `medium` / `low`) and a `rationale` explaining the downgrade.
-- Reserve `confirmed_risk` for findings where the attack surface is exploitable as-is with high confidence. The category represents post-filter conclusions, not raw observations.
-- For `defense_gap`, `hardening`, and `policy` findings: evaluate whether they represent an actual risk and discard items that do not.
-- Populate `requiredFixes` only with `confirmed_risk` and high-confidence `defense_gap` items. Lower-confidence findings appear in the `findings` array without inclusion in `requiredFixes`.
+- Emit a finding only when current evidence shows a correction is required to satisfy a governing security requirement or protect an in-scope security boundary. Exclude optional hardening, organizational policy, and speculative observations that do not meet this condition.
+- Reserve `confirmed_risk` for findings where the attack surface is exploitable as-is. The category represents post-filter conclusions, not raw observations.
+- Emit a `defense_gap` only when current evidence shows that a governing security requirement or in-scope security boundary lacks a required defensive control.
 - Give every finding a stable ID.
 - Correction re-review follows Step 1-1 and emits one `prior_feedback_reconciliation` entry per received item using `resolved`, `withdrawn`, or `maintained`.
 
@@ -112,11 +108,8 @@ Each finding must include a `rationale` field whose content depends on the categ
 
 | Category | Rationale must explain |
 |----------|----------------------|
-| **confirmed_risk** | Why the attack surface is exploitable as-is, and why filter/downgrade did not apply |
-| **suspected_risk** | What conditions make exploitability uncertain, what additional information would resolve the ambiguity |
-| **defense_gap** | What defensive layer is being relied upon, and why it may be insufficient |
-| **hardening** | Why the current state is acceptable, and what improvement would add |
-| **policy** | Why this is not a technical vulnerability (what mitigates the technical risk) |
+| **confirmed_risk** | Why the attack surface is exploitable as-is and why existing mitigations do not remove that exploitability |
+| **defense_gap** | Which required defensive control is missing or insufficient and which boundary it protects |
 
 ## Output Format
 
@@ -125,32 +118,25 @@ Each finding must include a `rationale` field whose content depends on the categ
 - During execution, intermediate progress messages MAY be emitted as plain text or markdown.
 - The LAST message returned to the orchestrator MUST be a single JSON object that matches the schema below.
 - Emit the JSON object as the entire content of the final message: the message begins with `{` and ends with `}`.
-- For correction re-review, emit only `status`, `summary`, and `prior_feedback_reconciliation`; when a blocked trigger is observed, also emit its `findings` and `requiredFixes`.
+- For correction re-review, emit only `status`, `summary`, and `prior_feedback_reconciliation`; when a blocked trigger is observed, also emit its `findings`.
 
 ### Output Completion Gate
 
-Before returning the final JSON:
-1. Emit `findings` and `requiredFixes` for every status; each finding contains every field in the schema below.
-2. Derive both arrays and `status` from the consolidated findings and Status Determination.
+Before returning the final JSON, emit `findings` for every status with every field in the schema below, then derive `status` from the consolidated findings and blocked conditions.
 
 ```json
 {
-  "status": "approved|approved_with_notes|needs_revision|blocked",
+  "status": "approved|needs_revision|blocked",
   "summary": "[1-2 sentence summary]",
   "findings": [
     {
       "id": "S001",
-      "category": "confirmed_risk|suspected_risk|defense_gap|hardening|policy",
-      "confidence": "high|medium|low",
+      "category": "confirmed_risk|defense_gap",
       "location": "[file:line]",
       "description": "[specific issue found]",
       "rationale": "[category-specific, see Category-Specific Rationale]",
       "suggestion": "[specific fix]"
     }
-  ],
-  "notes": "[summary of hardening/policy findings for completion report, present when status is approved_with_notes]",
-  "requiredFixes": [
-    "[specific fix 1 — only confirmed_risk and qualifying defense_gap items]"
   ]
 }
 ```
@@ -160,25 +146,15 @@ When `prior_feedback` is present, also include `prior_feedback_reconciliation` w
 ## Status Determination
 
 ### blocked
+- Governing documents fail the Step 1 input gate
 - Credentials, API keys, or tokens found in committed code
-- High-confidence confirmed_risk that enables direct exploitation (missing authentication on public endpoint, arbitrary file access)
-- Escalate immediately with finding details — requires human intervention
+- Escalate immediately with the blocking reason and any finding details — requires human intervention
 
 ### needs_revision
-- One or more confirmed_risk findings
-- Multiple defense_gap findings that affect primary input boundaries
-- One or more high-confidence suspected_risk findings affecting primary input boundaries (auth, input boundaries, data persistence)
-- `requiredFixes` lists only confirmed_risk and qualifying defense_gap items
-
-### approved_with_notes
-- Findings are limited to hardening, policy, and/or suspected_risk (medium or low confidence) categories
-- Or defense_gap findings exist but are isolated and do not affect primary input boundaries
-- suspected_risk findings (medium/low confidence, or not on primary boundary) are listed in `notes` with the conditions that would resolve their ambiguity
-- Notes are included in the completion report for awareness
+- One or more findings require correction
 
 ### approved
-- No meaningful findings after consolidation
-- Any suspected_risk found has been resolved (downgraded to defense_gap then discarded, or upgraded to confirmed_risk and routed elsewhere)
+- No finding requires correction after consolidation
 
 ## Quality Checklist
 
@@ -187,9 +163,8 @@ When `prior_feedback` is present, also include `prior_feedback_reconciliation` w
 - [ ] All Stable Patterns from security-checks.md searched
 - [ ] All Trend-Sensitive Patterns from security-checks.md searched
 - [ ] Technology stack trend check performed
-- [ ] Each finding classified into confirmed_risk / suspected_risk / defense_gap / hardening / policy
-- [ ] suspected_risk findings have confidence (high/medium/low) and a rationale stating what would resolve the ambiguity
-- [ ] suspected_risk findings routed to status per Status Determination (high-confidence on primary boundary → needs_revision; otherwise → approved_with_notes)
+- [ ] Each finding classified into confirmed_risk / defense_gap
+- [ ] Every finding requires correction; optional hardening, policy, and non-blocking speculation were excluded
 - [ ] False positives excluded considering runtime environment and existing mitigations
 - [ ] Committed secrets checked (blocked status if found)
 - [ ] Every finding has a stable ID

--- a/agents/security-reviewer.md
+++ b/agents/security-reviewer.md
@@ -96,7 +96,7 @@ Consolidate all findings, remove duplicates, and classify each finding into one 
 
 Evaluate every finding against the project's runtime environment, framework protections, and existing mitigations. Apply the following rules per category:
 
-- Emit a finding only when current evidence shows a correction is required to satisfy a governing security requirement or protect an in-scope security boundary. Exclude optional hardening, organizational policy, and speculative observations that do not meet this condition.
+- Emit a finding only when current evidence shows a correction is required to satisfy a governing security requirement or protect an in-scope security boundary.
 - Reserve `confirmed_risk` for findings where the attack surface is exploitable as-is. The category represents post-filter conclusions, not raw observations.
 - Emit a `defense_gap` only when current evidence shows that a governing security requirement or in-scope security boundary lacks a required defensive control.
 - Give every finding a stable ID.
@@ -108,7 +108,7 @@ Each finding must include a `rationale` field whose content depends on the categ
 
 | Category | Rationale must explain |
 |----------|----------------------|
-| **confirmed_risk** | Why the attack surface is exploitable as-is and why existing mitigations do not remove that exploitability |
+| **confirmed_risk** | Why the attack surface is exploitable as-is and remains exploitable after applying existing mitigations |
 | **defense_gap** | Which required defensive control is missing or insufficient and which boundary it protects |
 
 ## Output Format
@@ -164,8 +164,8 @@ When `prior_feedback` is present, also include `prior_feedback_reconciliation` w
 - [ ] All Trend-Sensitive Patterns from security-checks.md searched
 - [ ] Technology stack trend check performed
 - [ ] Each finding classified into confirmed_risk / defense_gap
-- [ ] Every finding requires correction; optional hardening, policy, and non-blocking speculation were excluded
-- [ ] False positives excluded considering runtime environment and existing mitigations
+- [ ] The findings array contains only items that require correction
+- [ ] Every finding remains valid after considering the runtime environment and existing mitigations
 - [ ] Committed secrets checked (blocked status if found)
 - [ ] Every finding has a stable ID
 - [ ] When prior feedback is present, every received ID appears once in `prior_feedback_reconciliation`

--- a/agents/task-executor-frontend.md
+++ b/agents/task-executor-frontend.md
@@ -63,7 +63,7 @@ Escalation thresholds:
 
 ### Step4: Core Mechanism Preservation Check (Any YES → Immediate Escalation)
 Preserve the core mechanism the task, AC, Design Doc, or UI Spec requires. Implementation details (variable names, internal logic order, local structure) stay free to change; the required mechanism itself stays intact.
-□ Required core mechanism replaced by a simpler or weaker substitute? (passing tests do not make a substitute acceptable)
+□ Required core mechanism replaced by a simpler or weaker substitute, including one justified only by passing tests?
 □ Required core mechanism infeasible as specified?
 Any YES → stop and escalate with `escalation_type: "design_compliance_violation"`, recording the required mechanism, the proposed alternative, the resulting change in behavior, and the condition that would lift the block.
 
@@ -208,7 +208,7 @@ Return the final response per Structured Response Specification. For research/an
 **mutationEvidence**: Use `[]` when no mutation verification ran; otherwise populate every field in the schema below with revision-bound evidence.
 
 ### 1. Task Completion Response
-Report in the following JSON format upon task completion (**without executing quality checks or commits**, delegating to quality assurance process):
+Complete this agent's work by returning the following JSON; the quality assurance process performs quality checks and commits:
 
 ```json
 {
@@ -331,7 +331,7 @@ This gate runs immediately before producing the final JSON response.
 ☐ Implementation is consistent with the Investigation Notes recorded at Step 2 (when Investigation Targets were present)
 ☐ Adjacent Case Sweep evidence records each inspected case and disposition, or the searched surface and no-case result, when the current task triggers the sweep
 ☐ Every Operation Verification Method succeeds and Verification Focus is satisfied when present
-☐ When test runs are cited as `runnableCheck` evidence, they are substantive and executable per the runnableCheck.result field spec (skipped tests, placeholder/TODO-only bodies, always-passing assertions, and 0-match runner reports do not count); non-test verification (build/typecheck/CLI) is not subject to this check
+☐ Test runs cited as `runnableCheck` evidence meet the substantive and executable rules in the `runnableCheck.result` field specification
 ☐ Final response is a single JSON with `status: "completed"` or `status: "escalation_needed"` and matches the schema in Structured Response Specification
 
 **ENFORCEMENT**: When any gate item is unchecked, return `escalation_needed` with `escalation_type: "design_compliance_violation"` for incomplete work or divergence from governing sources and Investigation Notes.

--- a/agents/task-executor.md
+++ b/agents/task-executor.md
@@ -58,7 +58,7 @@ Escalation thresholds:
 
 ### Step4: Core Mechanism Preservation Check (Any YES → Immediate Escalation)
 Preserve the core mechanism the task, AC, Design Doc, or referenced materials require. Implementation details (variable names, internal ordering, local structure) stay free to change; the required mechanism itself stays intact.
-□ Required core mechanism replaced by a simpler or weaker substitute? (passing tests do not make a substitute acceptable)
+□ Required core mechanism replaced by a simpler or weaker substitute, including one justified only by passing tests?
 □ Required core mechanism infeasible as specified?
 Any YES → stop and escalate with `escalation_type: "design_compliance_violation"`, recording the required mechanism, the proposed alternative, the resulting change in behavior, and the condition that would lift the block.
 
@@ -205,7 +205,7 @@ Return the final response per Structured Response Specification. For research/an
 **mutationEvidence**: Use `[]` when no mutation verification ran; otherwise populate every field in the schema below with revision-bound evidence.
 
 ### 1. Task Completion Response
-Report in the following JSON format upon task completion (**without executing quality checks or commits**, delegating to quality assurance process):
+Complete this agent's work by returning the following JSON; the quality assurance process performs quality checks and commits:
 
 ```json
 {
@@ -326,7 +326,7 @@ This gate runs immediately before producing the final JSON response.
 ☐ Implementation is consistent with the Investigation Notes recorded at Step 2 (when Investigation Targets were present)
 ☐ Adjacent Case Sweep evidence records each inspected case and disposition, or the searched surface and no-case result, when the current task triggers the sweep
 ☐ Every Operation Verification Method succeeds and Verification Focus is satisfied when present
-☐ When test runs are cited as `runnableCheck` evidence, they are substantive and executable per the runnableCheck.result field spec (skipped tests, placeholder/TODO-only bodies, always-passing assertions, and 0-match runner reports do not count); non-test verification (build/typecheck/CLI) is not subject to this check
+☐ Test runs cited as `runnableCheck` evidence meet the substantive and executable rules in the `runnableCheck.result` field specification
 ☐ Final response is a single JSON with `status: "completed"` or `status: "escalation_needed"` and matches the schema in Structured Response Specification
 
 **ENFORCEMENT**: When any gate item is unchecked, return `escalation_needed` with `escalation_type: "design_compliance_violation"` for incomplete work or divergence from governing sources and Investigation Notes.

--- a/agents/verifier.md
+++ b/agents/verifier.md
@@ -40,7 +40,7 @@ Solution derivation is out of scope for this agent.
 - Grasp areas explicitly marked as uninvestigated
 
 **impactAnalysis Validity Check**:
-- Verify logical validity of impactAnalysis for each failure point (without additional searches)
+- Verify the logical validity of each failure point's impactAnalysis using only the supplied investigation evidence; perform additional searches in Step 2
 
 ### Step 2: Triangulation Supplementation
 Identify source types NOT covered in the investigation's `investigationSources`, then investigate at least one:
@@ -78,7 +78,7 @@ For each failure point, critically evaluate:
 - Official documentation of packages in use
 
 ### Step 6: Failure Point Evaluation and Consistency Verification
-Evaluate each failure point independently (do NOT select a single "winner"):
+Evaluate every failure point independently and allow multiple confirmed failure points:
 
 | finalStatus | Definition |
 |-------------|------------|
@@ -92,7 +92,7 @@ Evaluate each failure point independently (do NOT select a single "winner"):
 - Example: "The implementation is wrong" → Was design_gap considered?
 - If inconsistent, explicitly note "Investigation focus may be misaligned with user report"
 
-**Conclusion**: Evaluate each failure point individually. Multiple failure points can be simultaneously valid — do not force selection of a single root cause. For each pair of confirmed failure points, determine their relationship (independent / dependent / same_chain) and record in `failurePointRelationships`
+**Conclusion**: Evaluate each failure point individually and retain every supported cause. For each pair of confirmed failure points, determine their relationship (independent / dependent / same_chain) and record it in `failurePointRelationships`
 
 ## Coverage Assessment Criteria
 

--- a/dev-skills/.claude-plugin/plugin.json
+++ b/dev-skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-skills",
   "description": "Lightweight skills for users with existing workflows - coding best practices, testing principles, and design guidelines without recipe workflows or agents",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-skills/skills/ai-development-guide/SKILL.md
+++ b/dev-skills/skills/ai-development-guide/SKILL.md
@@ -280,7 +280,7 @@ Proceed when discovery and understanding cover the files and behaviors named by 
 When an artifact made obsolete by the requested change is detected:
 - Delete it in the same change when its callers and generated/operational uses are checked
 - Preserve and report it when obsolescence is uncertain or deletion would expand beyond the files and behaviors named by the user or current task/design artifact
-- Do not implement unrelated dormant code merely because it was discovered
+- Keep unrelated dormant code outside the implementation scope
 
 ### Existing Code Modification
 

--- a/dev-skills/skills/coding-principles/SKILL.md
+++ b/dev-skills/skills/coding-principles/SKILL.md
@@ -127,7 +127,7 @@ One comment per decision. If a comment restates what the names and control flow 
 - Delete commented-out code (retrieve from git history when needed)
 
 ### Comment Quality
-- Write comments that remain accurate regardless of future code changes; avoid references to dates, versions, or temporary state
+- Base comments on stable rationale, limits, and contracts rather than dates, versions, or temporary state
 - Update comments when changing code
 - Use proper grammar and formatting
 - Write for future maintainers
@@ -138,7 +138,7 @@ One comment per decision. If a comment restates what the names and control flow 
 - **Small steps**: Make one change at a time
 - **Maintain working state**: Keep tests passing
 - **Verify behavior**: Run tests after each change
-- **Incremental improvement**: Don't aim for perfection immediately
+- **Incremental improvement**: Make the smallest sufficient improvement in each increment
 
 ### Refactoring Triggers
 - Code duplication (DRY principle)

--- a/dev-skills/skills/documentation-criteria/SKILL.md
+++ b/dev-skills/skills/documentation-criteria/SKILL.md
@@ -56,7 +56,7 @@ Qualifying durable choices include:
 - reversing or superseding an accepted architecture decision;
 - choosing an irreversible or high-cost-to-reverse data or compatibility strategy.
 
-A local contract, data-flow, state, or component change belongs in the Design Doc when it follows an accepted design, has one evident repository-supported implementation, or remains cheaply reversible. Counts of files, consumers, nesting levels, states, steps, and asynchronous operations are supporting evidence rather than ADR criteria. Generic technical concerns, operational possibilities, and rejected activities do not create ADRs by themselves.
+A local contract, data-flow, state, or component change belongs in the Design Doc when it follows an accepted design, has one evident repository-supported implementation, or remains cheaply reversible. Counts of files, consumers, nesting levels, states, steps, and asynchronous operations are supporting evidence rather than ADR criteria. Only the qualifying decisions above create ADRs; generic technical concerns, operational possibilities, and rejected activities can only support that determination.
 
 ## Detailed Document Definitions
 
@@ -114,7 +114,7 @@ Create a UI Spec when screen structure, transitions, component/state interaction
 
 **Prototype Code Handling**:
 - Prototype code provided by user is placed in `docs/ui-spec/assets/{feature-name}/`
-- Prototype is an attachment to UI Spec, never the source of truth
+- Prototype code supports the UI Spec as an attachment
 - UI Spec + Design Doc are the canonical specifications
 
 ### Design Document

--- a/dev-skills/skills/external-resource-context/SKILL.md
+++ b/dev-skills/skills/external-resource-context/SKILL.md
@@ -55,7 +55,7 @@ Each domain reference defines the axes and the question template.
 
 ### Two-Phase Hearing
 
-1. **Structured hearing** — for each axis defined in every selected domain reference, present the user with AskUserQuestion using the choices listed there (always include "Not applicable" as an option). For each non-N/A axis, follow up with an access-method question (URL / MCP name / file path / command). Domain references end after their axes; they do not add their own self-declaration question.
+1. **Structured hearing** — for each axis defined in every selected domain reference, present the user with AskUserQuestion using the choices listed there (always include "Not applicable" as an option). For each non-N/A axis, follow up with an access-method question (URL / MCP name / file path / command). Each domain reference ends after its access-method follow-up; phase 2 owns the single self-declaration question.
 
 2. **Self-declaration** — after the structured axes for all selected domains are complete, present one integrated AskUserQuestion: "Are there any other external resources for this work that the structured questions did not cover? If yes, describe them in your next message." If the user describes additional resources, append them to the storage file under an "Additional resources" subsection.
 

--- a/dev-skills/skills/frontend-ai-guide/SKILL.md
+++ b/dev-skills/skills/frontend-ai-guide/SKILL.md
@@ -126,7 +126,7 @@ function EmailInput({ context }: { context: 'user' | 'contact' | 'admin' }) { /*
 
 ## Quality Check Workflow
 
-Read `package.json` scripts and run them with the project's package manager (`packageManager` field). Map the project's actual script names to the phases below — do not assume fixed names.
+Read `package.json` scripts, map the project's actual commands to the phases below, and run them with the project's package manager (`packageManager` field).
 
 ### Phases (run in order)
 1. **Lint/format** — the project's formatter + linter (e.g., Biome, or ESLint + Prettier)
@@ -189,7 +189,7 @@ Proceed when the user-requested or task-defined scope, consumers, state flow, an
 
 ### Unused Code Deletion Rule
 
-When the requested change makes a component, hook, utility, document, or configuration entry obsolete, delete it after checking its consumers and generated/operational use. Preserve and report uncertain or out-of-scope cleanup; do not implement unrelated dormant code merely because it was discovered.
+When the requested change makes a component, hook, utility, document, or configuration entry obsolete, delete it after checking its consumers and generated/operational use. Preserve and report uncertain or out-of-scope cleanup, and keep unrelated dormant code outside the implementation scope.
 
 ### Existing Code Deletion Decision Flow
 

--- a/dev-skills/skills/implementation-approach/SKILL.md
+++ b/dev-skills/skills/implementation-approach/SKILL.md
@@ -65,7 +65,7 @@ External Research: Official/current sources only when repository evidence cannot
 - Decorator Pattern: Phased enhancement of existing features
 - Bridge Pattern: Flexibility through abstraction
 
-Use these patterns only when their named migration or dependency problem exists. Start with the direct strategy. Compare an alternative when it would materially change risk, rollout, compatibility, or the early verification point; do not add a pattern or combination only to increase the option count.
+Use these patterns only when their named migration or dependency problem exists. Start with the direct strategy. Compare an alternative when it would materially change risk, rollout, compatibility, or the early verification point. Keep the option set limited to patterns that produce one of those material differences.
 
 ### Phase 4: Risk Assessment and Control
 

--- a/dev-skills/skills/integration-e2e-testing/SKILL.md
+++ b/dev-skills/skills/integration-e2e-testing/SKILL.md
@@ -43,7 +43,7 @@ One input Design Doc is one budget scope: apply each lane budget once across all
 
 ROI is used to **rank candidates within the same test type** (integration candidates against each other, E2E candidates against each other). Cross-type comparison is unnecessary because integration and E2E budgets are selected independently.
 
-Score every input before calculating ROI. For the three numeric inputs, use only `0`, `5`, or `10`; do not interpolate intermediate values. Legal Requirement remains boolean:
+Score every input before calculating ROI. For the three numeric inputs, use exactly `0`, `5`, or `10`. Legal Requirement remains boolean:
 
 | Input | Scale |
 |---|---|

--- a/dev-skills/skills/llm-friendly-context/SKILL.md
+++ b/dev-skills/skills/llm-friendly-context/SKILL.md
@@ -65,7 +65,7 @@ Before sending a prompt or artifact to another agent, verify:
 
 - [ ] The target action is explicit.
 - [ ] Required input paths and source artifacts are named.
-- [ ] Accepted decisions and constraints are stated once, without alternate wording.
+- [ ] Accepted decisions and constraints use one canonical wording.
 - [ ] Output format or expected status fields are specified.
 - [ ] Success criteria are observable.
 - [ ] Ambiguous expressions have been rewritten or marked as unresolved.

--- a/dev-skills/skills/test-implement/SKILL.md
+++ b/dev-skills/skills/test-implement/SKILL.md
@@ -23,7 +23,7 @@ All tests follow **Arrange-Act-Assert**:
 ### Test Independence
 - Each test runs independently without depending on other tests
 - No shared mutable state between tests
-- Deterministic execution — no random or time dependencies without mocking
+- Deterministic execution — mock random and time dependencies
 
 ### Naming
 - Test names describe expected behavior from user perspective

--- a/dev-skills/skills/test-implement/references/e2e.md
+++ b/dev-skills/skills/test-implement/references/e2e.md
@@ -38,7 +38,7 @@ Use the repository's existing seed and authentication mechanisms. Create per-tes
 ## Locator and Assertion Rules
 
 - Follow the repository's locator convention; otherwise prefer accessible role/name or label locators, then stable test IDs when no semantic locator exists.
-- Assert user-observable state, navigation, accessibility, or persisted behavior named by the skeleton. Avoid assertions tied only to CSS classes or internal DOM structure.
+- Assert user-observable state, navigation, accessibility, or persisted behavior named by the skeleton. Treat assertions tied only to CSS classes or internal DOM structure as insufficient proof.
 - When the UI specification defines responsive behavior, run the affected interaction at the specified viewport; otherwise use the repository's default browser matrix.
 - Each test starts from isolated state and remains independent of execution order.
 

--- a/dev-skills/skills/test-implement/references/frontend.md
+++ b/dev-skills/skills/test-implement/references/frontend.md
@@ -13,7 +13,7 @@ Before writing a test, inspect package scripts, runner configuration, setup file
 
 - Concentrate rigor on shared components, hooks, and utilities with a wide blast radius. Use integration or E2E coverage for higher-composition surfaces when their boundary is the behavior under test.
 - For a behavior-preserving refactor, establish passing regression or characterization evidence before the change and rerun it afterward.
-- Configuration that changes runtime or build behavior requires executable validation. Documentation-only changes do not require test-first development.
+- Test-first scope covers executable behavior; configuration that changes runtime or build behavior requires executable validation.
 - Continuity tests cover existing feature behavior affected by the change; long-term performance and operational testing remain infrastructure concerns unless the accepted work includes them.
 
 ## Mock Boundary

--- a/dev-skills/skills/testing-principles/SKILL.md
+++ b/dev-skills/skills/testing-principles/SKILL.md
@@ -39,7 +39,7 @@ RED: confirm the new test fails for the intended reason. GREEN: implement the sm
 
 Mock-based tests are sufficient when data access is only a dependency of the behavior under test. Verify against the project's real database engine or its accepted equivalent when the subject is a query, repository implementation, schema constraint, or migration compatibility. Resolve the test environment from repository configuration; when no representative environment exists and adding one is outside the approved work, report the missing verification decision.
 
-Cross-check data-access code against the schema source named in the Design Doc or repository configuration. Successful mocks do not prove table, column, type, constraint, or dialect compatibility.
+Cross-check data-access code against the schema source named in the Design Doc or repository configuration. Schema-source verification is required to prove table, column, type, constraint, or dialect compatibility; successful mocks prove behavior only at the mocked boundary.
 
 ## Verification Requirements
 

--- a/dev-workflows-frontend/.claude-plugin/plugin.json
+++ b/dev-workflows-frontend/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflows-frontend",
   "description": "Skills + Subagents for React/TypeScript - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows-frontend/agents/acceptance-test-generator.md
+++ b/dev-workflows-frontend/agents/acceptance-test-generator.md
@@ -19,7 +19,7 @@ Operates in an independent context, executing autonomously until task completion
 
 ### Implementation Approach Compliance
 - **Test Code Generation**: MUST strictly comply with Design Doc implementation patterns (function vs class selection)
-- **Contract Safety**: MUST enforce testing-principles skill mock creation and contract definition rules without exception
+- **Contract Safety**: Apply the testing-principles skill mock creation and contract definition rules to every generated skeleton
 
 ## Input Parameters
 
@@ -50,7 +50,7 @@ Test type definitions, budgets, and ROI calculations are specified in **integrat
 | **System Context** | Requires full system integration? | Skip | [UNIT_LEVEL] |
 | **Upstream Scope** | In Include list? | Skip | [OUT_OF_SCOPE] |
 
-**AC Include/Exclude Criteria**:
+**AC Selection Criteria**:
 
 **Include** (High automation ROI):
 - Business logic correctness (calculations, state transitions, data transformations)
@@ -58,7 +58,7 @@ Test type definitions, budgets, and ROI calculations are specified in **integrat
 - User-visible functionality completeness
 - Error handling behavior (what user sees/experiences)
 
-**Exclude** (Low ROI in LLM/CI/CD environment):
+**Use alternative verification** (Low ROI in LLM/CI/CD environment):
 - External service real connections → Use contract/interface verification instead
 - Performance metrics → Non-deterministic in CI, defer to load testing
 - Implementation details → Focus on observable behavior
@@ -116,7 +116,7 @@ ROI calculation formula and cost table are defined in **integration-e2e-testing 
      - A downstream service receives a real event/message (e.g., topic publish, queue enqueue, webhook call)
      - An external service receives a real API call with the expected payload
      - Transactional consistency across services (e.g., two-phase commit, saga compensation)
-5. **Sort by ROI** within each lane using the score and tie-break order from integration-e2e-testing skill — this is the single ranking step; Phase 4 budget enforcement consumes this ranked list directly without re-sorting.
+5. **Sort by ROI** within each lane using the score and tie-break order from integration-e2e-testing skill — this is the single ranking step, and Phase 4 budget enforcement processes the ranked list in the order produced here.
 
 **Output**: Ranked, deduplicated candidate list with lane assigned per E2E candidate.
 

--- a/dev-workflows-frontend/agents/code-reviewer.md
+++ b/dev-workflows-frontend/agents/code-reviewer.md
@@ -124,7 +124,7 @@ For each function/method in implementation files, check against coding-principle
 #### 3-3. Test Coverage for Acceptance Criteria
 - For each AC marked fulfilled: Glob/Grep for corresponding test cases
 - Record which ACs have test coverage and which do not
-- For each test claimed as AC coverage, inspect the test body and confirm at least one assertion exercises the AC's observable behavior. Tests that are `skip`/`xit`-marked (on tests that should run), contain only TODO/placeholder bodies, or use always-true assertions (e.g., `expect(true).toBe(true)`, `expect(arr.length).toBeGreaterThanOrEqual(0)`) do not count as AC coverage even when grep finds them; record those as `coverage_gap` with rationale explaining the substance issue. Tests verifying intentional absence (e.g., empty list, null result) are substantive when the absence is the AC's expectation.
+- For each test claimed as AC coverage, inspect the test body and count it as coverage only when at least one assertion exercises the AC's observable behavior. Record `skip`/`xit`-marked tests that should run, TODO/placeholder-only bodies, and always-true assertions (e.g., `expect(true).toBe(true)`, `expect(arr.length).toBeGreaterThanOrEqual(0)`) as `coverage_gap` even when grep finds them, with rationale explaining the substance issue. Tests verifying intentional absence (e.g., empty list, null result) are substantive when the absence is the AC's expectation.
 - Beyond substance, confirm each AC test exercises the claimed boundary and would turn red if the promised behavior regressed. When a task file is in scope, verify its Operation Verification Methods and optional Verification Focus. Missing required evidence is a `coverage_gap`.
 
 #### Finding Classification

--- a/dev-workflows-frontend/agents/code-reviewer.md
+++ b/dev-workflows-frontend/agents/code-reviewer.md
@@ -71,7 +71,7 @@ When `prior_feedback` is present, complete the correction re-review here:
 
 For each acceptance criterion extracted in Step 1:
 - Search implementation files for the corresponding code
-- Determine status: fulfilled / partially fulfilled / unfulfilled
+- Mark it `fulfilled` only when evidence covers every governing boundary path; otherwise mark it `unfulfilled` and name each uncovered path in `gap`
 - Record the file path and relevant code location
 - Note any deviations from the Design Doc specification
 - For behavior-changing ACs, confirm the evidence covers the boundary paths, not only the main path: where a distinct branch, state, input class, lifecycle step, or fallback governs the behavior, verify it is exercised. Compare the source/referenced behavior and the implemented behavior at the same granularity; an unsupported change in a boundary dimension is a `dd_violation`
@@ -185,13 +185,13 @@ Verify against the Design Doc architecture:
 verdict:              string ("pass" | "needs-improvement" | "needs-redesign")
 
 acceptanceCriteria[].item:        string
-acceptanceCriteria[].id:          string (required only when status is not fulfilled; stable within this review chain)
-acceptanceCriteria[].status:      string ("fulfilled" | "partially_fulfilled" | "unfulfilled")
+acceptanceCriteria[].id:          string (required only when status is unfulfilled; stable within this review chain)
+acceptanceCriteria[].status:      string ("fulfilled" | "unfulfilled")
 acceptanceCriteria[].confidence:  string ("high" | "medium" | "low")
 acceptanceCriteria[].location:    string (file:line; null if unimplemented)
 acceptanceCriteria[].evidence:    string[] (each "source: file:line")
-acceptanceCriteria[].gap:         string (null when fully fulfilled)
-acceptanceCriteria[].suggestion:  string (null when fully fulfilled)
+acceptanceCriteria[].gap:         string (null when status is fulfilled)
+acceptanceCriteria[].suggestion:  string (null when status is fulfilled)
 
 identifierVerification[].identifier:    string
 identifierVerification[].id:            string (required only when match is false; stable within this review chain)

--- a/dev-workflows-frontend/agents/code-verifier.md
+++ b/dev-workflows-frontend/agents/code-verifier.md
@@ -54,9 +54,9 @@ Stop expanding the search when additional evidence cannot change a discrepancy o
 - `conflict`: Observed behavior or a governing contract contradicts the document.
 - `unverified`: Available evidence cannot establish the claim; state the exact limitation and effect.
 
-Use `critical` only when the issue makes approved scope incorrect, non-executable, or non-verifiable. Use `major` for a material correction and `minor` for non-blocking precision. Group locations that share one cause and correction into one discrepancy.
+Emit a discrepancy only when leaving it unresolved can change scope, feasibility, implementation, a contract, or verification. Group locations that share one cause and correction into one discrepancy.
 
-Use `unverified` only for a specific material document claim whose unresolved truth can change scope, feasibility, implementation, a contract, or verification; assign it `critical` or `major`. Use `limitations` only for an evidence-access or coverage constraint that does not itself identify a material document claim. Record a fact in one place, not both; a material limitation becomes an `unverified` discrepancy.
+Use `unverified` only for a specific material document claim whose unresolved truth can change scope, feasibility, implementation, a contract, or verification. Use `limitations` only for an evidence-access or coverage constraint that does not itself identify a material document claim. Record a fact in one place, not both; a material limitation becomes an `unverified` discrepancy.
 
 ## Output
 
@@ -64,11 +64,11 @@ Return exactly one JSON object:
 
 ```json
 {
-  "summary": {"docType": "design-doc", "documentPath": "docs/design/example.md", "status": "consistent|mostly_consistent|needs_review|inconsistent|blocked"},
+  "summary": {"docType": "design-doc", "documentPath": "docs/design/example.md", "status": "consistent|needs_review|inconsistent|blocked"},
   "blockingReason": null,
   "inventoryCoverage": null,
   "discrepancies": [
-    {"id": "D001", "status": "drift|gap|conflict|unverified", "severity": "critical|major|minor", "claim": "document claim", "documentLocation": "section or line", "codeLocation": "file:line or null", "relatedLocations": ["other location with the same cause"], "evidence": "observed fact", "effect": "why this changes scope, feasibility, implementation, contract, or verification"}
+    {"id": "D001", "status": "drift|gap|conflict|unverified", "claim": "document claim", "documentLocation": "section or line", "codeLocation": "file:line or null", "relatedLocations": ["other location with the same cause"], "evidence": "observed fact", "effect": "why this changes scope, feasibility, implementation, contract, or verification"}
   ],
   "limitations": ["exact evidence-access or coverage constraint and its verification effect"]
 }
@@ -86,12 +86,11 @@ When `unit_inventory` is supplied, replace `inventoryCoverage: null` with this o
 
 For each inventory category, `accountedCount + excluded.length + unaccounted.length` equals `inputCount`. Report every unaccounted item as one cause-grouped `gap` discrepancy.
 
-An unaccounted inventory item makes `consistent` and `mostly_consistent` invalid; use at least `needs_review`. When the supplied inventory cannot be parsed or the counts cannot be made balanced from it, use `blocked` and state the exact input defect.
+An unaccounted inventory item makes `consistent` invalid; use at least `needs_review`. When the supplied inventory cannot be parsed or the counts cannot be made balanced from it, use `blocked` and state the exact input defect.
 
 Status rules:
 
-- `consistent`: no discrepancy or material limitation exists;
-- `mostly_consistent`: only minor precision issues or non-material coverage limitations remain, and inventory has no unaccounted item;
+- `consistent`: no discrepancy exists;
 - `needs_review`: a repairable material discrepancy, including any `unverified` discrepancy, exists;
 - `inconsistent`: governing evidence contradicts the selected outcome or contract;
 - `blocked`: required input or repository evidence is unusable for the requested verification.

--- a/dev-workflows-frontend/agents/integration-test-reviewer.md
+++ b/dev-workflows-frontend/agents/integration-test-reviewer.md
@@ -78,7 +78,7 @@ Evaluate each test for:
 - Clear Arrange section (setup)
 - Single Act (action)
 - Meaningful Assert (verification)
-- Substantive assertion: each test must execute at least one assertion that observes the AC's behavior. Always-true assertions (e.g., `expect(true).toBe(true)`, `expect(arr.length).toBeGreaterThanOrEqual(0)`), TODO-only bodies, or leftover `skip`/`xit` markers on tests that should run do not count as substantive evidence. Tests verifying intentional absence (e.g., `expect(queryAllBy*).toHaveLength(0)`) are substantive when the absence is the AC's expectation
+- Substantive assertion: classify a test as substantive only when it executes at least one assertion that observes the AC's behavior. Classify always-true assertions (e.g., `expect(true).toBe(true)`, `expect(arr.length).toBeGreaterThanOrEqual(0)`), TODO-only bodies, and leftover `skip`/`xit` markers on tests that should run as insufficient evidence. Tests verifying intentional absence (e.g., `expect(queryAllBy*).toHaveLength(0)`) are substantive when the absence is the AC's expectation
 - Isolated state per test (reset in beforeEach)
 - Deterministic execution (mock time/random sources when needed)
 

--- a/dev-workflows-frontend/agents/investigator.md
+++ b/dev-workflows-frontend/agents/investigator.md
@@ -1,6 +1,6 @@
 ---
 name: investigator
-description: Comprehensively collects problem-related information and creates evidence matrix. Use PROACTIVELY when bug/error/issue/defect/not working/strange behavior is reported. Reports only observations without proposing solutions.
+description: Comprehensively collects problem-related information and creates evidence matrix. Use PROACTIVELY when bug/error/issue/defect/not working/strange behavior is reported. Reports observations and evidence for downstream cause verification.
 tools: Read, Grep, Glob, LS, Bash, WebSearch, TaskCreate, TaskUpdate
 skills:
   - ai-development-guide
@@ -79,7 +79,7 @@ For each node listed in the path map, check whether there is a fault. A node is 
 - It contains an inconsistency that can explain the user-reported symptom
 
 If a fault is found, record it as a failure point with the required fields (see Output Format).
-- **Do NOT stop after finding the first fault** — check all remaining nodes on all mapped paths
+- After finding a fault, continue through every remaining node on all mapped paths
 - A single symptom can have multiple failure points at different layers
 
 For each failure point found:
@@ -129,7 +129,7 @@ Disclose unexplored areas and investigation limitations.
     {
       "type": "code|history|dependency|config|document|external",
       "location": "Location investigated",
-      "findings": "Facts discovered (without interpretation)"
+      "findings": "Observed facts"
     }
   ],
   "externalResearch": [

--- a/dev-workflows-frontend/agents/quality-fixer-frontend.md
+++ b/dev-workflows-frontend/agents/quality-fixer-frontend.md
@@ -52,7 +52,7 @@ Use the indicators below for this review.
 - Functions with TODO comments but whose current logic is functionally correct
 - Legitimate empty returns or default values that match the expected behavior
 
-**If any incomplete implementation is found**: Stop immediately. Return `status: "stub_detected"` without proceeding to quality checks (see Output Format).
+**If any incomplete implementation is found**: Stop at Step 1 and return `status: "stub_detected"` (see Output Format).
 
 **If no incomplete implementation is found**: Proceed to Step 2.
 

--- a/dev-workflows-frontend/agents/security-reviewer.md
+++ b/dev-workflows-frontend/agents/security-reviewer.md
@@ -91,18 +91,14 @@ Consolidate all findings, remove duplicates, and classify each finding into one 
 
 | Category | Definition | Examples |
 |----------|-----------|----------|
-| **confirmed_risk** | Attack surface is exploitable as-is, post-filter conclusion with high confidence | Missing authentication on endpoint, arbitrary file access, SQL injection via string concatenation |
-| **suspected_risk** | Attack surface plausible but exploitability uncertain or partially mitigated; downgrade target from confirmed_risk when confidence drops | Potential SSRF behind a network ACL of unknown coverage; auth bypass possible only under specific framework configuration |
-| **defense_gap** | Not immediately exploitable, but a defensive layer is thin or absent | Runtime type validation missing (framework may catch it), unnecessary capability enabled |
-| **hardening** | Improvement to reduce attack surface or exposure | Reducing log verbosity, tightening error response content |
-| **policy** | Organizational or operational practice concern | Dependency version pinning strategy, CI security scanning coverage |
+| **confirmed_risk** | Attack surface is exploitable as-is, post-filter conclusion | Missing authentication on endpoint, arbitrary file access, SQL injection via string concatenation |
+| **defense_gap** | A governing security requirement or in-scope security boundary lacks a required defensive control | Runtime type validation missing at an input boundary, unnecessary capability enabled |
 
 Evaluate every finding against the project's runtime environment, framework protections, and existing mitigations. Apply the following rules per category:
 
-- For findings initially judged as `confirmed_risk` whose exploitability becomes uncertain or partially mitigated by existing defenses: downgrade to `defense_gap` or `suspected_risk` instead of discarding. Attach a `confidence` field (`high` / `medium` / `low`) and a `rationale` explaining the downgrade.
-- Reserve `confirmed_risk` for findings where the attack surface is exploitable as-is with high confidence. The category represents post-filter conclusions, not raw observations.
-- For `defense_gap`, `hardening`, and `policy` findings: evaluate whether they represent an actual risk and discard items that do not.
-- Populate `requiredFixes` only with `confirmed_risk` and high-confidence `defense_gap` items. Lower-confidence findings appear in the `findings` array without inclusion in `requiredFixes`.
+- Emit a finding only when current evidence shows a correction is required to satisfy a governing security requirement or protect an in-scope security boundary. Exclude optional hardening, organizational policy, and speculative observations that do not meet this condition.
+- Reserve `confirmed_risk` for findings where the attack surface is exploitable as-is. The category represents post-filter conclusions, not raw observations.
+- Emit a `defense_gap` only when current evidence shows that a governing security requirement or in-scope security boundary lacks a required defensive control.
 - Give every finding a stable ID.
 - Correction re-review follows Step 1-1 and emits one `prior_feedback_reconciliation` entry per received item using `resolved`, `withdrawn`, or `maintained`.
 
@@ -112,11 +108,8 @@ Each finding must include a `rationale` field whose content depends on the categ
 
 | Category | Rationale must explain |
 |----------|----------------------|
-| **confirmed_risk** | Why the attack surface is exploitable as-is, and why filter/downgrade did not apply |
-| **suspected_risk** | What conditions make exploitability uncertain, what additional information would resolve the ambiguity |
-| **defense_gap** | What defensive layer is being relied upon, and why it may be insufficient |
-| **hardening** | Why the current state is acceptable, and what improvement would add |
-| **policy** | Why this is not a technical vulnerability (what mitigates the technical risk) |
+| **confirmed_risk** | Why the attack surface is exploitable as-is and why existing mitigations do not remove that exploitability |
+| **defense_gap** | Which required defensive control is missing or insufficient and which boundary it protects |
 
 ## Output Format
 
@@ -125,32 +118,25 @@ Each finding must include a `rationale` field whose content depends on the categ
 - During execution, intermediate progress messages MAY be emitted as plain text or markdown.
 - The LAST message returned to the orchestrator MUST be a single JSON object that matches the schema below.
 - Emit the JSON object as the entire content of the final message: the message begins with `{` and ends with `}`.
-- For correction re-review, emit only `status`, `summary`, and `prior_feedback_reconciliation`; when a blocked trigger is observed, also emit its `findings` and `requiredFixes`.
+- For correction re-review, emit only `status`, `summary`, and `prior_feedback_reconciliation`; when a blocked trigger is observed, also emit its `findings`.
 
 ### Output Completion Gate
 
-Before returning the final JSON:
-1. Emit `findings` and `requiredFixes` for every status; each finding contains every field in the schema below.
-2. Derive both arrays and `status` from the consolidated findings and Status Determination.
+Before returning the final JSON, emit `findings` for every status with every field in the schema below, then derive `status` from the consolidated findings and blocked conditions.
 
 ```json
 {
-  "status": "approved|approved_with_notes|needs_revision|blocked",
+  "status": "approved|needs_revision|blocked",
   "summary": "[1-2 sentence summary]",
   "findings": [
     {
       "id": "S001",
-      "category": "confirmed_risk|suspected_risk|defense_gap|hardening|policy",
-      "confidence": "high|medium|low",
+      "category": "confirmed_risk|defense_gap",
       "location": "[file:line]",
       "description": "[specific issue found]",
       "rationale": "[category-specific, see Category-Specific Rationale]",
       "suggestion": "[specific fix]"
     }
-  ],
-  "notes": "[summary of hardening/policy findings for completion report, present when status is approved_with_notes]",
-  "requiredFixes": [
-    "[specific fix 1 — only confirmed_risk and qualifying defense_gap items]"
   ]
 }
 ```
@@ -160,25 +146,15 @@ When `prior_feedback` is present, also include `prior_feedback_reconciliation` w
 ## Status Determination
 
 ### blocked
+- Governing documents fail the Step 1 input gate
 - Credentials, API keys, or tokens found in committed code
-- High-confidence confirmed_risk that enables direct exploitation (missing authentication on public endpoint, arbitrary file access)
-- Escalate immediately with finding details — requires human intervention
+- Escalate immediately with the blocking reason and any finding details — requires human intervention
 
 ### needs_revision
-- One or more confirmed_risk findings
-- Multiple defense_gap findings that affect primary input boundaries
-- One or more high-confidence suspected_risk findings affecting primary input boundaries (auth, input boundaries, data persistence)
-- `requiredFixes` lists only confirmed_risk and qualifying defense_gap items
-
-### approved_with_notes
-- Findings are limited to hardening, policy, and/or suspected_risk (medium or low confidence) categories
-- Or defense_gap findings exist but are isolated and do not affect primary input boundaries
-- suspected_risk findings (medium/low confidence, or not on primary boundary) are listed in `notes` with the conditions that would resolve their ambiguity
-- Notes are included in the completion report for awareness
+- One or more findings require correction
 
 ### approved
-- No meaningful findings after consolidation
-- Any suspected_risk found has been resolved (downgraded to defense_gap then discarded, or upgraded to confirmed_risk and routed elsewhere)
+- No finding requires correction after consolidation
 
 ## Quality Checklist
 
@@ -187,9 +163,8 @@ When `prior_feedback` is present, also include `prior_feedback_reconciliation` w
 - [ ] All Stable Patterns from security-checks.md searched
 - [ ] All Trend-Sensitive Patterns from security-checks.md searched
 - [ ] Technology stack trend check performed
-- [ ] Each finding classified into confirmed_risk / suspected_risk / defense_gap / hardening / policy
-- [ ] suspected_risk findings have confidence (high/medium/low) and a rationale stating what would resolve the ambiguity
-- [ ] suspected_risk findings routed to status per Status Determination (high-confidence on primary boundary → needs_revision; otherwise → approved_with_notes)
+- [ ] Each finding classified into confirmed_risk / defense_gap
+- [ ] Every finding requires correction; optional hardening, policy, and non-blocking speculation were excluded
 - [ ] False positives excluded considering runtime environment and existing mitigations
 - [ ] Committed secrets checked (blocked status if found)
 - [ ] Every finding has a stable ID

--- a/dev-workflows-frontend/agents/security-reviewer.md
+++ b/dev-workflows-frontend/agents/security-reviewer.md
@@ -96,7 +96,7 @@ Consolidate all findings, remove duplicates, and classify each finding into one 
 
 Evaluate every finding against the project's runtime environment, framework protections, and existing mitigations. Apply the following rules per category:
 
-- Emit a finding only when current evidence shows a correction is required to satisfy a governing security requirement or protect an in-scope security boundary. Exclude optional hardening, organizational policy, and speculative observations that do not meet this condition.
+- Emit a finding only when current evidence shows a correction is required to satisfy a governing security requirement or protect an in-scope security boundary.
 - Reserve `confirmed_risk` for findings where the attack surface is exploitable as-is. The category represents post-filter conclusions, not raw observations.
 - Emit a `defense_gap` only when current evidence shows that a governing security requirement or in-scope security boundary lacks a required defensive control.
 - Give every finding a stable ID.
@@ -108,7 +108,7 @@ Each finding must include a `rationale` field whose content depends on the categ
 
 | Category | Rationale must explain |
 |----------|----------------------|
-| **confirmed_risk** | Why the attack surface is exploitable as-is and why existing mitigations do not remove that exploitability |
+| **confirmed_risk** | Why the attack surface is exploitable as-is and remains exploitable after applying existing mitigations |
 | **defense_gap** | Which required defensive control is missing or insufficient and which boundary it protects |
 
 ## Output Format
@@ -164,8 +164,8 @@ When `prior_feedback` is present, also include `prior_feedback_reconciliation` w
 - [ ] All Trend-Sensitive Patterns from security-checks.md searched
 - [ ] Technology stack trend check performed
 - [ ] Each finding classified into confirmed_risk / defense_gap
-- [ ] Every finding requires correction; optional hardening, policy, and non-blocking speculation were excluded
-- [ ] False positives excluded considering runtime environment and existing mitigations
+- [ ] The findings array contains only items that require correction
+- [ ] Every finding remains valid after considering the runtime environment and existing mitigations
 - [ ] Committed secrets checked (blocked status if found)
 - [ ] Every finding has a stable ID
 - [ ] When prior feedback is present, every received ID appears once in `prior_feedback_reconciliation`

--- a/dev-workflows-frontend/agents/task-executor-frontend.md
+++ b/dev-workflows-frontend/agents/task-executor-frontend.md
@@ -63,7 +63,7 @@ Escalation thresholds:
 
 ### Step4: Core Mechanism Preservation Check (Any YES → Immediate Escalation)
 Preserve the core mechanism the task, AC, Design Doc, or UI Spec requires. Implementation details (variable names, internal logic order, local structure) stay free to change; the required mechanism itself stays intact.
-□ Required core mechanism replaced by a simpler or weaker substitute? (passing tests do not make a substitute acceptable)
+□ Required core mechanism replaced by a simpler or weaker substitute, including one justified only by passing tests?
 □ Required core mechanism infeasible as specified?
 Any YES → stop and escalate with `escalation_type: "design_compliance_violation"`, recording the required mechanism, the proposed alternative, the resulting change in behavior, and the condition that would lift the block.
 
@@ -208,7 +208,7 @@ Return the final response per Structured Response Specification. For research/an
 **mutationEvidence**: Use `[]` when no mutation verification ran; otherwise populate every field in the schema below with revision-bound evidence.
 
 ### 1. Task Completion Response
-Report in the following JSON format upon task completion (**without executing quality checks or commits**, delegating to quality assurance process):
+Complete this agent's work by returning the following JSON; the quality assurance process performs quality checks and commits:
 
 ```json
 {
@@ -331,7 +331,7 @@ This gate runs immediately before producing the final JSON response.
 ☐ Implementation is consistent with the Investigation Notes recorded at Step 2 (when Investigation Targets were present)
 ☐ Adjacent Case Sweep evidence records each inspected case and disposition, or the searched surface and no-case result, when the current task triggers the sweep
 ☐ Every Operation Verification Method succeeds and Verification Focus is satisfied when present
-☐ When test runs are cited as `runnableCheck` evidence, they are substantive and executable per the runnableCheck.result field spec (skipped tests, placeholder/TODO-only bodies, always-passing assertions, and 0-match runner reports do not count); non-test verification (build/typecheck/CLI) is not subject to this check
+☐ Test runs cited as `runnableCheck` evidence meet the substantive and executable rules in the `runnableCheck.result` field specification
 ☐ Final response is a single JSON with `status: "completed"` or `status: "escalation_needed"` and matches the schema in Structured Response Specification
 
 **ENFORCEMENT**: When any gate item is unchecked, return `escalation_needed` with `escalation_type: "design_compliance_violation"` for incomplete work or divergence from governing sources and Investigation Notes.

--- a/dev-workflows-frontend/agents/verifier.md
+++ b/dev-workflows-frontend/agents/verifier.md
@@ -40,7 +40,7 @@ Solution derivation is out of scope for this agent.
 - Grasp areas explicitly marked as uninvestigated
 
 **impactAnalysis Validity Check**:
-- Verify logical validity of impactAnalysis for each failure point (without additional searches)
+- Verify the logical validity of each failure point's impactAnalysis using only the supplied investigation evidence; perform additional searches in Step 2
 
 ### Step 2: Triangulation Supplementation
 Identify source types NOT covered in the investigation's `investigationSources`, then investigate at least one:
@@ -78,7 +78,7 @@ For each failure point, critically evaluate:
 - Official documentation of packages in use
 
 ### Step 6: Failure Point Evaluation and Consistency Verification
-Evaluate each failure point independently (do NOT select a single "winner"):
+Evaluate every failure point independently and allow multiple confirmed failure points:
 
 | finalStatus | Definition |
 |-------------|------------|
@@ -92,7 +92,7 @@ Evaluate each failure point independently (do NOT select a single "winner"):
 - Example: "The implementation is wrong" → Was design_gap considered?
 - If inconsistent, explicitly note "Investigation focus may be misaligned with user report"
 
-**Conclusion**: Evaluate each failure point individually. Multiple failure points can be simultaneously valid — do not force selection of a single root cause. For each pair of confirmed failure points, determine their relationship (independent / dependent / same_chain) and record in `failurePointRelationships`
+**Conclusion**: Evaluate each failure point individually and retain every supported cause. For each pair of confirmed failure points, determine their relationship (independent / dependent / same_chain) and record it in `failurePointRelationships`
 
 ## Coverage Assessment Criteria
 

--- a/dev-workflows-frontend/skills/ai-development-guide/SKILL.md
+++ b/dev-workflows-frontend/skills/ai-development-guide/SKILL.md
@@ -280,7 +280,7 @@ Proceed when discovery and understanding cover the files and behaviors named by 
 When an artifact made obsolete by the requested change is detected:
 - Delete it in the same change when its callers and generated/operational uses are checked
 - Preserve and report it when obsolescence is uncertain or deletion would expand beyond the files and behaviors named by the user or current task/design artifact
-- Do not implement unrelated dormant code merely because it was discovered
+- Keep unrelated dormant code outside the implementation scope
 
 ### Existing Code Modification
 

--- a/dev-workflows-frontend/skills/coding-principles/SKILL.md
+++ b/dev-workflows-frontend/skills/coding-principles/SKILL.md
@@ -127,7 +127,7 @@ One comment per decision. If a comment restates what the names and control flow 
 - Delete commented-out code (retrieve from git history when needed)
 
 ### Comment Quality
-- Write comments that remain accurate regardless of future code changes; avoid references to dates, versions, or temporary state
+- Base comments on stable rationale, limits, and contracts rather than dates, versions, or temporary state
 - Update comments when changing code
 - Use proper grammar and formatting
 - Write for future maintainers
@@ -138,7 +138,7 @@ One comment per decision. If a comment restates what the names and control flow 
 - **Small steps**: Make one change at a time
 - **Maintain working state**: Keep tests passing
 - **Verify behavior**: Run tests after each change
-- **Incremental improvement**: Don't aim for perfection immediately
+- **Incremental improvement**: Make the smallest sufficient improvement in each increment
 
 ### Refactoring Triggers
 - Code duplication (DRY principle)

--- a/dev-workflows-frontend/skills/documentation-criteria/SKILL.md
+++ b/dev-workflows-frontend/skills/documentation-criteria/SKILL.md
@@ -56,7 +56,7 @@ Qualifying durable choices include:
 - reversing or superseding an accepted architecture decision;
 - choosing an irreversible or high-cost-to-reverse data or compatibility strategy.
 
-A local contract, data-flow, state, or component change belongs in the Design Doc when it follows an accepted design, has one evident repository-supported implementation, or remains cheaply reversible. Counts of files, consumers, nesting levels, states, steps, and asynchronous operations are supporting evidence rather than ADR criteria. Generic technical concerns, operational possibilities, and rejected activities do not create ADRs by themselves.
+A local contract, data-flow, state, or component change belongs in the Design Doc when it follows an accepted design, has one evident repository-supported implementation, or remains cheaply reversible. Counts of files, consumers, nesting levels, states, steps, and asynchronous operations are supporting evidence rather than ADR criteria. Only the qualifying decisions above create ADRs; generic technical concerns, operational possibilities, and rejected activities can only support that determination.
 
 ## Detailed Document Definitions
 
@@ -114,7 +114,7 @@ Create a UI Spec when screen structure, transitions, component/state interaction
 
 **Prototype Code Handling**:
 - Prototype code provided by user is placed in `docs/ui-spec/assets/{feature-name}/`
-- Prototype is an attachment to UI Spec, never the source of truth
+- Prototype code supports the UI Spec as an attachment
 - UI Spec + Design Doc are the canonical specifications
 
 ### Design Document

--- a/dev-workflows-frontend/skills/external-resource-context/SKILL.md
+++ b/dev-workflows-frontend/skills/external-resource-context/SKILL.md
@@ -55,7 +55,7 @@ Each domain reference defines the axes and the question template.
 
 ### Two-Phase Hearing
 
-1. **Structured hearing** — for each axis defined in every selected domain reference, present the user with AskUserQuestion using the choices listed there (always include "Not applicable" as an option). For each non-N/A axis, follow up with an access-method question (URL / MCP name / file path / command). Domain references end after their axes; they do not add their own self-declaration question.
+1. **Structured hearing** — for each axis defined in every selected domain reference, present the user with AskUserQuestion using the choices listed there (always include "Not applicable" as an option). For each non-N/A axis, follow up with an access-method question (URL / MCP name / file path / command). Each domain reference ends after its access-method follow-up; phase 2 owns the single self-declaration question.
 
 2. **Self-declaration** — after the structured axes for all selected domains are complete, present one integrated AskUserQuestion: "Are there any other external resources for this work that the structured questions did not cover? If yes, describe them in your next message." If the user describes additional resources, append them to the storage file under an "Additional resources" subsection.
 

--- a/dev-workflows-frontend/skills/frontend-ai-guide/SKILL.md
+++ b/dev-workflows-frontend/skills/frontend-ai-guide/SKILL.md
@@ -126,7 +126,7 @@ function EmailInput({ context }: { context: 'user' | 'contact' | 'admin' }) { /*
 
 ## Quality Check Workflow
 
-Read `package.json` scripts and run them with the project's package manager (`packageManager` field). Map the project's actual script names to the phases below — do not assume fixed names.
+Read `package.json` scripts, map the project's actual commands to the phases below, and run them with the project's package manager (`packageManager` field).
 
 ### Phases (run in order)
 1. **Lint/format** — the project's formatter + linter (e.g., Biome, or ESLint + Prettier)
@@ -189,7 +189,7 @@ Proceed when the user-requested or task-defined scope, consumers, state flow, an
 
 ### Unused Code Deletion Rule
 
-When the requested change makes a component, hook, utility, document, or configuration entry obsolete, delete it after checking its consumers and generated/operational use. Preserve and report uncertain or out-of-scope cleanup; do not implement unrelated dormant code merely because it was discovered.
+When the requested change makes a component, hook, utility, document, or configuration entry obsolete, delete it after checking its consumers and generated/operational use. Preserve and report uncertain or out-of-scope cleanup, and keep unrelated dormant code outside the implementation scope.
 
 ### Existing Code Deletion Decision Flow
 

--- a/dev-workflows-frontend/skills/implementation-approach/SKILL.md
+++ b/dev-workflows-frontend/skills/implementation-approach/SKILL.md
@@ -65,7 +65,7 @@ External Research: Official/current sources only when repository evidence cannot
 - Decorator Pattern: Phased enhancement of existing features
 - Bridge Pattern: Flexibility through abstraction
 
-Use these patterns only when their named migration or dependency problem exists. Start with the direct strategy. Compare an alternative when it would materially change risk, rollout, compatibility, or the early verification point; do not add a pattern or combination only to increase the option count.
+Use these patterns only when their named migration or dependency problem exists. Start with the direct strategy. Compare an alternative when it would materially change risk, rollout, compatibility, or the early verification point. Keep the option set limited to patterns that produce one of those material differences.
 
 ### Phase 4: Risk Assessment and Control
 

--- a/dev-workflows-frontend/skills/integration-e2e-testing/SKILL.md
+++ b/dev-workflows-frontend/skills/integration-e2e-testing/SKILL.md
@@ -43,7 +43,7 @@ One input Design Doc is one budget scope: apply each lane budget once across all
 
 ROI is used to **rank candidates within the same test type** (integration candidates against each other, E2E candidates against each other). Cross-type comparison is unnecessary because integration and E2E budgets are selected independently.
 
-Score every input before calculating ROI. For the three numeric inputs, use only `0`, `5`, or `10`; do not interpolate intermediate values. Legal Requirement remains boolean:
+Score every input before calculating ROI. For the three numeric inputs, use exactly `0`, `5`, or `10`. Legal Requirement remains boolean:
 
 | Input | Scale |
 |---|---|

--- a/dev-workflows-frontend/skills/llm-friendly-context/SKILL.md
+++ b/dev-workflows-frontend/skills/llm-friendly-context/SKILL.md
@@ -65,7 +65,7 @@ Before sending a prompt or artifact to another agent, verify:
 
 - [ ] The target action is explicit.
 - [ ] Required input paths and source artifacts are named.
-- [ ] Accepted decisions and constraints are stated once, without alternate wording.
+- [ ] Accepted decisions and constraints use one canonical wording.
 - [ ] Output format or expected status fields are specified.
 - [ ] Success criteria are observable.
 - [ ] Ambiguous expressions have been rewritten or marked as unresolved.

--- a/dev-workflows-frontend/skills/recipe-diagnose/SKILL.md
+++ b/dev-workflows-frontend/skills/recipe-diagnose/SKILL.md
@@ -121,7 +121,7 @@ prompt: |
   Re-investigate with focus on the following gaps:
   - Missing: [unsatisfied Step 2 Quality Check items, copied as written]
 
-  Previous investigation results (for context, do not re-investigate covered areas):
+  Use these previous investigation results as context and investigate only the gaps listed above:
   [Previous investigation JSON]
 ```
 

--- a/dev-workflows-frontend/skills/recipe-front-build/SKILL.md
+++ b/dev-workflows-frontend/skills/recipe-front-build/SKILL.md
@@ -138,7 +138,7 @@ Before the completion report, delete the implementation task files this recipe c
 - Delete every file in the Consumed Task Set
 - Preserve the work plan itself (`docs/plans/{plan-name}.md`) — the user decides whether to delete it after final review
 
-If task files cannot be deleted (filesystem error), report the failure but do not block the completion report.
+If task-file deletion fails with a filesystem error, report the failure and continue to the completion report.
 
 ## Completion Report Contract
 

--- a/dev-workflows-frontend/skills/recipe-front-review/SKILL.md
+++ b/dev-workflows-frontend/skills/recipe-front-review/SKILL.md
@@ -62,7 +62,7 @@ Invoke security-reviewer using Agent tool:
 
 ### Step 4: Verdict and Response
 
-**If security-reviewer returned `blocked`**: Stop immediately. Report the blocked finding and escalate to user. Do not proceed to fix steps.
+**If security-reviewer returned `blocked`**: Stop immediately. Report its blocking reason and any returned finding, then escalate to user. Do not proceed to fix steps.
 
 Apply the Review Resolution Gate to both outputs before reporting or routing them. Finding dispositions determine routing.
 
@@ -80,7 +80,6 @@ Then present the adjudicated result to the user. Group `apply` and `user_decisio
 Code Review: [verdict from code-reviewer]
   Acceptance Criteria:
   - [fulfilled] [item] (confidence: [high/medium/low])
-  - [partially_fulfilled] [item]: [gap] — [suggestion] [recommended: c | d]
   - [unfulfilled] [item]: [gap] — [suggestion] [recommended: c | d]
   Identifier Mismatches:
   - [identifier]: DD=[designDocValue] Code=[codeValue] at [location] [recommended: c | d]
@@ -91,9 +90,6 @@ Security Review: [status from security-reviewer]
   Findings by category:
   - [confirmed_risk] [location]: [description] — [rationale] [recommended: c]
   - [defense_gap] [location]: [description] — [rationale] [recommended: c]
-  - [hardening] [location]: [description] — [rationale] [recommended: c]
-  - [policy] [location]: [description] — [rationale] [recommended: c]
-  Notes: [notes from security-reviewer, if present]
 
 Approve the proposed changes or decide unresolved items:
   c) Code-side fix       — code violates Design Doc; modify code to match
@@ -175,7 +171,6 @@ Security Review:
   Initial: [status]
   Correction review: [status for the re-review scope] (if fixes executed)
   Reconciliation: [resolved / withdrawn / maintained by finding ID]
-  Notes: [notes from approved_with_notes, if any]
 
 Declined actionable findings:
 - [ID: governing reason — evidence] (only when any were declined)

--- a/dev-workflows-frontend/skills/recipe-front-review/SKILL.md
+++ b/dev-workflows-frontend/skills/recipe-front-review/SKILL.md
@@ -62,7 +62,7 @@ Invoke security-reviewer using Agent tool:
 
 ### Step 4: Verdict and Response
 
-**If security-reviewer returned `blocked`**: Stop immediately. Report its blocking reason and any returned finding, then escalate to user. Do not proceed to fix steps.
+**If security-reviewer returned `blocked`**: Stop at this gate, report its blocking reason and any returned finding, then escalate to the user. The workflow remains at this gate pending the user's response.
 
 Apply the Review Resolution Gate to both outputs before reporting or routing them. Finding dispositions determine routing.
 

--- a/dev-workflows-frontend/skills/subagents-orchestration-guide/SKILL.md
+++ b/dev-workflows-frontend/skills/subagents-orchestration-guide/SKILL.md
@@ -170,8 +170,8 @@ For Small, execute one direct-scope 4-step cycle and complete when quality-fixer
 
 | Verifier | Pass | Fail | Blocked |
 |----------|------|------|---------|
-| code-verifier | `summary.status` is `consistent` or `mostly_consistent` | `summary.status` is `needs_review` or `inconsistent` | `summary.status` is `blocked` → Escalate to user |
-| security-reviewer | `status` is `approved` or `approved_with_notes` | `status` is `needs_revision` | `status` is `blocked` → Escalate to user |
+| code-verifier | `summary.status` is `consistent` | `summary.status` is `needs_review` or `inconsistent` | `summary.status` is `blocked` → Escalate to user |
+| security-reviewer | `status` is `approved` | `status` is `needs_revision` | `status` is `blocked` → Escalate to user |
 
 **Fix-cycle handoff**: Apply Review Resolution, then pass each required executor the complete `apply` finding objects verbatim with only their dispositions added. Carry `prior_feedback` to reviewer inputs that support reconciliation.
 

--- a/dev-workflows-frontend/skills/test-implement/SKILL.md
+++ b/dev-workflows-frontend/skills/test-implement/SKILL.md
@@ -23,7 +23,7 @@ All tests follow **Arrange-Act-Assert**:
 ### Test Independence
 - Each test runs independently without depending on other tests
 - No shared mutable state between tests
-- Deterministic execution — no random or time dependencies without mocking
+- Deterministic execution — mock random and time dependencies
 
 ### Naming
 - Test names describe expected behavior from user perspective

--- a/dev-workflows-frontend/skills/test-implement/references/e2e.md
+++ b/dev-workflows-frontend/skills/test-implement/references/e2e.md
@@ -38,7 +38,7 @@ Use the repository's existing seed and authentication mechanisms. Create per-tes
 ## Locator and Assertion Rules
 
 - Follow the repository's locator convention; otherwise prefer accessible role/name or label locators, then stable test IDs when no semantic locator exists.
-- Assert user-observable state, navigation, accessibility, or persisted behavior named by the skeleton. Avoid assertions tied only to CSS classes or internal DOM structure.
+- Assert user-observable state, navigation, accessibility, or persisted behavior named by the skeleton. Treat assertions tied only to CSS classes or internal DOM structure as insufficient proof.
 - When the UI specification defines responsive behavior, run the affected interaction at the specified viewport; otherwise use the repository's default browser matrix.
 - Each test starts from isolated state and remains independent of execution order.
 

--- a/dev-workflows-frontend/skills/test-implement/references/frontend.md
+++ b/dev-workflows-frontend/skills/test-implement/references/frontend.md
@@ -13,7 +13,7 @@ Before writing a test, inspect package scripts, runner configuration, setup file
 
 - Concentrate rigor on shared components, hooks, and utilities with a wide blast radius. Use integration or E2E coverage for higher-composition surfaces when their boundary is the behavior under test.
 - For a behavior-preserving refactor, establish passing regression or characterization evidence before the change and rerun it afterward.
-- Configuration that changes runtime or build behavior requires executable validation. Documentation-only changes do not require test-first development.
+- Test-first scope covers executable behavior; configuration that changes runtime or build behavior requires executable validation.
 - Continuity tests cover existing feature behavior affected by the change; long-term performance and operational testing remain infrastructure concerns unless the accepted work includes them.
 
 ## Mock Boundary

--- a/dev-workflows-frontend/skills/testing-principles/SKILL.md
+++ b/dev-workflows-frontend/skills/testing-principles/SKILL.md
@@ -39,7 +39,7 @@ RED: confirm the new test fails for the intended reason. GREEN: implement the sm
 
 Mock-based tests are sufficient when data access is only a dependency of the behavior under test. Verify against the project's real database engine or its accepted equivalent when the subject is a query, repository implementation, schema constraint, or migration compatibility. Resolve the test environment from repository configuration; when no representative environment exists and adding one is outside the approved work, report the missing verification decision.
 
-Cross-check data-access code against the schema source named in the Design Doc or repository configuration. Successful mocks do not prove table, column, type, constraint, or dialect compatibility.
+Cross-check data-access code against the schema source named in the Design Doc or repository configuration. Schema-source verification is required to prove table, column, type, constraint, or dialect compatibility; successful mocks prove behavior only at the mocked boundary.
 
 ## Verification Requirements
 

--- a/dev-workflows-fullstack/.claude-plugin/plugin.json
+++ b/dev-workflows-fullstack/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflows-fullstack",
   "description": "Skills + Subagents for fullstack development (backend + React/TypeScript) - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows-fullstack/agents/acceptance-test-generator.md
+++ b/dev-workflows-fullstack/agents/acceptance-test-generator.md
@@ -19,7 +19,7 @@ Operates in an independent context, executing autonomously until task completion
 
 ### Implementation Approach Compliance
 - **Test Code Generation**: MUST strictly comply with Design Doc implementation patterns (function vs class selection)
-- **Contract Safety**: MUST enforce testing-principles skill mock creation and contract definition rules without exception
+- **Contract Safety**: Apply the testing-principles skill mock creation and contract definition rules to every generated skeleton
 
 ## Input Parameters
 
@@ -50,7 +50,7 @@ Test type definitions, budgets, and ROI calculations are specified in **integrat
 | **System Context** | Requires full system integration? | Skip | [UNIT_LEVEL] |
 | **Upstream Scope** | In Include list? | Skip | [OUT_OF_SCOPE] |
 
-**AC Include/Exclude Criteria**:
+**AC Selection Criteria**:
 
 **Include** (High automation ROI):
 - Business logic correctness (calculations, state transitions, data transformations)
@@ -58,7 +58,7 @@ Test type definitions, budgets, and ROI calculations are specified in **integrat
 - User-visible functionality completeness
 - Error handling behavior (what user sees/experiences)
 
-**Exclude** (Low ROI in LLM/CI/CD environment):
+**Use alternative verification** (Low ROI in LLM/CI/CD environment):
 - External service real connections → Use contract/interface verification instead
 - Performance metrics → Non-deterministic in CI, defer to load testing
 - Implementation details → Focus on observable behavior
@@ -116,7 +116,7 @@ ROI calculation formula and cost table are defined in **integration-e2e-testing 
      - A downstream service receives a real event/message (e.g., topic publish, queue enqueue, webhook call)
      - An external service receives a real API call with the expected payload
      - Transactional consistency across services (e.g., two-phase commit, saga compensation)
-5. **Sort by ROI** within each lane using the score and tie-break order from integration-e2e-testing skill — this is the single ranking step; Phase 4 budget enforcement consumes this ranked list directly without re-sorting.
+5. **Sort by ROI** within each lane using the score and tie-break order from integration-e2e-testing skill — this is the single ranking step, and Phase 4 budget enforcement processes the ranked list in the order produced here.
 
 **Output**: Ranked, deduplicated candidate list with lane assigned per E2E candidate.
 

--- a/dev-workflows-fullstack/agents/code-reviewer.md
+++ b/dev-workflows-fullstack/agents/code-reviewer.md
@@ -124,7 +124,7 @@ For each function/method in implementation files, check against coding-principle
 #### 3-3. Test Coverage for Acceptance Criteria
 - For each AC marked fulfilled: Glob/Grep for corresponding test cases
 - Record which ACs have test coverage and which do not
-- For each test claimed as AC coverage, inspect the test body and confirm at least one assertion exercises the AC's observable behavior. Tests that are `skip`/`xit`-marked (on tests that should run), contain only TODO/placeholder bodies, or use always-true assertions (e.g., `expect(true).toBe(true)`, `expect(arr.length).toBeGreaterThanOrEqual(0)`) do not count as AC coverage even when grep finds them; record those as `coverage_gap` with rationale explaining the substance issue. Tests verifying intentional absence (e.g., empty list, null result) are substantive when the absence is the AC's expectation.
+- For each test claimed as AC coverage, inspect the test body and count it as coverage only when at least one assertion exercises the AC's observable behavior. Record `skip`/`xit`-marked tests that should run, TODO/placeholder-only bodies, and always-true assertions (e.g., `expect(true).toBe(true)`, `expect(arr.length).toBeGreaterThanOrEqual(0)`) as `coverage_gap` even when grep finds them, with rationale explaining the substance issue. Tests verifying intentional absence (e.g., empty list, null result) are substantive when the absence is the AC's expectation.
 - Beyond substance, confirm each AC test exercises the claimed boundary and would turn red if the promised behavior regressed. When a task file is in scope, verify its Operation Verification Methods and optional Verification Focus. Missing required evidence is a `coverage_gap`.
 
 #### Finding Classification

--- a/dev-workflows-fullstack/agents/code-reviewer.md
+++ b/dev-workflows-fullstack/agents/code-reviewer.md
@@ -71,7 +71,7 @@ When `prior_feedback` is present, complete the correction re-review here:
 
 For each acceptance criterion extracted in Step 1:
 - Search implementation files for the corresponding code
-- Determine status: fulfilled / partially fulfilled / unfulfilled
+- Mark it `fulfilled` only when evidence covers every governing boundary path; otherwise mark it `unfulfilled` and name each uncovered path in `gap`
 - Record the file path and relevant code location
 - Note any deviations from the Design Doc specification
 - For behavior-changing ACs, confirm the evidence covers the boundary paths, not only the main path: where a distinct branch, state, input class, lifecycle step, or fallback governs the behavior, verify it is exercised. Compare the source/referenced behavior and the implemented behavior at the same granularity; an unsupported change in a boundary dimension is a `dd_violation`
@@ -185,13 +185,13 @@ Verify against the Design Doc architecture:
 verdict:              string ("pass" | "needs-improvement" | "needs-redesign")
 
 acceptanceCriteria[].item:        string
-acceptanceCriteria[].id:          string (required only when status is not fulfilled; stable within this review chain)
-acceptanceCriteria[].status:      string ("fulfilled" | "partially_fulfilled" | "unfulfilled")
+acceptanceCriteria[].id:          string (required only when status is unfulfilled; stable within this review chain)
+acceptanceCriteria[].status:      string ("fulfilled" | "unfulfilled")
 acceptanceCriteria[].confidence:  string ("high" | "medium" | "low")
 acceptanceCriteria[].location:    string (file:line; null if unimplemented)
 acceptanceCriteria[].evidence:    string[] (each "source: file:line")
-acceptanceCriteria[].gap:         string (null when fully fulfilled)
-acceptanceCriteria[].suggestion:  string (null when fully fulfilled)
+acceptanceCriteria[].gap:         string (null when status is fulfilled)
+acceptanceCriteria[].suggestion:  string (null when status is fulfilled)
 
 identifierVerification[].identifier:    string
 identifierVerification[].id:            string (required only when match is false; stable within this review chain)

--- a/dev-workflows-fullstack/agents/code-verifier.md
+++ b/dev-workflows-fullstack/agents/code-verifier.md
@@ -54,9 +54,9 @@ Stop expanding the search when additional evidence cannot change a discrepancy o
 - `conflict`: Observed behavior or a governing contract contradicts the document.
 - `unverified`: Available evidence cannot establish the claim; state the exact limitation and effect.
 
-Use `critical` only when the issue makes approved scope incorrect, non-executable, or non-verifiable. Use `major` for a material correction and `minor` for non-blocking precision. Group locations that share one cause and correction into one discrepancy.
+Emit a discrepancy only when leaving it unresolved can change scope, feasibility, implementation, a contract, or verification. Group locations that share one cause and correction into one discrepancy.
 
-Use `unverified` only for a specific material document claim whose unresolved truth can change scope, feasibility, implementation, a contract, or verification; assign it `critical` or `major`. Use `limitations` only for an evidence-access or coverage constraint that does not itself identify a material document claim. Record a fact in one place, not both; a material limitation becomes an `unverified` discrepancy.
+Use `unverified` only for a specific material document claim whose unresolved truth can change scope, feasibility, implementation, a contract, or verification. Use `limitations` only for an evidence-access or coverage constraint that does not itself identify a material document claim. Record a fact in one place, not both; a material limitation becomes an `unverified` discrepancy.
 
 ## Output
 
@@ -64,11 +64,11 @@ Return exactly one JSON object:
 
 ```json
 {
-  "summary": {"docType": "design-doc", "documentPath": "docs/design/example.md", "status": "consistent|mostly_consistent|needs_review|inconsistent|blocked"},
+  "summary": {"docType": "design-doc", "documentPath": "docs/design/example.md", "status": "consistent|needs_review|inconsistent|blocked"},
   "blockingReason": null,
   "inventoryCoverage": null,
   "discrepancies": [
-    {"id": "D001", "status": "drift|gap|conflict|unverified", "severity": "critical|major|minor", "claim": "document claim", "documentLocation": "section or line", "codeLocation": "file:line or null", "relatedLocations": ["other location with the same cause"], "evidence": "observed fact", "effect": "why this changes scope, feasibility, implementation, contract, or verification"}
+    {"id": "D001", "status": "drift|gap|conflict|unverified", "claim": "document claim", "documentLocation": "section or line", "codeLocation": "file:line or null", "relatedLocations": ["other location with the same cause"], "evidence": "observed fact", "effect": "why this changes scope, feasibility, implementation, contract, or verification"}
   ],
   "limitations": ["exact evidence-access or coverage constraint and its verification effect"]
 }
@@ -86,12 +86,11 @@ When `unit_inventory` is supplied, replace `inventoryCoverage: null` with this o
 
 For each inventory category, `accountedCount + excluded.length + unaccounted.length` equals `inputCount`. Report every unaccounted item as one cause-grouped `gap` discrepancy.
 
-An unaccounted inventory item makes `consistent` and `mostly_consistent` invalid; use at least `needs_review`. When the supplied inventory cannot be parsed or the counts cannot be made balanced from it, use `blocked` and state the exact input defect.
+An unaccounted inventory item makes `consistent` invalid; use at least `needs_review`. When the supplied inventory cannot be parsed or the counts cannot be made balanced from it, use `blocked` and state the exact input defect.
 
 Status rules:
 
-- `consistent`: no discrepancy or material limitation exists;
-- `mostly_consistent`: only minor precision issues or non-material coverage limitations remain, and inventory has no unaccounted item;
+- `consistent`: no discrepancy exists;
 - `needs_review`: a repairable material discrepancy, including any `unverified` discrepancy, exists;
 - `inconsistent`: governing evidence contradicts the selected outcome or contract;
 - `blocked`: required input or repository evidence is unusable for the requested verification.

--- a/dev-workflows-fullstack/agents/integration-test-reviewer.md
+++ b/dev-workflows-fullstack/agents/integration-test-reviewer.md
@@ -78,7 +78,7 @@ Evaluate each test for:
 - Clear Arrange section (setup)
 - Single Act (action)
 - Meaningful Assert (verification)
-- Substantive assertion: each test must execute at least one assertion that observes the AC's behavior. Always-true assertions (e.g., `expect(true).toBe(true)`, `expect(arr.length).toBeGreaterThanOrEqual(0)`), TODO-only bodies, or leftover `skip`/`xit` markers on tests that should run do not count as substantive evidence. Tests verifying intentional absence (e.g., `expect(queryAllBy*).toHaveLength(0)`) are substantive when the absence is the AC's expectation
+- Substantive assertion: classify a test as substantive only when it executes at least one assertion that observes the AC's behavior. Classify always-true assertions (e.g., `expect(true).toBe(true)`, `expect(arr.length).toBeGreaterThanOrEqual(0)`), TODO-only bodies, and leftover `skip`/`xit` markers on tests that should run as insufficient evidence. Tests verifying intentional absence (e.g., `expect(queryAllBy*).toHaveLength(0)`) are substantive when the absence is the AC's expectation
 - Isolated state per test (reset in beforeEach)
 - Deterministic execution (mock time/random sources when needed)
 

--- a/dev-workflows-fullstack/agents/investigator.md
+++ b/dev-workflows-fullstack/agents/investigator.md
@@ -1,6 +1,6 @@
 ---
 name: investigator
-description: Comprehensively collects problem-related information and creates evidence matrix. Use PROACTIVELY when bug/error/issue/defect/not working/strange behavior is reported. Reports only observations without proposing solutions.
+description: Comprehensively collects problem-related information and creates evidence matrix. Use PROACTIVELY when bug/error/issue/defect/not working/strange behavior is reported. Reports observations and evidence for downstream cause verification.
 tools: Read, Grep, Glob, LS, Bash, WebSearch, TaskCreate, TaskUpdate
 skills:
   - ai-development-guide
@@ -79,7 +79,7 @@ For each node listed in the path map, check whether there is a fault. A node is 
 - It contains an inconsistency that can explain the user-reported symptom
 
 If a fault is found, record it as a failure point with the required fields (see Output Format).
-- **Do NOT stop after finding the first fault** — check all remaining nodes on all mapped paths
+- After finding a fault, continue through every remaining node on all mapped paths
 - A single symptom can have multiple failure points at different layers
 
 For each failure point found:
@@ -129,7 +129,7 @@ Disclose unexplored areas and investigation limitations.
     {
       "type": "code|history|dependency|config|document|external",
       "location": "Location investigated",
-      "findings": "Facts discovered (without interpretation)"
+      "findings": "Observed facts"
     }
   ],
   "externalResearch": [

--- a/dev-workflows-fullstack/agents/quality-fixer-frontend.md
+++ b/dev-workflows-fullstack/agents/quality-fixer-frontend.md
@@ -52,7 +52,7 @@ Use the indicators below for this review.
 - Functions with TODO comments but whose current logic is functionally correct
 - Legitimate empty returns or default values that match the expected behavior
 
-**If any incomplete implementation is found**: Stop immediately. Return `status: "stub_detected"` without proceeding to quality checks (see Output Format).
+**If any incomplete implementation is found**: Stop at Step 1 and return `status: "stub_detected"` (see Output Format).
 
 **If no incomplete implementation is found**: Proceed to Step 2.
 

--- a/dev-workflows-fullstack/agents/quality-fixer.md
+++ b/dev-workflows-fullstack/agents/quality-fixer.md
@@ -46,7 +46,7 @@ Use the indicators below for this review.
 
 **Legitimate patterns** (treat as complete; proceed to Step 2): intentionally minimal implementations, functions with TODO comments but functionally correct logic, and legitimate empty/default returns that match the expected behavior.
 
-**If any incomplete implementation is found**: Stop immediately. Return `status: "stub_detected"` without proceeding to quality checks (see Output Format).
+**If any incomplete implementation is found**: Stop at Step 1 and return `status: "stub_detected"` (see Output Format).
 
 **If no incomplete implementation is found**: Proceed to Step 2.
 

--- a/dev-workflows-fullstack/agents/scope-discoverer.md
+++ b/dev-workflows-fullstack/agents/scope-discoverer.md
@@ -247,7 +247,7 @@ Includes additional fields:
 Run each item below before producing the final JSON. When any item is unsatisfied, return to the relevant Step and complete it before producing the JSON output.
 
 - [ ] Output is limited to scope discovery (no PRD or Design Doc content generated)
-- [ ] Every discovery is backed by evidence (no assumptions without sources)
+- [ ] Every discovery cites its source evidence
 - [ ] Low-confidence discoveries are reported with appropriate confidence markers
 - [ ] Triangulation strength reflects actual source count (weak noted when single-source)
 - [ ] Saturation check was performed before concluding discovery

--- a/dev-workflows-fullstack/agents/security-reviewer.md
+++ b/dev-workflows-fullstack/agents/security-reviewer.md
@@ -91,18 +91,14 @@ Consolidate all findings, remove duplicates, and classify each finding into one 
 
 | Category | Definition | Examples |
 |----------|-----------|----------|
-| **confirmed_risk** | Attack surface is exploitable as-is, post-filter conclusion with high confidence | Missing authentication on endpoint, arbitrary file access, SQL injection via string concatenation |
-| **suspected_risk** | Attack surface plausible but exploitability uncertain or partially mitigated; downgrade target from confirmed_risk when confidence drops | Potential SSRF behind a network ACL of unknown coverage; auth bypass possible only under specific framework configuration |
-| **defense_gap** | Not immediately exploitable, but a defensive layer is thin or absent | Runtime type validation missing (framework may catch it), unnecessary capability enabled |
-| **hardening** | Improvement to reduce attack surface or exposure | Reducing log verbosity, tightening error response content |
-| **policy** | Organizational or operational practice concern | Dependency version pinning strategy, CI security scanning coverage |
+| **confirmed_risk** | Attack surface is exploitable as-is, post-filter conclusion | Missing authentication on endpoint, arbitrary file access, SQL injection via string concatenation |
+| **defense_gap** | A governing security requirement or in-scope security boundary lacks a required defensive control | Runtime type validation missing at an input boundary, unnecessary capability enabled |
 
 Evaluate every finding against the project's runtime environment, framework protections, and existing mitigations. Apply the following rules per category:
 
-- For findings initially judged as `confirmed_risk` whose exploitability becomes uncertain or partially mitigated by existing defenses: downgrade to `defense_gap` or `suspected_risk` instead of discarding. Attach a `confidence` field (`high` / `medium` / `low`) and a `rationale` explaining the downgrade.
-- Reserve `confirmed_risk` for findings where the attack surface is exploitable as-is with high confidence. The category represents post-filter conclusions, not raw observations.
-- For `defense_gap`, `hardening`, and `policy` findings: evaluate whether they represent an actual risk and discard items that do not.
-- Populate `requiredFixes` only with `confirmed_risk` and high-confidence `defense_gap` items. Lower-confidence findings appear in the `findings` array without inclusion in `requiredFixes`.
+- Emit a finding only when current evidence shows a correction is required to satisfy a governing security requirement or protect an in-scope security boundary. Exclude optional hardening, organizational policy, and speculative observations that do not meet this condition.
+- Reserve `confirmed_risk` for findings where the attack surface is exploitable as-is. The category represents post-filter conclusions, not raw observations.
+- Emit a `defense_gap` only when current evidence shows that a governing security requirement or in-scope security boundary lacks a required defensive control.
 - Give every finding a stable ID.
 - Correction re-review follows Step 1-1 and emits one `prior_feedback_reconciliation` entry per received item using `resolved`, `withdrawn`, or `maintained`.
 
@@ -112,11 +108,8 @@ Each finding must include a `rationale` field whose content depends on the categ
 
 | Category | Rationale must explain |
 |----------|----------------------|
-| **confirmed_risk** | Why the attack surface is exploitable as-is, and why filter/downgrade did not apply |
-| **suspected_risk** | What conditions make exploitability uncertain, what additional information would resolve the ambiguity |
-| **defense_gap** | What defensive layer is being relied upon, and why it may be insufficient |
-| **hardening** | Why the current state is acceptable, and what improvement would add |
-| **policy** | Why this is not a technical vulnerability (what mitigates the technical risk) |
+| **confirmed_risk** | Why the attack surface is exploitable as-is and why existing mitigations do not remove that exploitability |
+| **defense_gap** | Which required defensive control is missing or insufficient and which boundary it protects |
 
 ## Output Format
 
@@ -125,32 +118,25 @@ Each finding must include a `rationale` field whose content depends on the categ
 - During execution, intermediate progress messages MAY be emitted as plain text or markdown.
 - The LAST message returned to the orchestrator MUST be a single JSON object that matches the schema below.
 - Emit the JSON object as the entire content of the final message: the message begins with `{` and ends with `}`.
-- For correction re-review, emit only `status`, `summary`, and `prior_feedback_reconciliation`; when a blocked trigger is observed, also emit its `findings` and `requiredFixes`.
+- For correction re-review, emit only `status`, `summary`, and `prior_feedback_reconciliation`; when a blocked trigger is observed, also emit its `findings`.
 
 ### Output Completion Gate
 
-Before returning the final JSON:
-1. Emit `findings` and `requiredFixes` for every status; each finding contains every field in the schema below.
-2. Derive both arrays and `status` from the consolidated findings and Status Determination.
+Before returning the final JSON, emit `findings` for every status with every field in the schema below, then derive `status` from the consolidated findings and blocked conditions.
 
 ```json
 {
-  "status": "approved|approved_with_notes|needs_revision|blocked",
+  "status": "approved|needs_revision|blocked",
   "summary": "[1-2 sentence summary]",
   "findings": [
     {
       "id": "S001",
-      "category": "confirmed_risk|suspected_risk|defense_gap|hardening|policy",
-      "confidence": "high|medium|low",
+      "category": "confirmed_risk|defense_gap",
       "location": "[file:line]",
       "description": "[specific issue found]",
       "rationale": "[category-specific, see Category-Specific Rationale]",
       "suggestion": "[specific fix]"
     }
-  ],
-  "notes": "[summary of hardening/policy findings for completion report, present when status is approved_with_notes]",
-  "requiredFixes": [
-    "[specific fix 1 — only confirmed_risk and qualifying defense_gap items]"
   ]
 }
 ```
@@ -160,25 +146,15 @@ When `prior_feedback` is present, also include `prior_feedback_reconciliation` w
 ## Status Determination
 
 ### blocked
+- Governing documents fail the Step 1 input gate
 - Credentials, API keys, or tokens found in committed code
-- High-confidence confirmed_risk that enables direct exploitation (missing authentication on public endpoint, arbitrary file access)
-- Escalate immediately with finding details — requires human intervention
+- Escalate immediately with the blocking reason and any finding details — requires human intervention
 
 ### needs_revision
-- One or more confirmed_risk findings
-- Multiple defense_gap findings that affect primary input boundaries
-- One or more high-confidence suspected_risk findings affecting primary input boundaries (auth, input boundaries, data persistence)
-- `requiredFixes` lists only confirmed_risk and qualifying defense_gap items
-
-### approved_with_notes
-- Findings are limited to hardening, policy, and/or suspected_risk (medium or low confidence) categories
-- Or defense_gap findings exist but are isolated and do not affect primary input boundaries
-- suspected_risk findings (medium/low confidence, or not on primary boundary) are listed in `notes` with the conditions that would resolve their ambiguity
-- Notes are included in the completion report for awareness
+- One or more findings require correction
 
 ### approved
-- No meaningful findings after consolidation
-- Any suspected_risk found has been resolved (downgraded to defense_gap then discarded, or upgraded to confirmed_risk and routed elsewhere)
+- No finding requires correction after consolidation
 
 ## Quality Checklist
 
@@ -187,9 +163,8 @@ When `prior_feedback` is present, also include `prior_feedback_reconciliation` w
 - [ ] All Stable Patterns from security-checks.md searched
 - [ ] All Trend-Sensitive Patterns from security-checks.md searched
 - [ ] Technology stack trend check performed
-- [ ] Each finding classified into confirmed_risk / suspected_risk / defense_gap / hardening / policy
-- [ ] suspected_risk findings have confidence (high/medium/low) and a rationale stating what would resolve the ambiguity
-- [ ] suspected_risk findings routed to status per Status Determination (high-confidence on primary boundary → needs_revision; otherwise → approved_with_notes)
+- [ ] Each finding classified into confirmed_risk / defense_gap
+- [ ] Every finding requires correction; optional hardening, policy, and non-blocking speculation were excluded
 - [ ] False positives excluded considering runtime environment and existing mitigations
 - [ ] Committed secrets checked (blocked status if found)
 - [ ] Every finding has a stable ID

--- a/dev-workflows-fullstack/agents/security-reviewer.md
+++ b/dev-workflows-fullstack/agents/security-reviewer.md
@@ -96,7 +96,7 @@ Consolidate all findings, remove duplicates, and classify each finding into one 
 
 Evaluate every finding against the project's runtime environment, framework protections, and existing mitigations. Apply the following rules per category:
 
-- Emit a finding only when current evidence shows a correction is required to satisfy a governing security requirement or protect an in-scope security boundary. Exclude optional hardening, organizational policy, and speculative observations that do not meet this condition.
+- Emit a finding only when current evidence shows a correction is required to satisfy a governing security requirement or protect an in-scope security boundary.
 - Reserve `confirmed_risk` for findings where the attack surface is exploitable as-is. The category represents post-filter conclusions, not raw observations.
 - Emit a `defense_gap` only when current evidence shows that a governing security requirement or in-scope security boundary lacks a required defensive control.
 - Give every finding a stable ID.
@@ -108,7 +108,7 @@ Each finding must include a `rationale` field whose content depends on the categ
 
 | Category | Rationale must explain |
 |----------|----------------------|
-| **confirmed_risk** | Why the attack surface is exploitable as-is and why existing mitigations do not remove that exploitability |
+| **confirmed_risk** | Why the attack surface is exploitable as-is and remains exploitable after applying existing mitigations |
 | **defense_gap** | Which required defensive control is missing or insufficient and which boundary it protects |
 
 ## Output Format
@@ -164,8 +164,8 @@ When `prior_feedback` is present, also include `prior_feedback_reconciliation` w
 - [ ] All Trend-Sensitive Patterns from security-checks.md searched
 - [ ] Technology stack trend check performed
 - [ ] Each finding classified into confirmed_risk / defense_gap
-- [ ] Every finding requires correction; optional hardening, policy, and non-blocking speculation were excluded
-- [ ] False positives excluded considering runtime environment and existing mitigations
+- [ ] The findings array contains only items that require correction
+- [ ] Every finding remains valid after considering the runtime environment and existing mitigations
 - [ ] Committed secrets checked (blocked status if found)
 - [ ] Every finding has a stable ID
 - [ ] When prior feedback is present, every received ID appears once in `prior_feedback_reconciliation`

--- a/dev-workflows-fullstack/agents/task-executor-frontend.md
+++ b/dev-workflows-fullstack/agents/task-executor-frontend.md
@@ -63,7 +63,7 @@ Escalation thresholds:
 
 ### Step4: Core Mechanism Preservation Check (Any YES → Immediate Escalation)
 Preserve the core mechanism the task, AC, Design Doc, or UI Spec requires. Implementation details (variable names, internal logic order, local structure) stay free to change; the required mechanism itself stays intact.
-□ Required core mechanism replaced by a simpler or weaker substitute? (passing tests do not make a substitute acceptable)
+□ Required core mechanism replaced by a simpler or weaker substitute, including one justified only by passing tests?
 □ Required core mechanism infeasible as specified?
 Any YES → stop and escalate with `escalation_type: "design_compliance_violation"`, recording the required mechanism, the proposed alternative, the resulting change in behavior, and the condition that would lift the block.
 
@@ -208,7 +208,7 @@ Return the final response per Structured Response Specification. For research/an
 **mutationEvidence**: Use `[]` when no mutation verification ran; otherwise populate every field in the schema below with revision-bound evidence.
 
 ### 1. Task Completion Response
-Report in the following JSON format upon task completion (**without executing quality checks or commits**, delegating to quality assurance process):
+Complete this agent's work by returning the following JSON; the quality assurance process performs quality checks and commits:
 
 ```json
 {
@@ -331,7 +331,7 @@ This gate runs immediately before producing the final JSON response.
 ☐ Implementation is consistent with the Investigation Notes recorded at Step 2 (when Investigation Targets were present)
 ☐ Adjacent Case Sweep evidence records each inspected case and disposition, or the searched surface and no-case result, when the current task triggers the sweep
 ☐ Every Operation Verification Method succeeds and Verification Focus is satisfied when present
-☐ When test runs are cited as `runnableCheck` evidence, they are substantive and executable per the runnableCheck.result field spec (skipped tests, placeholder/TODO-only bodies, always-passing assertions, and 0-match runner reports do not count); non-test verification (build/typecheck/CLI) is not subject to this check
+☐ Test runs cited as `runnableCheck` evidence meet the substantive and executable rules in the `runnableCheck.result` field specification
 ☐ Final response is a single JSON with `status: "completed"` or `status: "escalation_needed"` and matches the schema in Structured Response Specification
 
 **ENFORCEMENT**: When any gate item is unchecked, return `escalation_needed` with `escalation_type: "design_compliance_violation"` for incomplete work or divergence from governing sources and Investigation Notes.

--- a/dev-workflows-fullstack/agents/task-executor.md
+++ b/dev-workflows-fullstack/agents/task-executor.md
@@ -58,7 +58,7 @@ Escalation thresholds:
 
 ### Step4: Core Mechanism Preservation Check (Any YES → Immediate Escalation)
 Preserve the core mechanism the task, AC, Design Doc, or referenced materials require. Implementation details (variable names, internal ordering, local structure) stay free to change; the required mechanism itself stays intact.
-□ Required core mechanism replaced by a simpler or weaker substitute? (passing tests do not make a substitute acceptable)
+□ Required core mechanism replaced by a simpler or weaker substitute, including one justified only by passing tests?
 □ Required core mechanism infeasible as specified?
 Any YES → stop and escalate with `escalation_type: "design_compliance_violation"`, recording the required mechanism, the proposed alternative, the resulting change in behavior, and the condition that would lift the block.
 
@@ -205,7 +205,7 @@ Return the final response per Structured Response Specification. For research/an
 **mutationEvidence**: Use `[]` when no mutation verification ran; otherwise populate every field in the schema below with revision-bound evidence.
 
 ### 1. Task Completion Response
-Report in the following JSON format upon task completion (**without executing quality checks or commits**, delegating to quality assurance process):
+Complete this agent's work by returning the following JSON; the quality assurance process performs quality checks and commits:
 
 ```json
 {
@@ -326,7 +326,7 @@ This gate runs immediately before producing the final JSON response.
 ☐ Implementation is consistent with the Investigation Notes recorded at Step 2 (when Investigation Targets were present)
 ☐ Adjacent Case Sweep evidence records each inspected case and disposition, or the searched surface and no-case result, when the current task triggers the sweep
 ☐ Every Operation Verification Method succeeds and Verification Focus is satisfied when present
-☐ When test runs are cited as `runnableCheck` evidence, they are substantive and executable per the runnableCheck.result field spec (skipped tests, placeholder/TODO-only bodies, always-passing assertions, and 0-match runner reports do not count); non-test verification (build/typecheck/CLI) is not subject to this check
+☐ Test runs cited as `runnableCheck` evidence meet the substantive and executable rules in the `runnableCheck.result` field specification
 ☐ Final response is a single JSON with `status: "completed"` or `status: "escalation_needed"` and matches the schema in Structured Response Specification
 
 **ENFORCEMENT**: When any gate item is unchecked, return `escalation_needed` with `escalation_type: "design_compliance_violation"` for incomplete work or divergence from governing sources and Investigation Notes.

--- a/dev-workflows-fullstack/agents/verifier.md
+++ b/dev-workflows-fullstack/agents/verifier.md
@@ -40,7 +40,7 @@ Solution derivation is out of scope for this agent.
 - Grasp areas explicitly marked as uninvestigated
 
 **impactAnalysis Validity Check**:
-- Verify logical validity of impactAnalysis for each failure point (without additional searches)
+- Verify the logical validity of each failure point's impactAnalysis using only the supplied investigation evidence; perform additional searches in Step 2
 
 ### Step 2: Triangulation Supplementation
 Identify source types NOT covered in the investigation's `investigationSources`, then investigate at least one:
@@ -78,7 +78,7 @@ For each failure point, critically evaluate:
 - Official documentation of packages in use
 
 ### Step 6: Failure Point Evaluation and Consistency Verification
-Evaluate each failure point independently (do NOT select a single "winner"):
+Evaluate every failure point independently and allow multiple confirmed failure points:
 
 | finalStatus | Definition |
 |-------------|------------|
@@ -92,7 +92,7 @@ Evaluate each failure point independently (do NOT select a single "winner"):
 - Example: "The implementation is wrong" → Was design_gap considered?
 - If inconsistent, explicitly note "Investigation focus may be misaligned with user report"
 
-**Conclusion**: Evaluate each failure point individually. Multiple failure points can be simultaneously valid — do not force selection of a single root cause. For each pair of confirmed failure points, determine their relationship (independent / dependent / same_chain) and record in `failurePointRelationships`
+**Conclusion**: Evaluate each failure point individually and retain every supported cause. For each pair of confirmed failure points, determine their relationship (independent / dependent / same_chain) and record it in `failurePointRelationships`
 
 ## Coverage Assessment Criteria
 

--- a/dev-workflows-fullstack/skills/ai-development-guide/SKILL.md
+++ b/dev-workflows-fullstack/skills/ai-development-guide/SKILL.md
@@ -280,7 +280,7 @@ Proceed when discovery and understanding cover the files and behaviors named by 
 When an artifact made obsolete by the requested change is detected:
 - Delete it in the same change when its callers and generated/operational uses are checked
 - Preserve and report it when obsolescence is uncertain or deletion would expand beyond the files and behaviors named by the user or current task/design artifact
-- Do not implement unrelated dormant code merely because it was discovered
+- Keep unrelated dormant code outside the implementation scope
 
 ### Existing Code Modification
 

--- a/dev-workflows-fullstack/skills/coding-principles/SKILL.md
+++ b/dev-workflows-fullstack/skills/coding-principles/SKILL.md
@@ -127,7 +127,7 @@ One comment per decision. If a comment restates what the names and control flow 
 - Delete commented-out code (retrieve from git history when needed)
 
 ### Comment Quality
-- Write comments that remain accurate regardless of future code changes; avoid references to dates, versions, or temporary state
+- Base comments on stable rationale, limits, and contracts rather than dates, versions, or temporary state
 - Update comments when changing code
 - Use proper grammar and formatting
 - Write for future maintainers
@@ -138,7 +138,7 @@ One comment per decision. If a comment restates what the names and control flow 
 - **Small steps**: Make one change at a time
 - **Maintain working state**: Keep tests passing
 - **Verify behavior**: Run tests after each change
-- **Incremental improvement**: Don't aim for perfection immediately
+- **Incremental improvement**: Make the smallest sufficient improvement in each increment
 
 ### Refactoring Triggers
 - Code duplication (DRY principle)

--- a/dev-workflows-fullstack/skills/documentation-criteria/SKILL.md
+++ b/dev-workflows-fullstack/skills/documentation-criteria/SKILL.md
@@ -56,7 +56,7 @@ Qualifying durable choices include:
 - reversing or superseding an accepted architecture decision;
 - choosing an irreversible or high-cost-to-reverse data or compatibility strategy.
 
-A local contract, data-flow, state, or component change belongs in the Design Doc when it follows an accepted design, has one evident repository-supported implementation, or remains cheaply reversible. Counts of files, consumers, nesting levels, states, steps, and asynchronous operations are supporting evidence rather than ADR criteria. Generic technical concerns, operational possibilities, and rejected activities do not create ADRs by themselves.
+A local contract, data-flow, state, or component change belongs in the Design Doc when it follows an accepted design, has one evident repository-supported implementation, or remains cheaply reversible. Counts of files, consumers, nesting levels, states, steps, and asynchronous operations are supporting evidence rather than ADR criteria. Only the qualifying decisions above create ADRs; generic technical concerns, operational possibilities, and rejected activities can only support that determination.
 
 ## Detailed Document Definitions
 
@@ -114,7 +114,7 @@ Create a UI Spec when screen structure, transitions, component/state interaction
 
 **Prototype Code Handling**:
 - Prototype code provided by user is placed in `docs/ui-spec/assets/{feature-name}/`
-- Prototype is an attachment to UI Spec, never the source of truth
+- Prototype code supports the UI Spec as an attachment
 - UI Spec + Design Doc are the canonical specifications
 
 ### Design Document

--- a/dev-workflows-fullstack/skills/external-resource-context/SKILL.md
+++ b/dev-workflows-fullstack/skills/external-resource-context/SKILL.md
@@ -55,7 +55,7 @@ Each domain reference defines the axes and the question template.
 
 ### Two-Phase Hearing
 
-1. **Structured hearing** — for each axis defined in every selected domain reference, present the user with AskUserQuestion using the choices listed there (always include "Not applicable" as an option). For each non-N/A axis, follow up with an access-method question (URL / MCP name / file path / command). Domain references end after their axes; they do not add their own self-declaration question.
+1. **Structured hearing** — for each axis defined in every selected domain reference, present the user with AskUserQuestion using the choices listed there (always include "Not applicable" as an option). For each non-N/A axis, follow up with an access-method question (URL / MCP name / file path / command). Each domain reference ends after its access-method follow-up; phase 2 owns the single self-declaration question.
 
 2. **Self-declaration** — after the structured axes for all selected domains are complete, present one integrated AskUserQuestion: "Are there any other external resources for this work that the structured questions did not cover? If yes, describe them in your next message." If the user describes additional resources, append them to the storage file under an "Additional resources" subsection.
 

--- a/dev-workflows-fullstack/skills/frontend-ai-guide/SKILL.md
+++ b/dev-workflows-fullstack/skills/frontend-ai-guide/SKILL.md
@@ -126,7 +126,7 @@ function EmailInput({ context }: { context: 'user' | 'contact' | 'admin' }) { /*
 
 ## Quality Check Workflow
 
-Read `package.json` scripts and run them with the project's package manager (`packageManager` field). Map the project's actual script names to the phases below — do not assume fixed names.
+Read `package.json` scripts, map the project's actual commands to the phases below, and run them with the project's package manager (`packageManager` field).
 
 ### Phases (run in order)
 1. **Lint/format** — the project's formatter + linter (e.g., Biome, or ESLint + Prettier)
@@ -189,7 +189,7 @@ Proceed when the user-requested or task-defined scope, consumers, state flow, an
 
 ### Unused Code Deletion Rule
 
-When the requested change makes a component, hook, utility, document, or configuration entry obsolete, delete it after checking its consumers and generated/operational use. Preserve and report uncertain or out-of-scope cleanup; do not implement unrelated dormant code merely because it was discovered.
+When the requested change makes a component, hook, utility, document, or configuration entry obsolete, delete it after checking its consumers and generated/operational use. Preserve and report uncertain or out-of-scope cleanup, and keep unrelated dormant code outside the implementation scope.
 
 ### Existing Code Deletion Decision Flow
 

--- a/dev-workflows-fullstack/skills/implementation-approach/SKILL.md
+++ b/dev-workflows-fullstack/skills/implementation-approach/SKILL.md
@@ -65,7 +65,7 @@ External Research: Official/current sources only when repository evidence cannot
 - Decorator Pattern: Phased enhancement of existing features
 - Bridge Pattern: Flexibility through abstraction
 
-Use these patterns only when their named migration or dependency problem exists. Start with the direct strategy. Compare an alternative when it would materially change risk, rollout, compatibility, or the early verification point; do not add a pattern or combination only to increase the option count.
+Use these patterns only when their named migration or dependency problem exists. Start with the direct strategy. Compare an alternative when it would materially change risk, rollout, compatibility, or the early verification point. Keep the option set limited to patterns that produce one of those material differences.
 
 ### Phase 4: Risk Assessment and Control
 

--- a/dev-workflows-fullstack/skills/integration-e2e-testing/SKILL.md
+++ b/dev-workflows-fullstack/skills/integration-e2e-testing/SKILL.md
@@ -43,7 +43,7 @@ One input Design Doc is one budget scope: apply each lane budget once across all
 
 ROI is used to **rank candidates within the same test type** (integration candidates against each other, E2E candidates against each other). Cross-type comparison is unnecessary because integration and E2E budgets are selected independently.
 
-Score every input before calculating ROI. For the three numeric inputs, use only `0`, `5`, or `10`; do not interpolate intermediate values. Legal Requirement remains boolean:
+Score every input before calculating ROI. For the three numeric inputs, use exactly `0`, `5`, or `10`. Legal Requirement remains boolean:
 
 | Input | Scale |
 |---|---|

--- a/dev-workflows-fullstack/skills/llm-friendly-context/SKILL.md
+++ b/dev-workflows-fullstack/skills/llm-friendly-context/SKILL.md
@@ -65,7 +65,7 @@ Before sending a prompt or artifact to another agent, verify:
 
 - [ ] The target action is explicit.
 - [ ] Required input paths and source artifacts are named.
-- [ ] Accepted decisions and constraints are stated once, without alternate wording.
+- [ ] Accepted decisions and constraints use one canonical wording.
 - [ ] Output format or expected status fields are specified.
 - [ ] Success criteria are observable.
 - [ ] Ambiguous expressions have been rewritten or marked as unresolved.

--- a/dev-workflows-fullstack/skills/recipe-build/SKILL.md
+++ b/dev-workflows-fullstack/skills/recipe-build/SKILL.md
@@ -138,7 +138,7 @@ Before the completion report, delete the implementation task files this recipe c
 - Delete every file in the Consumed Task Set
 - Preserve the work plan itself (`docs/plans/{plan-name}.md`) — the user decides whether to delete it after final review
 
-If task files cannot be deleted (filesystem error), report the failure but do not block the completion report.
+If task-file deletion fails with a filesystem error, report the failure and continue to the completion report.
 
 ## Completion Report Contract
 

--- a/dev-workflows-fullstack/skills/recipe-diagnose/SKILL.md
+++ b/dev-workflows-fullstack/skills/recipe-diagnose/SKILL.md
@@ -121,7 +121,7 @@ prompt: |
   Re-investigate with focus on the following gaps:
   - Missing: [unsatisfied Step 2 Quality Check items, copied as written]
 
-  Previous investigation results (for context, do not re-investigate covered areas):
+  Use these previous investigation results as context and investigate only the gaps listed above:
   [Previous investigation JSON]
 ```
 

--- a/dev-workflows-fullstack/skills/recipe-front-build/SKILL.md
+++ b/dev-workflows-fullstack/skills/recipe-front-build/SKILL.md
@@ -138,7 +138,7 @@ Before the completion report, delete the implementation task files this recipe c
 - Delete every file in the Consumed Task Set
 - Preserve the work plan itself (`docs/plans/{plan-name}.md`) — the user decides whether to delete it after final review
 
-If task files cannot be deleted (filesystem error), report the failure but do not block the completion report.
+If task-file deletion fails with a filesystem error, report the failure and continue to the completion report.
 
 ## Completion Report Contract
 

--- a/dev-workflows-fullstack/skills/recipe-front-review/SKILL.md
+++ b/dev-workflows-fullstack/skills/recipe-front-review/SKILL.md
@@ -62,7 +62,7 @@ Invoke security-reviewer using Agent tool:
 
 ### Step 4: Verdict and Response
 
-**If security-reviewer returned `blocked`**: Stop immediately. Report the blocked finding and escalate to user. Do not proceed to fix steps.
+**If security-reviewer returned `blocked`**: Stop immediately. Report its blocking reason and any returned finding, then escalate to user. Do not proceed to fix steps.
 
 Apply the Review Resolution Gate to both outputs before reporting or routing them. Finding dispositions determine routing.
 
@@ -80,7 +80,6 @@ Then present the adjudicated result to the user. Group `apply` and `user_decisio
 Code Review: [verdict from code-reviewer]
   Acceptance Criteria:
   - [fulfilled] [item] (confidence: [high/medium/low])
-  - [partially_fulfilled] [item]: [gap] — [suggestion] [recommended: c | d]
   - [unfulfilled] [item]: [gap] — [suggestion] [recommended: c | d]
   Identifier Mismatches:
   - [identifier]: DD=[designDocValue] Code=[codeValue] at [location] [recommended: c | d]
@@ -91,9 +90,6 @@ Security Review: [status from security-reviewer]
   Findings by category:
   - [confirmed_risk] [location]: [description] — [rationale] [recommended: c]
   - [defense_gap] [location]: [description] — [rationale] [recommended: c]
-  - [hardening] [location]: [description] — [rationale] [recommended: c]
-  - [policy] [location]: [description] — [rationale] [recommended: c]
-  Notes: [notes from security-reviewer, if present]
 
 Approve the proposed changes or decide unresolved items:
   c) Code-side fix       — code violates Design Doc; modify code to match
@@ -175,7 +171,6 @@ Security Review:
   Initial: [status]
   Correction review: [status for the re-review scope] (if fixes executed)
   Reconciliation: [resolved / withdrawn / maintained by finding ID]
-  Notes: [notes from approved_with_notes, if any]
 
 Declined actionable findings:
 - [ID: governing reason — evidence] (only when any were declined)

--- a/dev-workflows-fullstack/skills/recipe-front-review/SKILL.md
+++ b/dev-workflows-fullstack/skills/recipe-front-review/SKILL.md
@@ -62,7 +62,7 @@ Invoke security-reviewer using Agent tool:
 
 ### Step 4: Verdict and Response
 
-**If security-reviewer returned `blocked`**: Stop immediately. Report its blocking reason and any returned finding, then escalate to user. Do not proceed to fix steps.
+**If security-reviewer returned `blocked`**: Stop at this gate, report its blocking reason and any returned finding, then escalate to the user. The workflow remains at this gate pending the user's response.
 
 Apply the Review Resolution Gate to both outputs before reporting or routing them. Finding dispositions determine routing.
 

--- a/dev-workflows-fullstack/skills/recipe-fullstack-build/SKILL.md
+++ b/dev-workflows-fullstack/skills/recipe-fullstack-build/SKILL.md
@@ -156,7 +156,7 @@ Before the completion report, delete the implementation task files this recipe c
 - Delete every file in the Consumed Task Set
 - Preserve the work plan itself (`docs/plans/{plan-name}.md`) — the user decides whether to delete it after final review
 
-If task files cannot be deleted (filesystem error), report the failure but do not block the completion report.
+If task-file deletion fails with a filesystem error, report the failure and continue to the completion report.
 
 ## Completion Report Contract
 

--- a/dev-workflows-fullstack/skills/recipe-reverse-engineer/SKILL.md
+++ b/dev-workflows-fullstack/skills/recipe-reverse-engineer/SKILL.md
@@ -394,7 +394,7 @@ prompt: |
 
 Output summary including:
 - Generated documents table (Type, Name, Verification Status, Review Status)
-- Action items (critical discrepancies, undocumented features, flagged items)
+- Action items (undocumented features, flagged items)
 - Declined actionable findings with ID, governing reason, and evidence, when any occurred
 - Next steps checklist
 

--- a/dev-workflows-fullstack/skills/recipe-review/SKILL.md
+++ b/dev-workflows-fullstack/skills/recipe-review/SKILL.md
@@ -62,7 +62,7 @@ Invoke security-reviewer using Agent tool:
 
 ### Step 4: Verdict and Response
 
-**If security-reviewer returned `blocked`**: Stop immediately. Report the blocked finding and escalate to user. Do not proceed to fix steps.
+**If security-reviewer returned `blocked`**: Stop immediately. Report its blocking reason and any returned finding, then escalate to user. Do not proceed to fix steps.
 
 Apply the Review Resolution Gate to both outputs before reporting or routing them. Finding dispositions determine routing.
 
@@ -80,7 +80,6 @@ Then present the adjudicated result to the user. Group `apply` and `user_decisio
 Code Review: [verdict from code-reviewer]
   Acceptance Criteria:
   - [fulfilled] [item] (confidence: [high/medium/low])
-  - [partially_fulfilled] [item]: [gap] — [suggestion] [recommended: c | d]
   - [unfulfilled] [item]: [gap] — [suggestion] [recommended: c | d]
   Identifier Mismatches:
   - [identifier]: DD=[designDocValue] Code=[codeValue] at [location] [recommended: c | d]
@@ -91,9 +90,6 @@ Security Review: [status from security-reviewer]
   Findings by category:
   - [confirmed_risk] [location]: [description] — [rationale] [recommended: c]
   - [defense_gap] [location]: [description] — [rationale] [recommended: c]
-  - [hardening] [location]: [description] — [rationale] [recommended: c]
-  - [policy] [location]: [description] — [rationale] [recommended: c]
-  Notes: [notes from security-reviewer, if present]
 
 Approve the proposed changes or decide unresolved items:
   c) Code-side fix       — code violates Design Doc; modify code to match
@@ -175,7 +171,6 @@ Security Review:
   Initial: [status]
   Correction review: [status for the re-review scope] (if fixes executed)
   Reconciliation: [resolved / withdrawn / maintained by finding ID]
-  Notes: [notes from approved_with_notes, if any]
 
 Declined actionable findings:
 - [ID: governing reason — evidence] (only when any were declined)

--- a/dev-workflows-fullstack/skills/recipe-review/SKILL.md
+++ b/dev-workflows-fullstack/skills/recipe-review/SKILL.md
@@ -62,7 +62,7 @@ Invoke security-reviewer using Agent tool:
 
 ### Step 4: Verdict and Response
 
-**If security-reviewer returned `blocked`**: Stop immediately. Report its blocking reason and any returned finding, then escalate to user. Do not proceed to fix steps.
+**If security-reviewer returned `blocked`**: Stop at this gate, report its blocking reason and any returned finding, then escalate to the user. The workflow remains at this gate pending the user's response.
 
 Apply the Review Resolution Gate to both outputs before reporting or routing them. Finding dispositions determine routing.
 

--- a/dev-workflows-fullstack/skills/subagents-orchestration-guide/SKILL.md
+++ b/dev-workflows-fullstack/skills/subagents-orchestration-guide/SKILL.md
@@ -170,8 +170,8 @@ For Small, execute one direct-scope 4-step cycle and complete when quality-fixer
 
 | Verifier | Pass | Fail | Blocked |
 |----------|------|------|---------|
-| code-verifier | `summary.status` is `consistent` or `mostly_consistent` | `summary.status` is `needs_review` or `inconsistent` | `summary.status` is `blocked` → Escalate to user |
-| security-reviewer | `status` is `approved` or `approved_with_notes` | `status` is `needs_revision` | `status` is `blocked` → Escalate to user |
+| code-verifier | `summary.status` is `consistent` | `summary.status` is `needs_review` or `inconsistent` | `summary.status` is `blocked` → Escalate to user |
+| security-reviewer | `status` is `approved` | `status` is `needs_revision` | `status` is `blocked` → Escalate to user |
 
 **Fix-cycle handoff**: Apply Review Resolution, then pass each required executor the complete `apply` finding objects verbatim with only their dispositions added. Carry `prior_feedback` to reviewer inputs that support reconciliation.
 

--- a/dev-workflows-fullstack/skills/test-implement/SKILL.md
+++ b/dev-workflows-fullstack/skills/test-implement/SKILL.md
@@ -23,7 +23,7 @@ All tests follow **Arrange-Act-Assert**:
 ### Test Independence
 - Each test runs independently without depending on other tests
 - No shared mutable state between tests
-- Deterministic execution — no random or time dependencies without mocking
+- Deterministic execution — mock random and time dependencies
 
 ### Naming
 - Test names describe expected behavior from user perspective

--- a/dev-workflows-fullstack/skills/test-implement/references/e2e.md
+++ b/dev-workflows-fullstack/skills/test-implement/references/e2e.md
@@ -38,7 +38,7 @@ Use the repository's existing seed and authentication mechanisms. Create per-tes
 ## Locator and Assertion Rules
 
 - Follow the repository's locator convention; otherwise prefer accessible role/name or label locators, then stable test IDs when no semantic locator exists.
-- Assert user-observable state, navigation, accessibility, or persisted behavior named by the skeleton. Avoid assertions tied only to CSS classes or internal DOM structure.
+- Assert user-observable state, navigation, accessibility, or persisted behavior named by the skeleton. Treat assertions tied only to CSS classes or internal DOM structure as insufficient proof.
 - When the UI specification defines responsive behavior, run the affected interaction at the specified viewport; otherwise use the repository's default browser matrix.
 - Each test starts from isolated state and remains independent of execution order.
 

--- a/dev-workflows-fullstack/skills/test-implement/references/frontend.md
+++ b/dev-workflows-fullstack/skills/test-implement/references/frontend.md
@@ -13,7 +13,7 @@ Before writing a test, inspect package scripts, runner configuration, setup file
 
 - Concentrate rigor on shared components, hooks, and utilities with a wide blast radius. Use integration or E2E coverage for higher-composition surfaces when their boundary is the behavior under test.
 - For a behavior-preserving refactor, establish passing regression or characterization evidence before the change and rerun it afterward.
-- Configuration that changes runtime or build behavior requires executable validation. Documentation-only changes do not require test-first development.
+- Test-first scope covers executable behavior; configuration that changes runtime or build behavior requires executable validation.
 - Continuity tests cover existing feature behavior affected by the change; long-term performance and operational testing remain infrastructure concerns unless the accepted work includes them.
 
 ## Mock Boundary

--- a/dev-workflows-fullstack/skills/testing-principles/SKILL.md
+++ b/dev-workflows-fullstack/skills/testing-principles/SKILL.md
@@ -39,7 +39,7 @@ RED: confirm the new test fails for the intended reason. GREEN: implement the sm
 
 Mock-based tests are sufficient when data access is only a dependency of the behavior under test. Verify against the project's real database engine or its accepted equivalent when the subject is a query, repository implementation, schema constraint, or migration compatibility. Resolve the test environment from repository configuration; when no representative environment exists and adding one is outside the approved work, report the missing verification decision.
 
-Cross-check data-access code against the schema source named in the Design Doc or repository configuration. Successful mocks do not prove table, column, type, constraint, or dialect compatibility.
+Cross-check data-access code against the schema source named in the Design Doc or repository configuration. Schema-source verification is required to prove table, column, type, constraint, or dialect compatibility; successful mocks prove behavior only at the mocked boundary.
 
 ## Verification Requirements
 

--- a/dev-workflows/.claude-plugin/plugin.json
+++ b/dev-workflows/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflows",
   "description": "Skills + Subagents for backend development - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows/agents/acceptance-test-generator.md
+++ b/dev-workflows/agents/acceptance-test-generator.md
@@ -19,7 +19,7 @@ Operates in an independent context, executing autonomously until task completion
 
 ### Implementation Approach Compliance
 - **Test Code Generation**: MUST strictly comply with Design Doc implementation patterns (function vs class selection)
-- **Contract Safety**: MUST enforce testing-principles skill mock creation and contract definition rules without exception
+- **Contract Safety**: Apply the testing-principles skill mock creation and contract definition rules to every generated skeleton
 
 ## Input Parameters
 
@@ -50,7 +50,7 @@ Test type definitions, budgets, and ROI calculations are specified in **integrat
 | **System Context** | Requires full system integration? | Skip | [UNIT_LEVEL] |
 | **Upstream Scope** | In Include list? | Skip | [OUT_OF_SCOPE] |
 
-**AC Include/Exclude Criteria**:
+**AC Selection Criteria**:
 
 **Include** (High automation ROI):
 - Business logic correctness (calculations, state transitions, data transformations)
@@ -58,7 +58,7 @@ Test type definitions, budgets, and ROI calculations are specified in **integrat
 - User-visible functionality completeness
 - Error handling behavior (what user sees/experiences)
 
-**Exclude** (Low ROI in LLM/CI/CD environment):
+**Use alternative verification** (Low ROI in LLM/CI/CD environment):
 - External service real connections → Use contract/interface verification instead
 - Performance metrics → Non-deterministic in CI, defer to load testing
 - Implementation details → Focus on observable behavior
@@ -116,7 +116,7 @@ ROI calculation formula and cost table are defined in **integration-e2e-testing 
      - A downstream service receives a real event/message (e.g., topic publish, queue enqueue, webhook call)
      - An external service receives a real API call with the expected payload
      - Transactional consistency across services (e.g., two-phase commit, saga compensation)
-5. **Sort by ROI** within each lane using the score and tie-break order from integration-e2e-testing skill — this is the single ranking step; Phase 4 budget enforcement consumes this ranked list directly without re-sorting.
+5. **Sort by ROI** within each lane using the score and tie-break order from integration-e2e-testing skill — this is the single ranking step, and Phase 4 budget enforcement processes the ranked list in the order produced here.
 
 **Output**: Ranked, deduplicated candidate list with lane assigned per E2E candidate.
 

--- a/dev-workflows/agents/code-reviewer.md
+++ b/dev-workflows/agents/code-reviewer.md
@@ -124,7 +124,7 @@ For each function/method in implementation files, check against coding-principle
 #### 3-3. Test Coverage for Acceptance Criteria
 - For each AC marked fulfilled: Glob/Grep for corresponding test cases
 - Record which ACs have test coverage and which do not
-- For each test claimed as AC coverage, inspect the test body and confirm at least one assertion exercises the AC's observable behavior. Tests that are `skip`/`xit`-marked (on tests that should run), contain only TODO/placeholder bodies, or use always-true assertions (e.g., `expect(true).toBe(true)`, `expect(arr.length).toBeGreaterThanOrEqual(0)`) do not count as AC coverage even when grep finds them; record those as `coverage_gap` with rationale explaining the substance issue. Tests verifying intentional absence (e.g., empty list, null result) are substantive when the absence is the AC's expectation.
+- For each test claimed as AC coverage, inspect the test body and count it as coverage only when at least one assertion exercises the AC's observable behavior. Record `skip`/`xit`-marked tests that should run, TODO/placeholder-only bodies, and always-true assertions (e.g., `expect(true).toBe(true)`, `expect(arr.length).toBeGreaterThanOrEqual(0)`) as `coverage_gap` even when grep finds them, with rationale explaining the substance issue. Tests verifying intentional absence (e.g., empty list, null result) are substantive when the absence is the AC's expectation.
 - Beyond substance, confirm each AC test exercises the claimed boundary and would turn red if the promised behavior regressed. When a task file is in scope, verify its Operation Verification Methods and optional Verification Focus. Missing required evidence is a `coverage_gap`.
 
 #### Finding Classification

--- a/dev-workflows/agents/code-reviewer.md
+++ b/dev-workflows/agents/code-reviewer.md
@@ -71,7 +71,7 @@ When `prior_feedback` is present, complete the correction re-review here:
 
 For each acceptance criterion extracted in Step 1:
 - Search implementation files for the corresponding code
-- Determine status: fulfilled / partially fulfilled / unfulfilled
+- Mark it `fulfilled` only when evidence covers every governing boundary path; otherwise mark it `unfulfilled` and name each uncovered path in `gap`
 - Record the file path and relevant code location
 - Note any deviations from the Design Doc specification
 - For behavior-changing ACs, confirm the evidence covers the boundary paths, not only the main path: where a distinct branch, state, input class, lifecycle step, or fallback governs the behavior, verify it is exercised. Compare the source/referenced behavior and the implemented behavior at the same granularity; an unsupported change in a boundary dimension is a `dd_violation`
@@ -185,13 +185,13 @@ Verify against the Design Doc architecture:
 verdict:              string ("pass" | "needs-improvement" | "needs-redesign")
 
 acceptanceCriteria[].item:        string
-acceptanceCriteria[].id:          string (required only when status is not fulfilled; stable within this review chain)
-acceptanceCriteria[].status:      string ("fulfilled" | "partially_fulfilled" | "unfulfilled")
+acceptanceCriteria[].id:          string (required only when status is unfulfilled; stable within this review chain)
+acceptanceCriteria[].status:      string ("fulfilled" | "unfulfilled")
 acceptanceCriteria[].confidence:  string ("high" | "medium" | "low")
 acceptanceCriteria[].location:    string (file:line; null if unimplemented)
 acceptanceCriteria[].evidence:    string[] (each "source: file:line")
-acceptanceCriteria[].gap:         string (null when fully fulfilled)
-acceptanceCriteria[].suggestion:  string (null when fully fulfilled)
+acceptanceCriteria[].gap:         string (null when status is fulfilled)
+acceptanceCriteria[].suggestion:  string (null when status is fulfilled)
 
 identifierVerification[].identifier:    string
 identifierVerification[].id:            string (required only when match is false; stable within this review chain)

--- a/dev-workflows/agents/code-verifier.md
+++ b/dev-workflows/agents/code-verifier.md
@@ -54,9 +54,9 @@ Stop expanding the search when additional evidence cannot change a discrepancy o
 - `conflict`: Observed behavior or a governing contract contradicts the document.
 - `unverified`: Available evidence cannot establish the claim; state the exact limitation and effect.
 
-Use `critical` only when the issue makes approved scope incorrect, non-executable, or non-verifiable. Use `major` for a material correction and `minor` for non-blocking precision. Group locations that share one cause and correction into one discrepancy.
+Emit a discrepancy only when leaving it unresolved can change scope, feasibility, implementation, a contract, or verification. Group locations that share one cause and correction into one discrepancy.
 
-Use `unverified` only for a specific material document claim whose unresolved truth can change scope, feasibility, implementation, a contract, or verification; assign it `critical` or `major`. Use `limitations` only for an evidence-access or coverage constraint that does not itself identify a material document claim. Record a fact in one place, not both; a material limitation becomes an `unverified` discrepancy.
+Use `unverified` only for a specific material document claim whose unresolved truth can change scope, feasibility, implementation, a contract, or verification. Use `limitations` only for an evidence-access or coverage constraint that does not itself identify a material document claim. Record a fact in one place, not both; a material limitation becomes an `unverified` discrepancy.
 
 ## Output
 
@@ -64,11 +64,11 @@ Return exactly one JSON object:
 
 ```json
 {
-  "summary": {"docType": "design-doc", "documentPath": "docs/design/example.md", "status": "consistent|mostly_consistent|needs_review|inconsistent|blocked"},
+  "summary": {"docType": "design-doc", "documentPath": "docs/design/example.md", "status": "consistent|needs_review|inconsistent|blocked"},
   "blockingReason": null,
   "inventoryCoverage": null,
   "discrepancies": [
-    {"id": "D001", "status": "drift|gap|conflict|unverified", "severity": "critical|major|minor", "claim": "document claim", "documentLocation": "section or line", "codeLocation": "file:line or null", "relatedLocations": ["other location with the same cause"], "evidence": "observed fact", "effect": "why this changes scope, feasibility, implementation, contract, or verification"}
+    {"id": "D001", "status": "drift|gap|conflict|unverified", "claim": "document claim", "documentLocation": "section or line", "codeLocation": "file:line or null", "relatedLocations": ["other location with the same cause"], "evidence": "observed fact", "effect": "why this changes scope, feasibility, implementation, contract, or verification"}
   ],
   "limitations": ["exact evidence-access or coverage constraint and its verification effect"]
 }
@@ -86,12 +86,11 @@ When `unit_inventory` is supplied, replace `inventoryCoverage: null` with this o
 
 For each inventory category, `accountedCount + excluded.length + unaccounted.length` equals `inputCount`. Report every unaccounted item as one cause-grouped `gap` discrepancy.
 
-An unaccounted inventory item makes `consistent` and `mostly_consistent` invalid; use at least `needs_review`. When the supplied inventory cannot be parsed or the counts cannot be made balanced from it, use `blocked` and state the exact input defect.
+An unaccounted inventory item makes `consistent` invalid; use at least `needs_review`. When the supplied inventory cannot be parsed or the counts cannot be made balanced from it, use `blocked` and state the exact input defect.
 
 Status rules:
 
-- `consistent`: no discrepancy or material limitation exists;
-- `mostly_consistent`: only minor precision issues or non-material coverage limitations remain, and inventory has no unaccounted item;
+- `consistent`: no discrepancy exists;
 - `needs_review`: a repairable material discrepancy, including any `unverified` discrepancy, exists;
 - `inconsistent`: governing evidence contradicts the selected outcome or contract;
 - `blocked`: required input or repository evidence is unusable for the requested verification.

--- a/dev-workflows/agents/integration-test-reviewer.md
+++ b/dev-workflows/agents/integration-test-reviewer.md
@@ -78,7 +78,7 @@ Evaluate each test for:
 - Clear Arrange section (setup)
 - Single Act (action)
 - Meaningful Assert (verification)
-- Substantive assertion: each test must execute at least one assertion that observes the AC's behavior. Always-true assertions (e.g., `expect(true).toBe(true)`, `expect(arr.length).toBeGreaterThanOrEqual(0)`), TODO-only bodies, or leftover `skip`/`xit` markers on tests that should run do not count as substantive evidence. Tests verifying intentional absence (e.g., `expect(queryAllBy*).toHaveLength(0)`) are substantive when the absence is the AC's expectation
+- Substantive assertion: classify a test as substantive only when it executes at least one assertion that observes the AC's behavior. Classify always-true assertions (e.g., `expect(true).toBe(true)`, `expect(arr.length).toBeGreaterThanOrEqual(0)`), TODO-only bodies, and leftover `skip`/`xit` markers on tests that should run as insufficient evidence. Tests verifying intentional absence (e.g., `expect(queryAllBy*).toHaveLength(0)`) are substantive when the absence is the AC's expectation
 - Isolated state per test (reset in beforeEach)
 - Deterministic execution (mock time/random sources when needed)
 

--- a/dev-workflows/agents/investigator.md
+++ b/dev-workflows/agents/investigator.md
@@ -1,6 +1,6 @@
 ---
 name: investigator
-description: Comprehensively collects problem-related information and creates evidence matrix. Use PROACTIVELY when bug/error/issue/defect/not working/strange behavior is reported. Reports only observations without proposing solutions.
+description: Comprehensively collects problem-related information and creates evidence matrix. Use PROACTIVELY when bug/error/issue/defect/not working/strange behavior is reported. Reports observations and evidence for downstream cause verification.
 tools: Read, Grep, Glob, LS, Bash, WebSearch, TaskCreate, TaskUpdate
 skills:
   - ai-development-guide
@@ -79,7 +79,7 @@ For each node listed in the path map, check whether there is a fault. A node is 
 - It contains an inconsistency that can explain the user-reported symptom
 
 If a fault is found, record it as a failure point with the required fields (see Output Format).
-- **Do NOT stop after finding the first fault** — check all remaining nodes on all mapped paths
+- After finding a fault, continue through every remaining node on all mapped paths
 - A single symptom can have multiple failure points at different layers
 
 For each failure point found:
@@ -129,7 +129,7 @@ Disclose unexplored areas and investigation limitations.
     {
       "type": "code|history|dependency|config|document|external",
       "location": "Location investigated",
-      "findings": "Facts discovered (without interpretation)"
+      "findings": "Observed facts"
     }
   ],
   "externalResearch": [

--- a/dev-workflows/agents/quality-fixer.md
+++ b/dev-workflows/agents/quality-fixer.md
@@ -46,7 +46,7 @@ Use the indicators below for this review.
 
 **Legitimate patterns** (treat as complete; proceed to Step 2): intentionally minimal implementations, functions with TODO comments but functionally correct logic, and legitimate empty/default returns that match the expected behavior.
 
-**If any incomplete implementation is found**: Stop immediately. Return `status: "stub_detected"` without proceeding to quality checks (see Output Format).
+**If any incomplete implementation is found**: Stop at Step 1 and return `status: "stub_detected"` (see Output Format).
 
 **If no incomplete implementation is found**: Proceed to Step 2.
 

--- a/dev-workflows/agents/scope-discoverer.md
+++ b/dev-workflows/agents/scope-discoverer.md
@@ -247,7 +247,7 @@ Includes additional fields:
 Run each item below before producing the final JSON. When any item is unsatisfied, return to the relevant Step and complete it before producing the JSON output.
 
 - [ ] Output is limited to scope discovery (no PRD or Design Doc content generated)
-- [ ] Every discovery is backed by evidence (no assumptions without sources)
+- [ ] Every discovery cites its source evidence
 - [ ] Low-confidence discoveries are reported with appropriate confidence markers
 - [ ] Triangulation strength reflects actual source count (weak noted when single-source)
 - [ ] Saturation check was performed before concluding discovery

--- a/dev-workflows/agents/security-reviewer.md
+++ b/dev-workflows/agents/security-reviewer.md
@@ -91,18 +91,14 @@ Consolidate all findings, remove duplicates, and classify each finding into one 
 
 | Category | Definition | Examples |
 |----------|-----------|----------|
-| **confirmed_risk** | Attack surface is exploitable as-is, post-filter conclusion with high confidence | Missing authentication on endpoint, arbitrary file access, SQL injection via string concatenation |
-| **suspected_risk** | Attack surface plausible but exploitability uncertain or partially mitigated; downgrade target from confirmed_risk when confidence drops | Potential SSRF behind a network ACL of unknown coverage; auth bypass possible only under specific framework configuration |
-| **defense_gap** | Not immediately exploitable, but a defensive layer is thin or absent | Runtime type validation missing (framework may catch it), unnecessary capability enabled |
-| **hardening** | Improvement to reduce attack surface or exposure | Reducing log verbosity, tightening error response content |
-| **policy** | Organizational or operational practice concern | Dependency version pinning strategy, CI security scanning coverage |
+| **confirmed_risk** | Attack surface is exploitable as-is, post-filter conclusion | Missing authentication on endpoint, arbitrary file access, SQL injection via string concatenation |
+| **defense_gap** | A governing security requirement or in-scope security boundary lacks a required defensive control | Runtime type validation missing at an input boundary, unnecessary capability enabled |
 
 Evaluate every finding against the project's runtime environment, framework protections, and existing mitigations. Apply the following rules per category:
 
-- For findings initially judged as `confirmed_risk` whose exploitability becomes uncertain or partially mitigated by existing defenses: downgrade to `defense_gap` or `suspected_risk` instead of discarding. Attach a `confidence` field (`high` / `medium` / `low`) and a `rationale` explaining the downgrade.
-- Reserve `confirmed_risk` for findings where the attack surface is exploitable as-is with high confidence. The category represents post-filter conclusions, not raw observations.
-- For `defense_gap`, `hardening`, and `policy` findings: evaluate whether they represent an actual risk and discard items that do not.
-- Populate `requiredFixes` only with `confirmed_risk` and high-confidence `defense_gap` items. Lower-confidence findings appear in the `findings` array without inclusion in `requiredFixes`.
+- Emit a finding only when current evidence shows a correction is required to satisfy a governing security requirement or protect an in-scope security boundary. Exclude optional hardening, organizational policy, and speculative observations that do not meet this condition.
+- Reserve `confirmed_risk` for findings where the attack surface is exploitable as-is. The category represents post-filter conclusions, not raw observations.
+- Emit a `defense_gap` only when current evidence shows that a governing security requirement or in-scope security boundary lacks a required defensive control.
 - Give every finding a stable ID.
 - Correction re-review follows Step 1-1 and emits one `prior_feedback_reconciliation` entry per received item using `resolved`, `withdrawn`, or `maintained`.
 
@@ -112,11 +108,8 @@ Each finding must include a `rationale` field whose content depends on the categ
 
 | Category | Rationale must explain |
 |----------|----------------------|
-| **confirmed_risk** | Why the attack surface is exploitable as-is, and why filter/downgrade did not apply |
-| **suspected_risk** | What conditions make exploitability uncertain, what additional information would resolve the ambiguity |
-| **defense_gap** | What defensive layer is being relied upon, and why it may be insufficient |
-| **hardening** | Why the current state is acceptable, and what improvement would add |
-| **policy** | Why this is not a technical vulnerability (what mitigates the technical risk) |
+| **confirmed_risk** | Why the attack surface is exploitable as-is and why existing mitigations do not remove that exploitability |
+| **defense_gap** | Which required defensive control is missing or insufficient and which boundary it protects |
 
 ## Output Format
 
@@ -125,32 +118,25 @@ Each finding must include a `rationale` field whose content depends on the categ
 - During execution, intermediate progress messages MAY be emitted as plain text or markdown.
 - The LAST message returned to the orchestrator MUST be a single JSON object that matches the schema below.
 - Emit the JSON object as the entire content of the final message: the message begins with `{` and ends with `}`.
-- For correction re-review, emit only `status`, `summary`, and `prior_feedback_reconciliation`; when a blocked trigger is observed, also emit its `findings` and `requiredFixes`.
+- For correction re-review, emit only `status`, `summary`, and `prior_feedback_reconciliation`; when a blocked trigger is observed, also emit its `findings`.
 
 ### Output Completion Gate
 
-Before returning the final JSON:
-1. Emit `findings` and `requiredFixes` for every status; each finding contains every field in the schema below.
-2. Derive both arrays and `status` from the consolidated findings and Status Determination.
+Before returning the final JSON, emit `findings` for every status with every field in the schema below, then derive `status` from the consolidated findings and blocked conditions.
 
 ```json
 {
-  "status": "approved|approved_with_notes|needs_revision|blocked",
+  "status": "approved|needs_revision|blocked",
   "summary": "[1-2 sentence summary]",
   "findings": [
     {
       "id": "S001",
-      "category": "confirmed_risk|suspected_risk|defense_gap|hardening|policy",
-      "confidence": "high|medium|low",
+      "category": "confirmed_risk|defense_gap",
       "location": "[file:line]",
       "description": "[specific issue found]",
       "rationale": "[category-specific, see Category-Specific Rationale]",
       "suggestion": "[specific fix]"
     }
-  ],
-  "notes": "[summary of hardening/policy findings for completion report, present when status is approved_with_notes]",
-  "requiredFixes": [
-    "[specific fix 1 — only confirmed_risk and qualifying defense_gap items]"
   ]
 }
 ```
@@ -160,25 +146,15 @@ When `prior_feedback` is present, also include `prior_feedback_reconciliation` w
 ## Status Determination
 
 ### blocked
+- Governing documents fail the Step 1 input gate
 - Credentials, API keys, or tokens found in committed code
-- High-confidence confirmed_risk that enables direct exploitation (missing authentication on public endpoint, arbitrary file access)
-- Escalate immediately with finding details — requires human intervention
+- Escalate immediately with the blocking reason and any finding details — requires human intervention
 
 ### needs_revision
-- One or more confirmed_risk findings
-- Multiple defense_gap findings that affect primary input boundaries
-- One or more high-confidence suspected_risk findings affecting primary input boundaries (auth, input boundaries, data persistence)
-- `requiredFixes` lists only confirmed_risk and qualifying defense_gap items
-
-### approved_with_notes
-- Findings are limited to hardening, policy, and/or suspected_risk (medium or low confidence) categories
-- Or defense_gap findings exist but are isolated and do not affect primary input boundaries
-- suspected_risk findings (medium/low confidence, or not on primary boundary) are listed in `notes` with the conditions that would resolve their ambiguity
-- Notes are included in the completion report for awareness
+- One or more findings require correction
 
 ### approved
-- No meaningful findings after consolidation
-- Any suspected_risk found has been resolved (downgraded to defense_gap then discarded, or upgraded to confirmed_risk and routed elsewhere)
+- No finding requires correction after consolidation
 
 ## Quality Checklist
 
@@ -187,9 +163,8 @@ When `prior_feedback` is present, also include `prior_feedback_reconciliation` w
 - [ ] All Stable Patterns from security-checks.md searched
 - [ ] All Trend-Sensitive Patterns from security-checks.md searched
 - [ ] Technology stack trend check performed
-- [ ] Each finding classified into confirmed_risk / suspected_risk / defense_gap / hardening / policy
-- [ ] suspected_risk findings have confidence (high/medium/low) and a rationale stating what would resolve the ambiguity
-- [ ] suspected_risk findings routed to status per Status Determination (high-confidence on primary boundary → needs_revision; otherwise → approved_with_notes)
+- [ ] Each finding classified into confirmed_risk / defense_gap
+- [ ] Every finding requires correction; optional hardening, policy, and non-blocking speculation were excluded
 - [ ] False positives excluded considering runtime environment and existing mitigations
 - [ ] Committed secrets checked (blocked status if found)
 - [ ] Every finding has a stable ID

--- a/dev-workflows/agents/security-reviewer.md
+++ b/dev-workflows/agents/security-reviewer.md
@@ -96,7 +96,7 @@ Consolidate all findings, remove duplicates, and classify each finding into one 
 
 Evaluate every finding against the project's runtime environment, framework protections, and existing mitigations. Apply the following rules per category:
 
-- Emit a finding only when current evidence shows a correction is required to satisfy a governing security requirement or protect an in-scope security boundary. Exclude optional hardening, organizational policy, and speculative observations that do not meet this condition.
+- Emit a finding only when current evidence shows a correction is required to satisfy a governing security requirement or protect an in-scope security boundary.
 - Reserve `confirmed_risk` for findings where the attack surface is exploitable as-is. The category represents post-filter conclusions, not raw observations.
 - Emit a `defense_gap` only when current evidence shows that a governing security requirement or in-scope security boundary lacks a required defensive control.
 - Give every finding a stable ID.
@@ -108,7 +108,7 @@ Each finding must include a `rationale` field whose content depends on the categ
 
 | Category | Rationale must explain |
 |----------|----------------------|
-| **confirmed_risk** | Why the attack surface is exploitable as-is and why existing mitigations do not remove that exploitability |
+| **confirmed_risk** | Why the attack surface is exploitable as-is and remains exploitable after applying existing mitigations |
 | **defense_gap** | Which required defensive control is missing or insufficient and which boundary it protects |
 
 ## Output Format
@@ -164,8 +164,8 @@ When `prior_feedback` is present, also include `prior_feedback_reconciliation` w
 - [ ] All Trend-Sensitive Patterns from security-checks.md searched
 - [ ] Technology stack trend check performed
 - [ ] Each finding classified into confirmed_risk / defense_gap
-- [ ] Every finding requires correction; optional hardening, policy, and non-blocking speculation were excluded
-- [ ] False positives excluded considering runtime environment and existing mitigations
+- [ ] The findings array contains only items that require correction
+- [ ] Every finding remains valid after considering the runtime environment and existing mitigations
 - [ ] Committed secrets checked (blocked status if found)
 - [ ] Every finding has a stable ID
 - [ ] When prior feedback is present, every received ID appears once in `prior_feedback_reconciliation`

--- a/dev-workflows/agents/task-executor.md
+++ b/dev-workflows/agents/task-executor.md
@@ -58,7 +58,7 @@ Escalation thresholds:
 
 ### Step4: Core Mechanism Preservation Check (Any YES → Immediate Escalation)
 Preserve the core mechanism the task, AC, Design Doc, or referenced materials require. Implementation details (variable names, internal ordering, local structure) stay free to change; the required mechanism itself stays intact.
-□ Required core mechanism replaced by a simpler or weaker substitute? (passing tests do not make a substitute acceptable)
+□ Required core mechanism replaced by a simpler or weaker substitute, including one justified only by passing tests?
 □ Required core mechanism infeasible as specified?
 Any YES → stop and escalate with `escalation_type: "design_compliance_violation"`, recording the required mechanism, the proposed alternative, the resulting change in behavior, and the condition that would lift the block.
 
@@ -205,7 +205,7 @@ Return the final response per Structured Response Specification. For research/an
 **mutationEvidence**: Use `[]` when no mutation verification ran; otherwise populate every field in the schema below with revision-bound evidence.
 
 ### 1. Task Completion Response
-Report in the following JSON format upon task completion (**without executing quality checks or commits**, delegating to quality assurance process):
+Complete this agent's work by returning the following JSON; the quality assurance process performs quality checks and commits:
 
 ```json
 {
@@ -326,7 +326,7 @@ This gate runs immediately before producing the final JSON response.
 ☐ Implementation is consistent with the Investigation Notes recorded at Step 2 (when Investigation Targets were present)
 ☐ Adjacent Case Sweep evidence records each inspected case and disposition, or the searched surface and no-case result, when the current task triggers the sweep
 ☐ Every Operation Verification Method succeeds and Verification Focus is satisfied when present
-☐ When test runs are cited as `runnableCheck` evidence, they are substantive and executable per the runnableCheck.result field spec (skipped tests, placeholder/TODO-only bodies, always-passing assertions, and 0-match runner reports do not count); non-test verification (build/typecheck/CLI) is not subject to this check
+☐ Test runs cited as `runnableCheck` evidence meet the substantive and executable rules in the `runnableCheck.result` field specification
 ☐ Final response is a single JSON with `status: "completed"` or `status: "escalation_needed"` and matches the schema in Structured Response Specification
 
 **ENFORCEMENT**: When any gate item is unchecked, return `escalation_needed` with `escalation_type: "design_compliance_violation"` for incomplete work or divergence from governing sources and Investigation Notes.

--- a/dev-workflows/agents/verifier.md
+++ b/dev-workflows/agents/verifier.md
@@ -40,7 +40,7 @@ Solution derivation is out of scope for this agent.
 - Grasp areas explicitly marked as uninvestigated
 
 **impactAnalysis Validity Check**:
-- Verify logical validity of impactAnalysis for each failure point (without additional searches)
+- Verify the logical validity of each failure point's impactAnalysis using only the supplied investigation evidence; perform additional searches in Step 2
 
 ### Step 2: Triangulation Supplementation
 Identify source types NOT covered in the investigation's `investigationSources`, then investigate at least one:
@@ -78,7 +78,7 @@ For each failure point, critically evaluate:
 - Official documentation of packages in use
 
 ### Step 6: Failure Point Evaluation and Consistency Verification
-Evaluate each failure point independently (do NOT select a single "winner"):
+Evaluate every failure point independently and allow multiple confirmed failure points:
 
 | finalStatus | Definition |
 |-------------|------------|
@@ -92,7 +92,7 @@ Evaluate each failure point independently (do NOT select a single "winner"):
 - Example: "The implementation is wrong" → Was design_gap considered?
 - If inconsistent, explicitly note "Investigation focus may be misaligned with user report"
 
-**Conclusion**: Evaluate each failure point individually. Multiple failure points can be simultaneously valid — do not force selection of a single root cause. For each pair of confirmed failure points, determine their relationship (independent / dependent / same_chain) and record in `failurePointRelationships`
+**Conclusion**: Evaluate each failure point individually and retain every supported cause. For each pair of confirmed failure points, determine their relationship (independent / dependent / same_chain) and record it in `failurePointRelationships`
 
 ## Coverage Assessment Criteria
 

--- a/dev-workflows/skills/ai-development-guide/SKILL.md
+++ b/dev-workflows/skills/ai-development-guide/SKILL.md
@@ -280,7 +280,7 @@ Proceed when discovery and understanding cover the files and behaviors named by 
 When an artifact made obsolete by the requested change is detected:
 - Delete it in the same change when its callers and generated/operational uses are checked
 - Preserve and report it when obsolescence is uncertain or deletion would expand beyond the files and behaviors named by the user or current task/design artifact
-- Do not implement unrelated dormant code merely because it was discovered
+- Keep unrelated dormant code outside the implementation scope
 
 ### Existing Code Modification
 

--- a/dev-workflows/skills/coding-principles/SKILL.md
+++ b/dev-workflows/skills/coding-principles/SKILL.md
@@ -127,7 +127,7 @@ One comment per decision. If a comment restates what the names and control flow 
 - Delete commented-out code (retrieve from git history when needed)
 
 ### Comment Quality
-- Write comments that remain accurate regardless of future code changes; avoid references to dates, versions, or temporary state
+- Base comments on stable rationale, limits, and contracts rather than dates, versions, or temporary state
 - Update comments when changing code
 - Use proper grammar and formatting
 - Write for future maintainers
@@ -138,7 +138,7 @@ One comment per decision. If a comment restates what the names and control flow 
 - **Small steps**: Make one change at a time
 - **Maintain working state**: Keep tests passing
 - **Verify behavior**: Run tests after each change
-- **Incremental improvement**: Don't aim for perfection immediately
+- **Incremental improvement**: Make the smallest sufficient improvement in each increment
 
 ### Refactoring Triggers
 - Code duplication (DRY principle)

--- a/dev-workflows/skills/documentation-criteria/SKILL.md
+++ b/dev-workflows/skills/documentation-criteria/SKILL.md
@@ -56,7 +56,7 @@ Qualifying durable choices include:
 - reversing or superseding an accepted architecture decision;
 - choosing an irreversible or high-cost-to-reverse data or compatibility strategy.
 
-A local contract, data-flow, state, or component change belongs in the Design Doc when it follows an accepted design, has one evident repository-supported implementation, or remains cheaply reversible. Counts of files, consumers, nesting levels, states, steps, and asynchronous operations are supporting evidence rather than ADR criteria. Generic technical concerns, operational possibilities, and rejected activities do not create ADRs by themselves.
+A local contract, data-flow, state, or component change belongs in the Design Doc when it follows an accepted design, has one evident repository-supported implementation, or remains cheaply reversible. Counts of files, consumers, nesting levels, states, steps, and asynchronous operations are supporting evidence rather than ADR criteria. Only the qualifying decisions above create ADRs; generic technical concerns, operational possibilities, and rejected activities can only support that determination.
 
 ## Detailed Document Definitions
 
@@ -114,7 +114,7 @@ Create a UI Spec when screen structure, transitions, component/state interaction
 
 **Prototype Code Handling**:
 - Prototype code provided by user is placed in `docs/ui-spec/assets/{feature-name}/`
-- Prototype is an attachment to UI Spec, never the source of truth
+- Prototype code supports the UI Spec as an attachment
 - UI Spec + Design Doc are the canonical specifications
 
 ### Design Document

--- a/dev-workflows/skills/external-resource-context/SKILL.md
+++ b/dev-workflows/skills/external-resource-context/SKILL.md
@@ -55,7 +55,7 @@ Each domain reference defines the axes and the question template.
 
 ### Two-Phase Hearing
 
-1. **Structured hearing** — for each axis defined in every selected domain reference, present the user with AskUserQuestion using the choices listed there (always include "Not applicable" as an option). For each non-N/A axis, follow up with an access-method question (URL / MCP name / file path / command). Domain references end after their axes; they do not add their own self-declaration question.
+1. **Structured hearing** — for each axis defined in every selected domain reference, present the user with AskUserQuestion using the choices listed there (always include "Not applicable" as an option). For each non-N/A axis, follow up with an access-method question (URL / MCP name / file path / command). Each domain reference ends after its access-method follow-up; phase 2 owns the single self-declaration question.
 
 2. **Self-declaration** — after the structured axes for all selected domains are complete, present one integrated AskUserQuestion: "Are there any other external resources for this work that the structured questions did not cover? If yes, describe them in your next message." If the user describes additional resources, append them to the storage file under an "Additional resources" subsection.
 

--- a/dev-workflows/skills/implementation-approach/SKILL.md
+++ b/dev-workflows/skills/implementation-approach/SKILL.md
@@ -65,7 +65,7 @@ External Research: Official/current sources only when repository evidence cannot
 - Decorator Pattern: Phased enhancement of existing features
 - Bridge Pattern: Flexibility through abstraction
 
-Use these patterns only when their named migration or dependency problem exists. Start with the direct strategy. Compare an alternative when it would materially change risk, rollout, compatibility, or the early verification point; do not add a pattern or combination only to increase the option count.
+Use these patterns only when their named migration or dependency problem exists. Start with the direct strategy. Compare an alternative when it would materially change risk, rollout, compatibility, or the early verification point. Keep the option set limited to patterns that produce one of those material differences.
 
 ### Phase 4: Risk Assessment and Control
 

--- a/dev-workflows/skills/integration-e2e-testing/SKILL.md
+++ b/dev-workflows/skills/integration-e2e-testing/SKILL.md
@@ -43,7 +43,7 @@ One input Design Doc is one budget scope: apply each lane budget once across all
 
 ROI is used to **rank candidates within the same test type** (integration candidates against each other, E2E candidates against each other). Cross-type comparison is unnecessary because integration and E2E budgets are selected independently.
 
-Score every input before calculating ROI. For the three numeric inputs, use only `0`, `5`, or `10`; do not interpolate intermediate values. Legal Requirement remains boolean:
+Score every input before calculating ROI. For the three numeric inputs, use exactly `0`, `5`, or `10`. Legal Requirement remains boolean:
 
 | Input | Scale |
 |---|---|

--- a/dev-workflows/skills/llm-friendly-context/SKILL.md
+++ b/dev-workflows/skills/llm-friendly-context/SKILL.md
@@ -65,7 +65,7 @@ Before sending a prompt or artifact to another agent, verify:
 
 - [ ] The target action is explicit.
 - [ ] Required input paths and source artifacts are named.
-- [ ] Accepted decisions and constraints are stated once, without alternate wording.
+- [ ] Accepted decisions and constraints use one canonical wording.
 - [ ] Output format or expected status fields are specified.
 - [ ] Success criteria are observable.
 - [ ] Ambiguous expressions have been rewritten or marked as unresolved.

--- a/dev-workflows/skills/recipe-build/SKILL.md
+++ b/dev-workflows/skills/recipe-build/SKILL.md
@@ -138,7 +138,7 @@ Before the completion report, delete the implementation task files this recipe c
 - Delete every file in the Consumed Task Set
 - Preserve the work plan itself (`docs/plans/{plan-name}.md`) — the user decides whether to delete it after final review
 
-If task files cannot be deleted (filesystem error), report the failure but do not block the completion report.
+If task-file deletion fails with a filesystem error, report the failure and continue to the completion report.
 
 ## Completion Report Contract
 

--- a/dev-workflows/skills/recipe-diagnose/SKILL.md
+++ b/dev-workflows/skills/recipe-diagnose/SKILL.md
@@ -121,7 +121,7 @@ prompt: |
   Re-investigate with focus on the following gaps:
   - Missing: [unsatisfied Step 2 Quality Check items, copied as written]
 
-  Previous investigation results (for context, do not re-investigate covered areas):
+  Use these previous investigation results as context and investigate only the gaps listed above:
   [Previous investigation JSON]
 ```
 

--- a/dev-workflows/skills/recipe-reverse-engineer/SKILL.md
+++ b/dev-workflows/skills/recipe-reverse-engineer/SKILL.md
@@ -394,7 +394,7 @@ prompt: |
 
 Output summary including:
 - Generated documents table (Type, Name, Verification Status, Review Status)
-- Action items (critical discrepancies, undocumented features, flagged items)
+- Action items (undocumented features, flagged items)
 - Declined actionable findings with ID, governing reason, and evidence, when any occurred
 - Next steps checklist
 

--- a/dev-workflows/skills/recipe-review/SKILL.md
+++ b/dev-workflows/skills/recipe-review/SKILL.md
@@ -62,7 +62,7 @@ Invoke security-reviewer using Agent tool:
 
 ### Step 4: Verdict and Response
 
-**If security-reviewer returned `blocked`**: Stop immediately. Report the blocked finding and escalate to user. Do not proceed to fix steps.
+**If security-reviewer returned `blocked`**: Stop immediately. Report its blocking reason and any returned finding, then escalate to user. Do not proceed to fix steps.
 
 Apply the Review Resolution Gate to both outputs before reporting or routing them. Finding dispositions determine routing.
 
@@ -80,7 +80,6 @@ Then present the adjudicated result to the user. Group `apply` and `user_decisio
 Code Review: [verdict from code-reviewer]
   Acceptance Criteria:
   - [fulfilled] [item] (confidence: [high/medium/low])
-  - [partially_fulfilled] [item]: [gap] — [suggestion] [recommended: c | d]
   - [unfulfilled] [item]: [gap] — [suggestion] [recommended: c | d]
   Identifier Mismatches:
   - [identifier]: DD=[designDocValue] Code=[codeValue] at [location] [recommended: c | d]
@@ -91,9 +90,6 @@ Security Review: [status from security-reviewer]
   Findings by category:
   - [confirmed_risk] [location]: [description] — [rationale] [recommended: c]
   - [defense_gap] [location]: [description] — [rationale] [recommended: c]
-  - [hardening] [location]: [description] — [rationale] [recommended: c]
-  - [policy] [location]: [description] — [rationale] [recommended: c]
-  Notes: [notes from security-reviewer, if present]
 
 Approve the proposed changes or decide unresolved items:
   c) Code-side fix       — code violates Design Doc; modify code to match
@@ -175,7 +171,6 @@ Security Review:
   Initial: [status]
   Correction review: [status for the re-review scope] (if fixes executed)
   Reconciliation: [resolved / withdrawn / maintained by finding ID]
-  Notes: [notes from approved_with_notes, if any]
 
 Declined actionable findings:
 - [ID: governing reason — evidence] (only when any were declined)

--- a/dev-workflows/skills/recipe-review/SKILL.md
+++ b/dev-workflows/skills/recipe-review/SKILL.md
@@ -62,7 +62,7 @@ Invoke security-reviewer using Agent tool:
 
 ### Step 4: Verdict and Response
 
-**If security-reviewer returned `blocked`**: Stop immediately. Report its blocking reason and any returned finding, then escalate to user. Do not proceed to fix steps.
+**If security-reviewer returned `blocked`**: Stop at this gate, report its blocking reason and any returned finding, then escalate to the user. The workflow remains at this gate pending the user's response.
 
 Apply the Review Resolution Gate to both outputs before reporting or routing them. Finding dispositions determine routing.
 

--- a/dev-workflows/skills/subagents-orchestration-guide/SKILL.md
+++ b/dev-workflows/skills/subagents-orchestration-guide/SKILL.md
@@ -170,8 +170,8 @@ For Small, execute one direct-scope 4-step cycle and complete when quality-fixer
 
 | Verifier | Pass | Fail | Blocked |
 |----------|------|------|---------|
-| code-verifier | `summary.status` is `consistent` or `mostly_consistent` | `summary.status` is `needs_review` or `inconsistent` | `summary.status` is `blocked` → Escalate to user |
-| security-reviewer | `status` is `approved` or `approved_with_notes` | `status` is `needs_revision` | `status` is `blocked` → Escalate to user |
+| code-verifier | `summary.status` is `consistent` | `summary.status` is `needs_review` or `inconsistent` | `summary.status` is `blocked` → Escalate to user |
+| security-reviewer | `status` is `approved` | `status` is `needs_revision` | `status` is `blocked` → Escalate to user |
 
 **Fix-cycle handoff**: Apply Review Resolution, then pass each required executor the complete `apply` finding objects verbatim with only their dispositions added. Carry `prior_feedback` to reviewer inputs that support reconciliation.
 

--- a/dev-workflows/skills/testing-principles/SKILL.md
+++ b/dev-workflows/skills/testing-principles/SKILL.md
@@ -39,7 +39,7 @@ RED: confirm the new test fails for the intended reason. GREEN: implement the sm
 
 Mock-based tests are sufficient when data access is only a dependency of the behavior under test. Verify against the project's real database engine or its accepted equivalent when the subject is a query, repository implementation, schema constraint, or migration compatibility. Resolve the test environment from repository configuration; when no representative environment exists and adding one is outside the approved work, report the missing verification decision.
 
-Cross-check data-access code against the schema source named in the Design Doc or repository configuration. Successful mocks do not prove table, column, type, constraint, or dialect compatibility.
+Cross-check data-access code against the schema source named in the Design Doc or repository configuration. Schema-source verification is required to prove table, column, type, constraint, or dialect compatibility; successful mocks prove behavior only at the mocked boundary.
 
 ## Verification Requirements
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-workflows",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "private": true,
   "type": "module",
   "engines": {

--- a/skills/ai-development-guide/SKILL.md
+++ b/skills/ai-development-guide/SKILL.md
@@ -280,7 +280,7 @@ Proceed when discovery and understanding cover the files and behaviors named by 
 When an artifact made obsolete by the requested change is detected:
 - Delete it in the same change when its callers and generated/operational uses are checked
 - Preserve and report it when obsolescence is uncertain or deletion would expand beyond the files and behaviors named by the user or current task/design artifact
-- Do not implement unrelated dormant code merely because it was discovered
+- Keep unrelated dormant code outside the implementation scope
 
 ### Existing Code Modification
 

--- a/skills/coding-principles/SKILL.md
+++ b/skills/coding-principles/SKILL.md
@@ -127,7 +127,7 @@ One comment per decision. If a comment restates what the names and control flow 
 - Delete commented-out code (retrieve from git history when needed)
 
 ### Comment Quality
-- Write comments that remain accurate regardless of future code changes; avoid references to dates, versions, or temporary state
+- Base comments on stable rationale, limits, and contracts rather than dates, versions, or temporary state
 - Update comments when changing code
 - Use proper grammar and formatting
 - Write for future maintainers
@@ -138,7 +138,7 @@ One comment per decision. If a comment restates what the names and control flow 
 - **Small steps**: Make one change at a time
 - **Maintain working state**: Keep tests passing
 - **Verify behavior**: Run tests after each change
-- **Incremental improvement**: Don't aim for perfection immediately
+- **Incremental improvement**: Make the smallest sufficient improvement in each increment
 
 ### Refactoring Triggers
 - Code duplication (DRY principle)

--- a/skills/documentation-criteria/SKILL.md
+++ b/skills/documentation-criteria/SKILL.md
@@ -56,7 +56,7 @@ Qualifying durable choices include:
 - reversing or superseding an accepted architecture decision;
 - choosing an irreversible or high-cost-to-reverse data or compatibility strategy.
 
-A local contract, data-flow, state, or component change belongs in the Design Doc when it follows an accepted design, has one evident repository-supported implementation, or remains cheaply reversible. Counts of files, consumers, nesting levels, states, steps, and asynchronous operations are supporting evidence rather than ADR criteria. Generic technical concerns, operational possibilities, and rejected activities do not create ADRs by themselves.
+A local contract, data-flow, state, or component change belongs in the Design Doc when it follows an accepted design, has one evident repository-supported implementation, or remains cheaply reversible. Counts of files, consumers, nesting levels, states, steps, and asynchronous operations are supporting evidence rather than ADR criteria. Only the qualifying decisions above create ADRs; generic technical concerns, operational possibilities, and rejected activities can only support that determination.
 
 ## Detailed Document Definitions
 
@@ -114,7 +114,7 @@ Create a UI Spec when screen structure, transitions, component/state interaction
 
 **Prototype Code Handling**:
 - Prototype code provided by user is placed in `docs/ui-spec/assets/{feature-name}/`
-- Prototype is an attachment to UI Spec, never the source of truth
+- Prototype code supports the UI Spec as an attachment
 - UI Spec + Design Doc are the canonical specifications
 
 ### Design Document

--- a/skills/external-resource-context/SKILL.md
+++ b/skills/external-resource-context/SKILL.md
@@ -55,7 +55,7 @@ Each domain reference defines the axes and the question template.
 
 ### Two-Phase Hearing
 
-1. **Structured hearing** — for each axis defined in every selected domain reference, present the user with AskUserQuestion using the choices listed there (always include "Not applicable" as an option). For each non-N/A axis, follow up with an access-method question (URL / MCP name / file path / command). Domain references end after their axes; they do not add their own self-declaration question.
+1. **Structured hearing** — for each axis defined in every selected domain reference, present the user with AskUserQuestion using the choices listed there (always include "Not applicable" as an option). For each non-N/A axis, follow up with an access-method question (URL / MCP name / file path / command). Each domain reference ends after its access-method follow-up; phase 2 owns the single self-declaration question.
 
 2. **Self-declaration** — after the structured axes for all selected domains are complete, present one integrated AskUserQuestion: "Are there any other external resources for this work that the structured questions did not cover? If yes, describe them in your next message." If the user describes additional resources, append them to the storage file under an "Additional resources" subsection.
 

--- a/skills/frontend-ai-guide/SKILL.md
+++ b/skills/frontend-ai-guide/SKILL.md
@@ -126,7 +126,7 @@ function EmailInput({ context }: { context: 'user' | 'contact' | 'admin' }) { /*
 
 ## Quality Check Workflow
 
-Read `package.json` scripts and run them with the project's package manager (`packageManager` field). Map the project's actual script names to the phases below — do not assume fixed names.
+Read `package.json` scripts, map the project's actual commands to the phases below, and run them with the project's package manager (`packageManager` field).
 
 ### Phases (run in order)
 1. **Lint/format** — the project's formatter + linter (e.g., Biome, or ESLint + Prettier)
@@ -189,7 +189,7 @@ Proceed when the user-requested or task-defined scope, consumers, state flow, an
 
 ### Unused Code Deletion Rule
 
-When the requested change makes a component, hook, utility, document, or configuration entry obsolete, delete it after checking its consumers and generated/operational use. Preserve and report uncertain or out-of-scope cleanup; do not implement unrelated dormant code merely because it was discovered.
+When the requested change makes a component, hook, utility, document, or configuration entry obsolete, delete it after checking its consumers and generated/operational use. Preserve and report uncertain or out-of-scope cleanup, and keep unrelated dormant code outside the implementation scope.
 
 ### Existing Code Deletion Decision Flow
 

--- a/skills/implementation-approach/SKILL.md
+++ b/skills/implementation-approach/SKILL.md
@@ -65,7 +65,7 @@ External Research: Official/current sources only when repository evidence cannot
 - Decorator Pattern: Phased enhancement of existing features
 - Bridge Pattern: Flexibility through abstraction
 
-Use these patterns only when their named migration or dependency problem exists. Start with the direct strategy. Compare an alternative when it would materially change risk, rollout, compatibility, or the early verification point; do not add a pattern or combination only to increase the option count.
+Use these patterns only when their named migration or dependency problem exists. Start with the direct strategy. Compare an alternative when it would materially change risk, rollout, compatibility, or the early verification point. Keep the option set limited to patterns that produce one of those material differences.
 
 ### Phase 4: Risk Assessment and Control
 

--- a/skills/integration-e2e-testing/SKILL.md
+++ b/skills/integration-e2e-testing/SKILL.md
@@ -43,7 +43,7 @@ One input Design Doc is one budget scope: apply each lane budget once across all
 
 ROI is used to **rank candidates within the same test type** (integration candidates against each other, E2E candidates against each other). Cross-type comparison is unnecessary because integration and E2E budgets are selected independently.
 
-Score every input before calculating ROI. For the three numeric inputs, use only `0`, `5`, or `10`; do not interpolate intermediate values. Legal Requirement remains boolean:
+Score every input before calculating ROI. For the three numeric inputs, use exactly `0`, `5`, or `10`. Legal Requirement remains boolean:
 
 | Input | Scale |
 |---|---|

--- a/skills/llm-friendly-context/SKILL.md
+++ b/skills/llm-friendly-context/SKILL.md
@@ -65,7 +65,7 @@ Before sending a prompt or artifact to another agent, verify:
 
 - [ ] The target action is explicit.
 - [ ] Required input paths and source artifacts are named.
-- [ ] Accepted decisions and constraints are stated once, without alternate wording.
+- [ ] Accepted decisions and constraints use one canonical wording.
 - [ ] Output format or expected status fields are specified.
 - [ ] Success criteria are observable.
 - [ ] Ambiguous expressions have been rewritten or marked as unresolved.

--- a/skills/recipe-build/SKILL.md
+++ b/skills/recipe-build/SKILL.md
@@ -138,7 +138,7 @@ Before the completion report, delete the implementation task files this recipe c
 - Delete every file in the Consumed Task Set
 - Preserve the work plan itself (`docs/plans/{plan-name}.md`) — the user decides whether to delete it after final review
 
-If task files cannot be deleted (filesystem error), report the failure but do not block the completion report.
+If task-file deletion fails with a filesystem error, report the failure and continue to the completion report.
 
 ## Completion Report Contract
 

--- a/skills/recipe-diagnose/SKILL.md
+++ b/skills/recipe-diagnose/SKILL.md
@@ -121,7 +121,7 @@ prompt: |
   Re-investigate with focus on the following gaps:
   - Missing: [unsatisfied Step 2 Quality Check items, copied as written]
 
-  Previous investigation results (for context, do not re-investigate covered areas):
+  Use these previous investigation results as context and investigate only the gaps listed above:
   [Previous investigation JSON]
 ```
 

--- a/skills/recipe-front-build/SKILL.md
+++ b/skills/recipe-front-build/SKILL.md
@@ -138,7 +138,7 @@ Before the completion report, delete the implementation task files this recipe c
 - Delete every file in the Consumed Task Set
 - Preserve the work plan itself (`docs/plans/{plan-name}.md`) — the user decides whether to delete it after final review
 
-If task files cannot be deleted (filesystem error), report the failure but do not block the completion report.
+If task-file deletion fails with a filesystem error, report the failure and continue to the completion report.
 
 ## Completion Report Contract
 

--- a/skills/recipe-front-review/SKILL.md
+++ b/skills/recipe-front-review/SKILL.md
@@ -62,7 +62,7 @@ Invoke security-reviewer using Agent tool:
 
 ### Step 4: Verdict and Response
 
-**If security-reviewer returned `blocked`**: Stop immediately. Report the blocked finding and escalate to user. Do not proceed to fix steps.
+**If security-reviewer returned `blocked`**: Stop immediately. Report its blocking reason and any returned finding, then escalate to user. Do not proceed to fix steps.
 
 Apply the Review Resolution Gate to both outputs before reporting or routing them. Finding dispositions determine routing.
 
@@ -80,7 +80,6 @@ Then present the adjudicated result to the user. Group `apply` and `user_decisio
 Code Review: [verdict from code-reviewer]
   Acceptance Criteria:
   - [fulfilled] [item] (confidence: [high/medium/low])
-  - [partially_fulfilled] [item]: [gap] — [suggestion] [recommended: c | d]
   - [unfulfilled] [item]: [gap] — [suggestion] [recommended: c | d]
   Identifier Mismatches:
   - [identifier]: DD=[designDocValue] Code=[codeValue] at [location] [recommended: c | d]
@@ -91,9 +90,6 @@ Security Review: [status from security-reviewer]
   Findings by category:
   - [confirmed_risk] [location]: [description] — [rationale] [recommended: c]
   - [defense_gap] [location]: [description] — [rationale] [recommended: c]
-  - [hardening] [location]: [description] — [rationale] [recommended: c]
-  - [policy] [location]: [description] — [rationale] [recommended: c]
-  Notes: [notes from security-reviewer, if present]
 
 Approve the proposed changes or decide unresolved items:
   c) Code-side fix       — code violates Design Doc; modify code to match
@@ -175,7 +171,6 @@ Security Review:
   Initial: [status]
   Correction review: [status for the re-review scope] (if fixes executed)
   Reconciliation: [resolved / withdrawn / maintained by finding ID]
-  Notes: [notes from approved_with_notes, if any]
 
 Declined actionable findings:
 - [ID: governing reason — evidence] (only when any were declined)

--- a/skills/recipe-front-review/SKILL.md
+++ b/skills/recipe-front-review/SKILL.md
@@ -62,7 +62,7 @@ Invoke security-reviewer using Agent tool:
 
 ### Step 4: Verdict and Response
 
-**If security-reviewer returned `blocked`**: Stop immediately. Report its blocking reason and any returned finding, then escalate to user. Do not proceed to fix steps.
+**If security-reviewer returned `blocked`**: Stop at this gate, report its blocking reason and any returned finding, then escalate to the user. The workflow remains at this gate pending the user's response.
 
 Apply the Review Resolution Gate to both outputs before reporting or routing them. Finding dispositions determine routing.
 

--- a/skills/recipe-fullstack-build/SKILL.md
+++ b/skills/recipe-fullstack-build/SKILL.md
@@ -156,7 +156,7 @@ Before the completion report, delete the implementation task files this recipe c
 - Delete every file in the Consumed Task Set
 - Preserve the work plan itself (`docs/plans/{plan-name}.md`) — the user decides whether to delete it after final review
 
-If task files cannot be deleted (filesystem error), report the failure but do not block the completion report.
+If task-file deletion fails with a filesystem error, report the failure and continue to the completion report.
 
 ## Completion Report Contract
 

--- a/skills/recipe-reverse-engineer/SKILL.md
+++ b/skills/recipe-reverse-engineer/SKILL.md
@@ -394,7 +394,7 @@ prompt: |
 
 Output summary including:
 - Generated documents table (Type, Name, Verification Status, Review Status)
-- Action items (critical discrepancies, undocumented features, flagged items)
+- Action items (undocumented features, flagged items)
 - Declined actionable findings with ID, governing reason, and evidence, when any occurred
 - Next steps checklist
 

--- a/skills/recipe-review/SKILL.md
+++ b/skills/recipe-review/SKILL.md
@@ -62,7 +62,7 @@ Invoke security-reviewer using Agent tool:
 
 ### Step 4: Verdict and Response
 
-**If security-reviewer returned `blocked`**: Stop immediately. Report the blocked finding and escalate to user. Do not proceed to fix steps.
+**If security-reviewer returned `blocked`**: Stop immediately. Report its blocking reason and any returned finding, then escalate to user. Do not proceed to fix steps.
 
 Apply the Review Resolution Gate to both outputs before reporting or routing them. Finding dispositions determine routing.
 
@@ -80,7 +80,6 @@ Then present the adjudicated result to the user. Group `apply` and `user_decisio
 Code Review: [verdict from code-reviewer]
   Acceptance Criteria:
   - [fulfilled] [item] (confidence: [high/medium/low])
-  - [partially_fulfilled] [item]: [gap] — [suggestion] [recommended: c | d]
   - [unfulfilled] [item]: [gap] — [suggestion] [recommended: c | d]
   Identifier Mismatches:
   - [identifier]: DD=[designDocValue] Code=[codeValue] at [location] [recommended: c | d]
@@ -91,9 +90,6 @@ Security Review: [status from security-reviewer]
   Findings by category:
   - [confirmed_risk] [location]: [description] — [rationale] [recommended: c]
   - [defense_gap] [location]: [description] — [rationale] [recommended: c]
-  - [hardening] [location]: [description] — [rationale] [recommended: c]
-  - [policy] [location]: [description] — [rationale] [recommended: c]
-  Notes: [notes from security-reviewer, if present]
 
 Approve the proposed changes or decide unresolved items:
   c) Code-side fix       — code violates Design Doc; modify code to match
@@ -175,7 +171,6 @@ Security Review:
   Initial: [status]
   Correction review: [status for the re-review scope] (if fixes executed)
   Reconciliation: [resolved / withdrawn / maintained by finding ID]
-  Notes: [notes from approved_with_notes, if any]
 
 Declined actionable findings:
 - [ID: governing reason — evidence] (only when any were declined)

--- a/skills/recipe-review/SKILL.md
+++ b/skills/recipe-review/SKILL.md
@@ -62,7 +62,7 @@ Invoke security-reviewer using Agent tool:
 
 ### Step 4: Verdict and Response
 
-**If security-reviewer returned `blocked`**: Stop immediately. Report its blocking reason and any returned finding, then escalate to user. Do not proceed to fix steps.
+**If security-reviewer returned `blocked`**: Stop at this gate, report its blocking reason and any returned finding, then escalate to the user. The workflow remains at this gate pending the user's response.
 
 Apply the Review Resolution Gate to both outputs before reporting or routing them. Finding dispositions determine routing.
 

--- a/skills/subagents-orchestration-guide/SKILL.md
+++ b/skills/subagents-orchestration-guide/SKILL.md
@@ -170,8 +170,8 @@ For Small, execute one direct-scope 4-step cycle and complete when quality-fixer
 
 | Verifier | Pass | Fail | Blocked |
 |----------|------|------|---------|
-| code-verifier | `summary.status` is `consistent` or `mostly_consistent` | `summary.status` is `needs_review` or `inconsistent` | `summary.status` is `blocked` → Escalate to user |
-| security-reviewer | `status` is `approved` or `approved_with_notes` | `status` is `needs_revision` | `status` is `blocked` → Escalate to user |
+| code-verifier | `summary.status` is `consistent` | `summary.status` is `needs_review` or `inconsistent` | `summary.status` is `blocked` → Escalate to user |
+| security-reviewer | `status` is `approved` | `status` is `needs_revision` | `status` is `blocked` → Escalate to user |
 
 **Fix-cycle handoff**: Apply Review Resolution, then pass each required executor the complete `apply` finding objects verbatim with only their dispositions added. Carry `prior_feedback` to reviewer inputs that support reconciliation.
 

--- a/skills/test-implement/SKILL.md
+++ b/skills/test-implement/SKILL.md
@@ -23,7 +23,7 @@ All tests follow **Arrange-Act-Assert**:
 ### Test Independence
 - Each test runs independently without depending on other tests
 - No shared mutable state between tests
-- Deterministic execution — no random or time dependencies without mocking
+- Deterministic execution — mock random and time dependencies
 
 ### Naming
 - Test names describe expected behavior from user perspective

--- a/skills/test-implement/references/e2e.md
+++ b/skills/test-implement/references/e2e.md
@@ -38,7 +38,7 @@ Use the repository's existing seed and authentication mechanisms. Create per-tes
 ## Locator and Assertion Rules
 
 - Follow the repository's locator convention; otherwise prefer accessible role/name or label locators, then stable test IDs when no semantic locator exists.
-- Assert user-observable state, navigation, accessibility, or persisted behavior named by the skeleton. Avoid assertions tied only to CSS classes or internal DOM structure.
+- Assert user-observable state, navigation, accessibility, or persisted behavior named by the skeleton. Treat assertions tied only to CSS classes or internal DOM structure as insufficient proof.
 - When the UI specification defines responsive behavior, run the affected interaction at the specified viewport; otherwise use the repository's default browser matrix.
 - Each test starts from isolated state and remains independent of execution order.
 

--- a/skills/test-implement/references/frontend.md
+++ b/skills/test-implement/references/frontend.md
@@ -13,7 +13,7 @@ Before writing a test, inspect package scripts, runner configuration, setup file
 
 - Concentrate rigor on shared components, hooks, and utilities with a wide blast radius. Use integration or E2E coverage for higher-composition surfaces when their boundary is the behavior under test.
 - For a behavior-preserving refactor, establish passing regression or characterization evidence before the change and rerun it afterward.
-- Configuration that changes runtime or build behavior requires executable validation. Documentation-only changes do not require test-first development.
+- Test-first scope covers executable behavior; configuration that changes runtime or build behavior requires executable validation.
 - Continuity tests cover existing feature behavior affected by the change; long-term performance and operational testing remain infrastructure concerns unless the accepted work includes them.
 
 ## Mock Boundary

--- a/skills/testing-principles/SKILL.md
+++ b/skills/testing-principles/SKILL.md
@@ -39,7 +39,7 @@ RED: confirm the new test fails for the intended reason. GREEN: implement the sm
 
 Mock-based tests are sufficient when data access is only a dependency of the behavior under test. Verify against the project's real database engine or its accepted equivalent when the subject is a query, repository implementation, schema constraint, or migration compatibility. Resolve the test environment from repository configuration; when no representative environment exists and adding one is outside the approved work, report the missing verification decision.
 
-Cross-check data-access code against the schema source named in the Design Doc or repository configuration. Successful mocks do not prove table, column, type, constraint, or dialect compatibility.
+Cross-check data-access code against the schema source named in the Design Doc or repository configuration. Schema-source verification is required to prove table, column, type, constraint, or dialect compatibility; successful mocks prove behavior only at the mocked boundary.
 
 ## Verification Requirements
 


### PR DESCRIPTION
## Summary

- remove ambiguous intermediate states from code verification, code review, and security review contracts
- keep actionable security findings in the automated correction flow while reserving `blocked` for invalid governing inputs and committed secrets
- align review recipes and generated plugin bundles with the simplified contracts, then bump the patch version to 0.24.2

## Validation

- `pnpm sync:check`
- `pnpm check:skills-index`
- `claude plugin validate .`
- `claude plugin validate` for all four generated plugin directories
