### PR TITLE
refactor: keep boundaries, drop work-generating constraints

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "dev-workflows",
       "source": "./dev-workflows",
       "strict": true,
-      "version": "0.24.3",
+      "version": "0.24.4",
       "description": "Skills + Subagents for backend development - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
       "author": {
         "name": "Shinsuke Kagawa",
@@ -82,7 +82,7 @@
       "name": "dev-workflows-frontend",
       "source": "./dev-workflows-frontend",
       "strict": true,
-      "version": "0.24.3",
+      "version": "0.24.4",
       "description": "Skills + Subagents for React/TypeScript - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
       "author": {
         "name": "Shinsuke Kagawa",
@@ -155,7 +155,7 @@
       "name": "dev-workflows-fullstack",
       "source": "./dev-workflows-fullstack",
       "strict": true,
-      "version": "0.24.3",
+      "version": "0.24.4",
       "description": "Skills + Subagents for fullstack development (backend + React/TypeScript) - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
       "author": {
         "name": "Shinsuke Kagawa",
@@ -244,7 +244,7 @@
       "name": "dev-skills",
       "source": "./dev-skills",
       "strict": true,
-      "version": "0.24.3",
+      "version": "0.24.4",
       "description": "Lightweight skills for users with existing workflows - coding best practices, testing principles, and design guidelines without recipe workflows or agents",
       "author": {
         "name": "Shinsuke Kagawa",

--- a/agents/acceptance-test-generator.md
+++ b/agents/acceptance-test-generator.md
@@ -198,22 +198,6 @@ A skeleton is committed before its implementation exists, so its committed form 
 
 ### Generation Report
 
-**When both E2E lanes are emitted:**
-```json
-{
-  "status": "completed",
-  "feature": "payment",
-  "generatedFiles": {
-    "integration": "tests/payment.int.test.[ext]",
-    "fixtureE2e": "tests/payment.fixture.e2e.test.[ext]",
-    "serviceE2e": "tests/payment.service.e2e.test.[ext]"
-  },
-  "budgetUsage": { "integration": "2/3", "fixtureE2e": "1/3", "serviceE2e": "1/2" },
-  "e2eAbsenceReason": { "fixtureE2e": null, "serviceE2e": null }
-}
-```
-
-**When only fixture-e2e is emitted:**
 ```json
 {
   "status": "completed",
@@ -222,30 +206,13 @@ A skeleton is committed before its implementation exists, so its committed form 
     "integration": "tests/payment.int.test.[ext]",
     "fixtureE2e": "tests/payment.fixture.e2e.test.[ext]",
     "serviceE2e": null
-  },
-  "budgetUsage": { "integration": "2/3", "fixtureE2e": "2/3", "serviceE2e": "0/2" },
-  "e2eAbsenceReason": { "fixtureE2e": null, "serviceE2e": "Design Doc §Test Boundaries designates the gateway as mockable; the selected fixture-e2e covers every accepted journey proof obligation." }
+  }
 }
 ```
 
-**When no E2E tests are emitted:**
-```json
-{
-  "status": "completed",
-  "feature": "config-update",
-  "generatedFiles": {
-    "integration": "tests/config.int.test.[ext]",
-    "fixtureE2e": null,
-    "serviceE2e": null
-  },
-  "budgetUsage": { "integration": "1/3", "fixtureE2e": "0/3", "serviceE2e": "0/2" },
-  "e2eAbsenceReason": { "fixtureE2e": "Design Doc AC1-AC4 classify as single-step behavior under the journey rule; selected integration coverage proves their accepted boundaries.", "serviceE2e": "Design Doc §Test Boundaries assigns every external dependency to a mockable boundary; selected integration coverage proves the accepted boundaries." }
-}
-```
+**Contract**: a `completed` result always contains `generatedFiles.integration`, `generatedFiles.fixtureE2e`, and `generatedFiles.serviceE2e`. Value is a file path string when that lane emitted, `null` when it did not. The orchestrator confirms an empty lane against the Design Doc's accepted proof obligations; the selection evidence for every emitted skeleton stays in that skeleton's metadata.
 
-**Contract**:
-- A `completed` result always contains `generatedFiles.integration`, `generatedFiles.fixtureE2e`, and `generatedFiles.serviceE2e`. Value is a file path string when generated, `null` when not.
-- `e2eAbsenceReason` is an object with `fixtureE2e` and `serviceE2e` keys. Each value is `null` when that lane emitted; otherwise name the selection rule, the source evidence checked, and the selected or governing proof that covers the accepted boundary. A valid null lane accounts for every accepted proof obligation.
+Describe the run's filtering and selection outcome in the surrounding message. Whenever a lane emits nothing, name the removed candidates and the filter that removed each one — the JSON carries paths only.
 
 **When a decision-relevant value input is missing:**
 ```json
@@ -258,7 +225,7 @@ A skeleton is committed before its implementation exists, so its committed form 
 }
 ```
 
-Return this status before creating or modifying skeleton files. The caller supplies its single response as `test_value_context` and reinvokes the generator. Apply supplied facts, preserve every remaining decision-relevant value as `unknown`, use Unknown-Value Ordering, and return the normal completed result. Record the evidence checked, ordering basis, and selection effect in generated skeleton metadata or the absence report.
+Return this status before creating or modifying skeleton files. The caller supplies its single response as `test_value_context` and reinvokes the generator. Apply supplied facts, preserve every remaining decision-relevant value as `unknown`, use Unknown-Value Ordering, and return the normal completed result. Record the evidence checked, ordering basis, and selection effect in generated skeleton metadata.
 
 ## Test Meta Information Assignment
 
@@ -290,23 +257,25 @@ These annotations drive test planning and prioritization. The `@lane` annotation
 - Clarify dependencies explicitly
 - Logical test execution order
 
-## Exception Handling and Escalation
+## Exception Handling and Stop Conditions
 
 ### Auto-processable
 - **Directory Absent**: Auto-create appropriate directory following detected test structure
 - **No Integration Candidates**: Valid outcome - report "No Integration candidates remained after Phase 1 filtering, deduplication, and push-down analysis"
 - **No E2E Tests (no multi-step journey)**: Valid outcome - report "No multi-step user journey detected; E2E tests not applicable"
-- **Budget Exceeded by Critical Test**: Report to user
+- **Budget insufficient for a critical user journey (ROI > 90)**: Exceed the lane budget per the integration-e2e-testing skill's budget rule when the journey's failure mode cannot be proved by a selected test, and annotate the exception and why consolidation cannot cover it
+- **No E2E test emitted after budget enforcement, but the input Design Doc contains a user-facing multi-step journey**: Report the journey, every candidate evaluated with its ROI score, and the filter that removed each one, then continue. (This case arises only when the reserved slot in Phase 4 did not apply — e.g., no journey candidate passed Phase 1-3 filtering.)
+- **Every AC filtered out, leaving no generated test**: Valid outcome - return the empty result and report the filter that removed each AC
+- **Multiple interpretations possible but minor impact**: Adopt the interpretation and note it in the report
 - **Missing value that cannot change selection**: Record `not_decision_relevant` with the invariant selection basis and continue
 - **Decision-relevant value remains unknown after the value-input round**: Preserve `unknown`, apply Unknown-Value Ordering, record its selection effect, and continue
 
-### Escalation Required
-1. **Critical**: AC absent, Design Doc absent → Error termination
-2. **High**: No E2E test emitted after budget enforcement, but the input Design Doc contains a user-facing multi-step journey → Escalate with message: "The Design Doc includes a user-facing multi-step journey but no E2E test was emitted. Journey candidates evaluated: [list with ROI scores]. Confirm whether to proceed without E2E." (Note: this escalation fires only when the reserved slot in Phase 4 did not apply — e.g., no journey candidate passed Phase 1-3 filtering. When a reserved slot candidate exists, it is emitted and this escalation does not fire.)
-3. **High**: All ACs filtered out but feature is business-critical → User confirmation needed
-4. **Medium**: Budget insufficient for critical user journey (ROI > 90) → Present options
-5. **Low**: Multiple interpretations possible but minor impact → Adopt interpretation + note in report
-6. **Decision input**: An unknown Business Value, User Frequency, or Legal Requirement can change ranking, threshold, or budget selection → Return `value_input_required` when `test_value_context` is absent; after that input round, preserve remaining unknowns and continue with Unknown-Value Ordering
+### Stop Conditions
+
+These two cases end generation and hand control back; every other case above completes with a recorded result.
+
+1. **Required input absent**: AC absent or Design Doc absent → terminate and name the missing input
+2. **Decision input required**: An unknown Business Value, User Frequency, or Legal Requirement can change ranking, threshold, or budget selection → Return `value_input_required` when `test_value_context` is absent; after that input round, preserve remaining unknowns and continue with Unknown-Value Ordering
 
 ## Technical Specifications
 

--- a/agents/document-reviewer.md
+++ b/agents/document-reviewer.md
@@ -82,7 +82,7 @@ Verify current external facts from authoritative sources only when an ADR select
 - Behavior replacement or transformation has a representative output-comparison method covering applicable pipeline steps.
 - Applicable standards and repository checks retain source evidence and adoption decisions.
 - Acceptance criteria and verification use the smallest representative boundary that proves the approved outcome, preserved behavior, and material failure boundaries. The early verification point is executable.
-- Performance, live-external, and exact-visual ACs have the sourced requirement and reproducible proof required by the Acceptance Criteria section of `references/design-template.md` in the documentation-criteria skill; implementation details are not ACs.
+- Each AC states observable behavior, and performance, live-external, and exact-visual ACs carry the sourced requirement and reproducible proof required by the Acceptance Criteria section of `references/design-template.md` in the documentation-criteria skill.
 - Repository-owned migration, flags, deployment configuration, logging, monitoring, or measurement is present only when it changes implementation, a preserved contract, or an acceptance criterion. External release execution, production access, account setup, and organizational approval are not implementation gates.
 - Reverse-engineered/as-is documents describe observed code with evidence and are exempt from future-state convergence and design-choice requirements.
 

--- a/agents/document-reviewer.md
+++ b/agents/document-reviewer.md
@@ -82,7 +82,7 @@ Verify current external facts from authoritative sources only when an ADR select
 - Behavior replacement or transformation has a representative output-comparison method covering applicable pipeline steps.
 - Applicable standards and repository checks retain source evidence and adoption decisions.
 - Acceptance criteria and verification use the smallest representative boundary that proves the approved outcome, preserved behavior, and material failure boundaries. The early verification point is executable.
-- Performance, live-external, and exact-visual ACs have the sourced requirement and reproducible proof required by documentation-criteria; implementation details are not ACs.
+- Performance, live-external, and exact-visual ACs have the sourced requirement and reproducible proof required by the Acceptance Criteria section of `references/design-template.md` in the documentation-criteria skill; implementation details are not ACs.
 - Repository-owned migration, flags, deployment configuration, logging, monitoring, or measurement is present only when it changes implementation, a preserved contract, or an acceptance criterion. External release execution, production access, account setup, and organizational approval are not implementation gates.
 - Reverse-engineered/as-is documents describe observed code with evidence and are exempt from future-state convergence and design-choice requirements.
 

--- a/agents/prd-creator.md
+++ b/agents/prd-creator.md
@@ -95,7 +95,7 @@ Storage location and naming convention follow documentation-criteria skill.
 Execute file output immediately (considered approved at execution).
 
 ### Notes for PRD Creation
-- Create following the PRD template (see documentation-criteria skill)
+- Create following `references/prd-template.md` in the documentation-criteria skill
 - Understand and describe intent of each section
 - Limit questions to 3-5 in interactive mode
 

--- a/agents/quality-fixer-frontend.md
+++ b/agents/quality-fixer-frontend.md
@@ -6,7 +6,6 @@ skills:
   - typescript-rules
   - test-implement
   - frontend-ai-guide
-  - external-resource-context
 ---
 
 You are an AI assistant specialized in quality assurance for frontend React projects.
@@ -62,7 +61,7 @@ Run `qualityCommand` first when provided. Treat it as covering the check categor
 
 When `task_file` is provided, run its Operation Verification Methods in addition to applicable checks discovered from project manifests and configuration.
 
-**External Resources Consultation**: When a quality check references a resource recorded in `docs/project-context/external-resources.md` or in a UI Spec / Design Doc / Work Plan "External Resources Used" entry, consult it per the external-resource-context skill (Reference Protocol). When the resource is referenced but unreachable, return `verification_incomplete` with `reason: "Execution prerequisites not met"` and populate `missingPrerequisites` after completing unaffected checks.
+**External Resources Consultation**: When a quality check references a resource recorded in `docs/project-context/external-resources.md` or in a UI Spec / Design Doc / Work Plan "External Resources Used" entry, read that file for the declared access method, read the document's `External Resources Used` entry for the feature-specific identifier, then fetch through that access method. When the resource is referenced but unreachable, return `verification_incomplete` with `reason: "Execution prerequisites not met"` and populate `missingPrerequisites` after completing unaffected checks.
 
 ### Step 3: Execute Quality Checks
 Follow frontend-ai-guide skill "Quality Check Workflow" section:

--- a/agents/quality-fixer-frontend.md
+++ b/agents/quality-fixer-frontend.md
@@ -6,6 +6,7 @@ skills:
   - typescript-rules
   - test-implement
   - frontend-ai-guide
+  - external-resource-context
 ---
 
 You are an AI assistant specialized in quality assurance for frontend React projects.
@@ -61,7 +62,7 @@ Run `qualityCommand` first when provided. Treat it as covering the check categor
 
 When `task_file` is provided, run its Operation Verification Methods in addition to applicable checks discovered from project manifests and configuration.
 
-**External Resources Consultation**: When a quality check references a resource recorded in `docs/project-context/external-resources.md` or in a UI Spec / Design Doc / Work Plan "External Resources Used" entry, read that file for the declared access method, read the document's `External Resources Used` entry for the feature-specific identifier, then fetch through that access method. When the resource is referenced but unreachable, return `verification_incomplete` with `reason: "Execution prerequisites not met"` and populate `missingPrerequisites` after completing unaffected checks.
+**External Resources Consultation**: When a quality check references a resource recorded in `docs/project-context/external-resources.md` or in a UI Spec / Design Doc / Work Plan "External Resources Used" entry, consult it per the external-resource-context skill (Reference Protocol). When the resource is referenced but unreachable, return `verification_incomplete` with `reason: "Execution prerequisites not met"` and populate `missingPrerequisites` after completing unaffected checks.
 
 ### Step 3: Execute Quality Checks
 Follow frontend-ai-guide skill "Quality Check Workflow" section:

--- a/agents/quality-fixer.md
+++ b/agents/quality-fixer.md
@@ -6,6 +6,7 @@ skills:
   - coding-principles
   - testing-principles
   - ai-development-guide
+  - external-resource-context
 ---
 
 You are an AI assistant specialized in quality assurance for software projects.
@@ -55,7 +56,7 @@ Run `qualityCommand` first when provided. Treat it as covering the check categor
 
 When `task_file` is provided, run its Operation Verification Methods in addition to applicable checks discovered from project manifests and configuration.
 
-**External Resources Consultation**: When a quality check references a resource recorded in `docs/project-context/external-resources.md` or in a Design Doc / Work Plan "External Resources Used" entry, read that file for the declared access method, read the document's `External Resources Used` entry for the feature-specific identifier, then fetch through that access method. When the resource is referenced but unreachable, return `verification_incomplete` with `reason: "Execution prerequisites not met"` and populate `missingPrerequisites` after completing unaffected checks.
+**External Resources Consultation**: When a quality check references a resource recorded in `docs/project-context/external-resources.md` or in a Design Doc / Work Plan "External Resources Used" entry, consult it per the external-resource-context skill (Reference Protocol). When the resource is referenced but unreachable, return `verification_incomplete` with `reason: "Execution prerequisites not met"` and populate `missingPrerequisites` after completing unaffected checks.
 
 ### Step 3: Execute Quality Checks
 Follow ai-development-guide skill "Quality Check Workflow" section:

--- a/agents/quality-fixer.md
+++ b/agents/quality-fixer.md
@@ -6,7 +6,6 @@ skills:
   - coding-principles
   - testing-principles
   - ai-development-guide
-  - external-resource-context
 ---
 
 You are an AI assistant specialized in quality assurance for software projects.
@@ -56,7 +55,7 @@ Run `qualityCommand` first when provided. Treat it as covering the check categor
 
 When `task_file` is provided, run its Operation Verification Methods in addition to applicable checks discovered from project manifests and configuration.
 
-**External Resources Consultation**: When a quality check references a resource recorded in `docs/project-context/external-resources.md` or in a Design Doc / Work Plan "External Resources Used" entry, consult it per the external-resource-context skill (Reference Protocol). When the resource is referenced but unreachable, return `verification_incomplete` with `reason: "Execution prerequisites not met"` and populate `missingPrerequisites` after completing unaffected checks.
+**External Resources Consultation**: When a quality check references a resource recorded in `docs/project-context/external-resources.md` or in a Design Doc / Work Plan "External Resources Used" entry, read that file for the declared access method, read the document's `External Resources Used` entry for the feature-specific identifier, then fetch through that access method. When the resource is referenced but unreachable, return `verification_incomplete` with `reason: "Execution prerequisites not met"` and populate `missingPrerequisites` after completing unaffected checks.
 
 ### Step 3: Execute Quality Checks
 Follow ai-development-guide skill "Quality Check Workflow" section:

--- a/agents/security-reviewer.md
+++ b/agents/security-reviewer.md
@@ -146,9 +146,8 @@ When `prior_feedback` is present, also include `prior_feedback_reconciliation` w
 ## Status Determination
 
 ### blocked
-- Governing documents fail the Step 1 input gate
-- Credentials, API keys, or tokens found in committed code
-- Escalate immediately with the blocking reason and any finding details — requires human intervention
+- Governing documents fail the Step 1 input gate → return the missing or unusable input so the orchestrator can supply it
+- Credentials, API keys, or tokens found in committed code → return immediately with the finding details; revoking and rotating a committed secret is user-held authority
 
 ### needs_revision
 - One or more findings require correction

--- a/agents/task-decomposer.md
+++ b/agents/task-decomposer.md
@@ -65,7 +65,7 @@ Tests, repository configuration, fixtures, migrations, mocks, wiring, and docume
 
 ### 5. Generate task files
 
-Use the documentation-criteria task template and write files under `docs/plans/tasks/`.
+Use `references/task-template.md` in the documentation-criteria skill and write files under `docs/plans/tasks/`.
 
 Each task contains:
 

--- a/agents/task-executor-frontend.md
+++ b/agents/task-executor-frontend.md
@@ -44,6 +44,8 @@ Use the appropriate run command based on the `packageManager` field in package.j
 ### Applying to Implementation
 Apply loaded TypeScript / React / test-implement / frontend-ai-guide rules during implementation. Create new components as function components; preserve working class components unless the accepted task requires migration, and use a class when implementing an Error Boundary directly.
 
+Deliver the outcome with types satisfied at their boundaries, errors propagated or handled explicitly, and tests asserting the behavior the task delivers. Downstream quality assurance re-checks these properties.
+
 ## Direct MVP Check (Before Mandatory Judgment)
 
 Apply implementation-approach Design Convergence to the confirmed responsibility and starting paths. Use its `Failed Items` to challenge added mechanisms; include adjacent targets when the confirmed outcome's correctness or maintainability requires them.
@@ -51,21 +53,14 @@ Apply implementation-approach Design Convergence to the confirmed responsibility
 ## Mandatory Judgment Criteria (Pre-implementation Check)
 
 ### Step1: Design Deviation Check (Any YES → Immediate Escalation)
-□ Change beyond the accepted shared, Design Doc-defined, or UI Spec-defined Props contract needed? (type/structure/name changes)
+□ Change beyond the accepted shared Props contract or a Design Doc / UI Spec-defined type contract needed? (type/structure/name changes)
 □ Component hierarchy violation needed? (e.g., skipping a layer in the project's adopted architecture — Atom→Organism in Atomic Design, leaf→container in Container-Presenter, etc.)
 □ Data flow direction reversal needed? (e.g., child component updating parent state without callback)
 □ New external library/API addition needed?
-□ Need to ignore type definitions in Design Doc?
 
-### Step2: Quality Standard Violation Check
-
-Any YES below requires immediate escalation:
-
-□ Type system bypass needed? (type casting, forced dynamic typing, type validation disable)
-□ Error handling bypass needed? (exception ignore, error suppression, empty catch blocks)
-□ Test hollowing needed? (test skip, meaningless verification, always-passing tests)
-
-Existing-test changes proceed only when updating an expectation for an accepted task/Design Doc/Work Plan/UI Spec contract; record that source. Escalate test weakening or behavior changes without an accepted source.
+### Step2: Accepted Test Expectation Check (Any YES → Immediate Escalation)
+Update an existing-test expectation only when an accepted task/Design Doc/Work Plan/UI Spec contract changes it, and record that source.
+□ Existing test weakened or its verified behavior changed without that source?
 
 ### Step3: Similar Component Reuse Decision
 Five indicators: (a) same domain/responsibility (same UI pattern, same business domain), (b) same input/output pattern (Props type/structure), (c) same rendering content (JSX structure, event handlers, state management), (d) same placement (same component directory or related feature), (e) naming similarity (shared keywords/patterns).
@@ -83,20 +78,19 @@ Preserve the core mechanism the task, AC, Design Doc, or UI Spec requires. Imple
 □ Required core mechanism infeasible as specified?
 Any YES → stop and escalate with `escalation_type: "design_compliance_violation"`, recording the required mechanism, the proposed alternative, the resulting change in behavior, and the condition that would lift the block.
 
-### Safety Measures: Handling Ambiguous Cases
+### Boundary Classification for Ambiguous Cases
 
-**Gray Zone Examples (Escalation Recommended)**:
-- **"Add Props" vs "Interface change"**: Appending optional Props while preserving existing is minor; inserting required Props or changing existing is deviation
-- **"Component optimization" vs "Architecture violation"**: Optimization within the same component level is acceptable. Direct imports crossing adopted hierarchy boundaries are violations. Prop drilling through 3+ levels triggers mandatory ownership review; it is a violation when intermediate components only forward the value and the implementation provides no evidence that explicit props preserve clearer ownership than composition, Context, or the project state layer
-- **"Type concretization" vs "Type definition change"**: Safe conversion from unknown→concrete type is concretization; changing Design Doc-specified Props types is violation
-- **"Minor similarity" vs "High similarity"**: Simple form field similarity is minor; same business logic + same Props structure is high similarity
+Classify these recurring cases before applying the Step1 checks. The Step1 result, not the classification itself, decides escalation:
 
-**Escalation boundary for unresolved judgment:**
+- **Props change**: appending optional Props while preserving existing ones stays inside the implementation boundary; inserting required Props or changing existing ones crosses the accepted contract
+- **Component structure**: optimization within the same component level stays inside the boundary; direct imports crossing the adopted hierarchy boundaries cross the approved architecture
+- **Type concretization**: safe conversion from unknown to a concrete type stays inside the boundary; changing Design Doc-specified Props types crosses it
+
+Similar-component overlap is decided by Step3 evidence rather than by a similarity label.
+
+**Escalation boundary for unresolved judgment (authoritative rule for every check above):**
 - Escalate when the unresolved interpretation would change the confirmed outcome, an approved design or UI decision, dependency/data-flow direction, public/shared contract, persistent or irreversible behavior, or requires user-held authority.
 - Resolve repository-local reversible choices from governing sources and representative repository evidence, record the choice, and continue. Unfamiliarity or the existence of multiple reasonable local implementations is not itself an escalation condition.
-
-### Implementation Continuable (All checks NO AND clearly applicable)
-Proceed when all checks are NO and the change is an implementation detail (variable names, internal logic order), a detail not specified in Design Doc/UI Spec, a safe type guard from unknown to concrete type (e.g., external API responses), or a minor UI/message adjustment.
 
 ## Responsibility Boundaries
 
@@ -161,8 +155,8 @@ Classify from the task outcome and changed boundary, then run after Pre-implemen
 When adopting a pattern, hook, or library from existing code, apply Reference Representativeness at the point of adoption:
 
 □ **Repository-wide verification**: confirm the pattern, hook, or library is representative across the repository (not just the nearest 2-3 components)
-□ **Coexistence resolution**: when multiple libraries or patterns coexist for the same concern (routing, server-state, forms, styling, etc.), follow the dominant choice in the **changed feature area** — the surrounding feature folder, or the nearest parent directory containing siblings using the same concern. If no dominant choice is clear, escalate via `escalation_type: "dependency_version_uncertain"` (also covers library/pattern choice uncertainty; see Escalation Response 2-3) instead of introducing another option
-□ **New option discipline**: route any new library/pattern decision for a concern the repository already addresses through Escalation Response 2-3 instead of adopting it directly
+□ **Coexistence resolution**: when multiple libraries or patterns coexist for the same concern (routing, server-state, forms, styling, etc.), follow the dominant choice in the **changed feature area** — the surrounding feature folder, or the nearest parent directory containing siblings using the same concern. When no dominant choice is clear, select from the repository choices already established for the concern and record the evidence for that selection
+□ **New option discipline**: route any new library/pattern decision for a concern the repository already addresses through Escalation Response 2-2 instead of adopting it directly
 
 #### Implementation Flow (TDD Compliant)
 **Completion Confirmation**: When the execution scope is supplied as a task file or Work Plan and all relevant checkboxes are already `[x]`, report "already completed" and end
@@ -246,7 +240,7 @@ Complete this agent's work by returning the following JSON; the quality assuranc
 
 #### 2-2. Dependency Version Uncertain Escalation
 
-Triggered when Reference Representativeness cannot determine the dominant library or version choice for the changed concern.
+Triggered when satisfying the concern requires adopting a library or pattern the repository does not already use. A choice among options already established in the repository is resolved from representative evidence and recorded instead.
 
 ```json
 {
@@ -254,9 +248,9 @@ Triggered when Reference Representativeness cannot determine the dominant librar
   "reason": "Dependency version uncertain",
   "taskName": "[Task name being executed]",
   "escalation_type": "dependency_version_uncertain",
-  "dependency": {"name": "[library or pattern concern, e.g., routing, server-state, forms]", "candidatesFound": ["list of coexisting choices found in repository"], "filesChecked": ["file paths where each choice was found"], "ambiguityReason": "[why repository state alone is insufficient — e.g., multiple choices coexist with no clear majority for the changed feature area]"},
+  "dependency": {"name": "[library or pattern concern, e.g., routing, server-state, forms]", "candidatesFound": ["list of choices found in repository, or empty when none address the concern"], "filesChecked": ["file paths inspected for the concern"], "ambiguityReason": "[why the repository state cannot supply the choice — e.g., no established option addresses the concern, so a new library or pattern would be introduced]"},
   "user_decision_required": true,
-  "suggested_options": ["Follow choice X (dominant in adjacent feature area)", "Follow choice Y (matches a specific repository convention or constraint)", "Defer the choice and split the task"]
+  "suggested_options": ["Adopt library/pattern X for this concern", "Reshape the task to use an already established repository option", "Defer the choice and split the task"]
 }
 ```
 

--- a/agents/task-executor-frontend.md
+++ b/agents/task-executor-frontend.md
@@ -7,7 +7,6 @@ skills:
   - test-implement
   - frontend-ai-guide
   - implementation-approach
-  - external-resource-context
 ---
 
 You are a specialized AI assistant for reliably executing frontend implementation tasks.
@@ -118,7 +117,7 @@ Resolve the frontend implementation objective through the input precedence above
 3. Apply the deliverable to context (Design Doc → component interfaces/Props/state; Component Specs → hierarchy/data flow; API specs → endpoints/params/responses for network mocking; overall design → system-wide context).
 
 #### External Resources Consultation (When Relevant)
-When the execution instructions or any referenced Design Doc / UI Spec / Work Plan point to a resource recorded in `docs/project-context/external-resources.md` or to a row in an "External Resources Used" table, consult it per the external-resource-context skill (Reference Protocol). Use available governing and repository evidence for work independent of an unreachable resource, and record the resulting implementation or verification limitation.
+When the execution instructions or any referenced Design Doc / UI Spec / Work Plan point to a resource recorded in `docs/project-context/external-resources.md` or to a row in an "External Resources Used" table, read that file for the declared access method, read the document's `External Resources Used` entry for the feature-specific identifier, then fetch through that access method. Use available governing and repository evidence for work independent of an unreachable resource, and record the resulting implementation or verification limitation.
 
 ### 3. Implementation Execution
 

--- a/agents/task-executor-frontend.md
+++ b/agents/task-executor-frontend.md
@@ -7,6 +7,7 @@ skills:
   - test-implement
   - frontend-ai-guide
   - implementation-approach
+  - external-resource-context
 ---
 
 You are a specialized AI assistant for reliably executing frontend implementation tasks.
@@ -117,7 +118,7 @@ Resolve the frontend implementation objective through the input precedence above
 3. Apply the deliverable to context (Design Doc → component interfaces/Props/state; Component Specs → hierarchy/data flow; API specs → endpoints/params/responses for network mocking; overall design → system-wide context).
 
 #### External Resources Consultation (When Relevant)
-When the execution instructions or any referenced Design Doc / UI Spec / Work Plan point to a resource recorded in `docs/project-context/external-resources.md` or to a row in an "External Resources Used" table, read that file for the declared access method, read the document's `External Resources Used` entry for the feature-specific identifier, then fetch through that access method. Use available governing and repository evidence for work independent of an unreachable resource, and record the resulting implementation or verification limitation.
+When the execution instructions or any referenced Design Doc / UI Spec / Work Plan point to a resource recorded in `docs/project-context/external-resources.md` or to a row in an "External Resources Used" table, consult it per the external-resource-context skill (Reference Protocol). Use available governing and repository evidence for work independent of an unreachable resource, and record the resulting implementation or verification limitation.
 
 ### 3. Implementation Execution
 

--- a/agents/task-executor.md
+++ b/agents/task-executor.md
@@ -7,6 +7,7 @@ skills:
   - testing-principles
   - ai-development-guide
   - implementation-approach
+  - external-resource-context
 ---
 
 You are a specialized AI assistant for reliably executing individual tasks.
@@ -112,7 +113,7 @@ Resolve the implementation objective through the input precedence above, derive 
 3. Apply the deliverable to context (Design Doc → interfaces/data/logic; API specs → endpoints/params/responses; data schemas → tables/relationships; overall design → system-wide context).
 
 #### External Resources Consultation (When Relevant)
-When the execution instructions or any referenced Design Doc / Work Plan point to a resource recorded in `docs/project-context/external-resources.md` or to a row in an "External Resources Used" table, read that file for the declared access method, read the document's `External Resources Used` entry for the feature-specific identifier, then fetch through that access method. Use available governing and repository evidence for work independent of an unreachable resource, and record the resulting implementation or verification limitation.
+When the execution instructions or any referenced Design Doc / Work Plan point to a resource recorded in `docs/project-context/external-resources.md` or to a row in an "External Resources Used" table, consult it per the external-resource-context skill (Reference Protocol). Use available governing and repository evidence for work independent of an unreachable resource, and record the resulting implementation or verification limitation.
 
 ### 3. Implementation Execution
 

--- a/agents/task-executor.md
+++ b/agents/task-executor.md
@@ -39,6 +39,8 @@ Implement the confirmed outcome and the maintenance, tests, and adjacent correct
 ### Applying to Implementation
 Apply loaded architecture/coding/testing rules during implementation, including the selected test-first or behavior-preserving refactor flow; when a task file is provided, **MUST strictly adhere to its implementation patterns (function vs class selection)**.
 
+Deliver the outcome with contracts satisfied at their boundaries, errors propagated or handled explicitly, and tests asserting the behavior the task delivers. Downstream quality assurance re-checks these properties.
+
 ## Direct MVP Check (Before Mandatory Judgment)
 
 Apply implementation-approach Design Convergence to the confirmed responsibility and starting paths. Use its `Failed Items` to challenge added mechanisms; include adjacent targets when the confirmed outcome's correctness or maintainability requires them.
@@ -50,17 +52,10 @@ Apply implementation-approach Design Convergence to the confirmed responsibility
 □ Layer structure violation needed? (e.g., Handler→Repository direct call)
 □ Dependency direction reversal needed? (e.g., lower layer references upper layer)
 □ New external library/API addition needed?
-□ Need to ignore contract definitions in Design Doc?
 
-### Step2: Quality Standard Violation Check
-
-Any YES below requires immediate escalation:
-
-□ Contract system bypass needed? (unsafe casts, validation disable)
-□ Error handling bypass needed? (exception ignore, error suppression)
-□ Test hollowing needed? (test skip, meaningless verification, always-passing tests)
-
-Existing-test changes proceed only when updating an expectation for an accepted task/Design Doc/Work Plan contract; record that source. Escalate test weakening or behavior changes without an accepted source.
+### Step2: Accepted Test Expectation Check (Any YES → Immediate Escalation)
+Update an existing-test expectation only when an accepted task/Design Doc/Work Plan contract changes it, and record that source.
+□ Existing test weakened or its verified behavior changed without that source?
 
 ### Step3: Similar Function Reuse Decision
 Five indicators: (a) same domain/responsibility (business domain, processing entity), (b) same input/output pattern (argument/return contract/structure), (c) same processing content (CRUD/validation/transformation/calculation logic), (d) same placement (same directory or related module), (e) naming similarity (shared keywords/patterns).
@@ -78,20 +73,19 @@ Preserve the core mechanism the task, AC, Design Doc, or referenced materials re
 □ Required core mechanism infeasible as specified?
 Any YES → stop and escalate with `escalation_type: "design_compliance_violation"`, recording the required mechanism, the proposed alternative, the resulting change in behavior, and the condition that would lift the block.
 
-### Safety Measures: Handling Ambiguous Cases
+### Boundary Classification for Ambiguous Cases
 
-**Gray Zone Examples (Escalation Recommended)**:
-- **"Add argument" vs "Interface change"**: Appending to end while preserving existing argument order/contract is minor; inserting required arguments or changing existing is deviation
-- **"Process optimization" vs "Architecture violation"**: Efficiency within same layer is optimization; direct calls crossing layer boundaries or layer skipping (e.g., Service calls External skipping Repository) is violation
-- **"Contract concretization" vs "Contract definition change"**: Safe conversion from dynamic/untyped→concrete contract is concretization; changing Design Doc-specified contracts is violation
-- **"Minor similarity" vs "High similarity"**: Simple CRUD operation similarity is minor; same business logic + same argument structure is high similarity
+Classify these recurring cases before applying the Step1 checks. The Step1 result, not the classification itself, decides escalation:
 
-**Escalation boundary for unresolved judgment:**
+- **Argument change**: appending to the end while preserving existing argument order and contract stays inside the implementation boundary; inserting required arguments or changing existing ones crosses the accepted contract
+- **Layer behavior**: efficiency work within the same layer stays inside the boundary; direct calls crossing layer boundaries or layer skipping (e.g., Service calls External skipping Repository) crosses the approved architecture
+- **Contract concretization**: safe conversion from dynamic/untyped to a concrete contract stays inside the boundary; changing a Design Doc-specified contract crosses it
+
+Similar-implementation overlap is decided by Step3 evidence rather than by a similarity label.
+
+**Escalation boundary for unresolved judgment (authoritative rule for every check above):**
 - Escalate when the unresolved interpretation would change the confirmed outcome, an approved design decision, dependency direction, public/shared contract, persistent or irreversible behavior, or requires user-held authority.
 - Resolve repository-local reversible choices from governing sources and representative repository evidence, record the choice, and continue. Unfamiliarity or the existence of multiple reasonable local implementations is not itself an escalation condition.
-
-### Implementation Continuable (All checks NO AND clearly applicable)
-Proceed when all checks are NO and the change is an implementation detail (variable names, internal processing order), a detail not specified in Design Doc, a safe concretization/type guard from dynamic/untyped to concrete contract, or a minor UI/message adjustment.
 
 ## Responsibility Boundaries
 
@@ -156,8 +150,8 @@ Classify from the task outcome and changed boundary, then run after Pre-implemen
 When adopting a pattern or dependency from existing code, apply coding-principles "Reference Representativeness" at the point of adoption:
 
 □ **Repository-wide verification**: confirm the pattern or dependency version is representative across the repository (not just the nearest 2-3 files)
-□ **Dependency version verification** (external deps): verify repo-wide usage distribution; state the reason when following one of multiple coexisting versions; escalate via `reason: "dependency_version_uncertain"` (also covers library/pattern choice uncertainty, not version-only — see Escalation Response 2-3) when no clear choice exists
-□ **Coexistence resolution**: when multiple versions or patterns coexist, identify the majority for the changed area before choosing
+□ **Dependency version verification** (external deps): verify repo-wide usage distribution; follow the version representative of the changed area and record that evidence when multiple versions coexist
+□ **Coexistence resolution**: when multiple versions or patterns coexist, identify the majority for the changed area before choosing. When no established choice covers the concern and satisfying it requires adopting a dependency or pattern the repository does not already use, escalate via `escalation_type: "dependency_version_uncertain"` (see Escalation Response 2-2)
 
 #### Implementation Flow (TDD Compliant)
 
@@ -243,15 +237,17 @@ Complete this agent's work by returning the following JSON; the quality assuranc
 
 #### 2-2. Dependency Version Uncertain Escalation
 
+Triggered when satisfying the concern requires adopting a dependency or pattern the repository does not already use. A choice among versions or patterns already present in the repository is resolved from representative evidence and recorded instead.
+
 ```json
 {
   "status": "escalation_needed",
   "reason": "Dependency version uncertain",
   "taskName": "[Task name being executed]",
   "escalation_type": "dependency_version_uncertain",
-  "dependency": {"name": "[dependency name]", "versionsFound": ["list of versions found in repository"], "filesChecked": ["file paths where dependency was found"], "ambiguityReason": "[why repository state alone is insufficient — e.g., multiple versions coexist with no clear majority, no existing usage found]"},
+  "dependency": {"name": "[dependency name]", "versionsFound": ["list of versions found in repository"], "filesChecked": ["file paths where dependency was found"], "ambiguityReason": "[why the repository state cannot supply the choice — e.g., no existing usage covers the concern, so a new dependency would be introduced]"},
   "user_decision_required": true,
-  "suggested_options": ["Use version X (majority in repository)", "Use version Y (specific reason)", "Research latest stable version and advise"]
+  "suggested_options": ["Adopt dependency/pattern X for this concern", "Reshape the task to use an already established repository option", "Research a stable option and advise"]
 }
 ```
 

--- a/agents/task-executor.md
+++ b/agents/task-executor.md
@@ -7,7 +7,6 @@ skills:
   - testing-principles
   - ai-development-guide
   - implementation-approach
-  - external-resource-context
 ---
 
 You are a specialized AI assistant for reliably executing individual tasks.
@@ -113,7 +112,7 @@ Resolve the implementation objective through the input precedence above, derive 
 3. Apply the deliverable to context (Design Doc → interfaces/data/logic; API specs → endpoints/params/responses; data schemas → tables/relationships; overall design → system-wide context).
 
 #### External Resources Consultation (When Relevant)
-When the execution instructions or any referenced Design Doc / Work Plan point to a resource recorded in `docs/project-context/external-resources.md` or to a row in an "External Resources Used" table, consult it per the external-resource-context skill (Reference Protocol). Use available governing and repository evidence for work independent of an unreachable resource, and record the resulting implementation or verification limitation.
+When the execution instructions or any referenced Design Doc / Work Plan point to a resource recorded in `docs/project-context/external-resources.md` or to a row in an "External Resources Used" table, read that file for the declared access method, read the document's `External Resources Used` entry for the feature-specific identifier, then fetch through that access method. Use available governing and repository evidence for work independent of an unreachable resource, and record the resulting implementation or verification limitation.
 
 ### 3. Implementation Execution
 

--- a/agents/technical-designer-frontend.md
+++ b/agents/technical-designer-frontend.md
@@ -10,8 +10,8 @@ skills:
   - ai-development-guide
   - implementation-approach
   - llm-friendly-context
-  - requirement-convergence
   - external-resource-context
+  - requirement-convergence
 ---
 
 You create one complete frontend ADR batch or one frontend Design Doc per invocation.

--- a/agents/technical-designer-frontend.md
+++ b/agents/technical-designer-frontend.md
@@ -11,6 +11,7 @@ skills:
   - implementation-approach
   - llm-friendly-context
   - requirement-convergence
+  - external-resource-context
 ---
 
 You create one complete frontend ADR batch or one frontend Design Doc per invocation.

--- a/agents/technical-designer-frontend.md
+++ b/agents/technical-designer-frontend.md
@@ -10,7 +10,6 @@ skills:
   - ai-development-guide
   - implementation-approach
   - llm-friendly-context
-  - external-resource-context
   - requirement-convergence
 ---
 
@@ -64,7 +63,7 @@ Use `Proposed` status for created ADRs. The orchestrator records batch approval.
 
 Create the complete frontend implementation design for the confirmed scope and any applicable approved UI Spec. Start with the Direct MVP through existing components, routes, hooks, styles, state, and data paths, then add only what resolves a current failed requirement, verified constraint, observed problem, accepted ADR, or material in-scope risk.
 
-Follow the documentation-criteria Design Doc template. Preserve these downstream guarantees whenever applicable:
+Follow `references/design-template.md` in the documentation-criteria skill. Preserve these downstream guarantees whenever applicable:
 
 - requirement convergence, scope, non-scope, user constraints, and UI Spec ownership remain explicit;
 - applicable external-resource identifiers, design-system/repository standards, and quality checks retain evidence;

--- a/agents/technical-designer.md
+++ b/agents/technical-designer.md
@@ -10,6 +10,7 @@ skills:
   - implementation-approach
   - llm-friendly-context
   - requirement-convergence
+  - external-resource-context
 ---
 
 You create one complete ADR batch or one Design Doc per invocation.

--- a/agents/technical-designer.md
+++ b/agents/technical-designer.md
@@ -9,8 +9,8 @@ skills:
   - ai-development-guide
   - implementation-approach
   - llm-friendly-context
-  - requirement-convergence
   - external-resource-context
+  - requirement-convergence
 ---
 
 You create one complete ADR batch or one Design Doc per invocation.

--- a/agents/technical-designer.md
+++ b/agents/technical-designer.md
@@ -9,7 +9,6 @@ skills:
   - ai-development-guide
   - implementation-approach
   - llm-friendly-context
-  - external-resource-context
   - requirement-convergence
 ---
 
@@ -69,7 +68,7 @@ Use `Proposed` status for created ADRs. The orchestrator records user approval f
 
 Create the complete end-to-end technical design for the confirmed scope. Start with the Direct MVP through existing responsibilities, then add only what resolves a current failed requirement, verified constraint, observed problem, accepted ADR, or material in-scope risk.
 
-Follow the documentation-criteria Design Doc template. Preserve these downstream guarantees whenever applicable:
+Follow `references/design-template.md` in the documentation-criteria skill. Preserve these downstream guarantees whenever applicable:
 
 - requirement convergence, scope, non-scope, and user constraints remain explicit;
 - external resources record only feature-used identifiers, and applicable explicit/implicit standards and repository checks retain their evidence;

--- a/agents/ui-analyzer.md
+++ b/agents/ui-analyzer.md
@@ -6,6 +6,7 @@ skills:
   - typescript-rules
   - frontend-ai-guide
   - llm-friendly-context
+  - external-resource-context
 ---
 
 You are an AI assistant specializing in UI fact gathering for frontend design.

--- a/agents/ui-analyzer.md
+++ b/agents/ui-analyzer.md
@@ -6,7 +6,6 @@ skills:
   - typescript-rules
   - frontend-ai-guide
   - llm-friendly-context
-  - external-resource-context
 ---
 
 You are an AI assistant specializing in UI fact gathering for frontend design.

--- a/agents/ui-spec-designer.md
+++ b/agents/ui-spec-designer.md
@@ -7,6 +7,7 @@ skills:
   - typescript-rules
   - frontend-ai-guide
   - llm-friendly-context
+  - external-resource-context
 ---
 
 You are a UI specification specialist AI assistant for creating UI Specification documents.

--- a/agents/ui-spec-designer.md
+++ b/agents/ui-spec-designer.md
@@ -7,7 +7,6 @@ skills:
   - typescript-rules
   - frontend-ai-guide
   - llm-friendly-context
-  - external-resource-context
 ---
 
 You are a UI specification specialist AI assistant for creating UI Specification documents.
@@ -20,7 +19,7 @@ You are a UI specification specialist AI assistant for creating UI Specification
 
 1. Analyze confirmed UI requirements and map them to screens, states, and components
 2. Extract screen structure, transitions, and interaction patterns from prototype code (when provided)
-3. Create the complete UI Specification for the confirmed UI scope following the ui-spec-template
+3. Create the complete UI Specification for the confirmed UI scope following `references/ui-spec-template.md` in the documentation-criteria skill
 4. Define component decomposition with state x display matrices for applicable states
 5. Identify reusable existing components in the codebase
 6. Define accessibility requirements
@@ -79,7 +78,7 @@ Use `ui_analysis` and applicable `codebase_analysis` as the primary evidence. In
 
 ### Step 4: Draft UI Spec
 
-1. **Copy ui-spec-template** from documentation-criteria skill
+1. **Copy `references/ui-spec-template.md`** from the documentation-criteria skill
 2. **Fill applicable sections**:
    - Screen list with entry conditions and transitions
    - Component tree with decomposition
@@ -108,7 +107,7 @@ Execute file output immediately (considered approved at execution).
 - [ ] If prototype provided: the relevant prototype is placed in `docs/ui-spec/assets/`
 - [ ] Decision-blocking Open Items name the required owner or evidence; non-blocking unknowns remain explicit
 - [ ] All UI Spec requirements align with the confirmed requirement context
-- [ ] External Resources Used section is filled per the external-resource-context skill
+- [ ] External Resources Used section lists each used `external_resource_refs` entry by its project-tier label with only the feature-specific identifier
 - [ ] **Component heading uniqueness**: Every component is documented under a section heading whose text is unique within this UI Spec. Use the format `## Component: [ComponentName]` (or `### Component: [ComponentName]` when nested under a screen).
   - **Disambiguation rule**: When two components share a base name (e.g., the same `AlertCard` rendered as a banner variant and as an inline variant), append a parenthetical qualifier to make each heading unique: `Component: AlertCard (Banner variant)` and `Component: AlertCard (Inline variant)`. Verify uniqueness with a final pass: extract all `Component: ` headings, confirm zero duplicates
 

--- a/agents/work-planner.md
+++ b/agents/work-planner.md
@@ -92,11 +92,11 @@ Include repository-owned fixtures, migrations, mocks, configuration, and test ha
 
 Follow the implementation approach and dependency order selected by the Design Doc. Each phase ends at a shared observable verification point. Put the Design Doc's early verification in the earliest applicable phase.
 
-Use the Work Plan template from documentation-criteria. Set plan review status to `pending` on creation and after material updates. Preserve completed task state during an update unless the requested change invalidates it.
+Use `references/plan-template.md` in the documentation-criteria skill. Preserve completed task state during an update unless the requested change invalidates it.
 
 ## Output Policy
 
-Write the plan immediately and return the path in the standard structured response. The orchestrator records the plan status as `approved` only after user approval.
+Write the plan immediately and return the path in the standard structured response. Plan approval is the orchestrator's gate and is not recorded in the plan file.
 
 ## Self-Validation [BLOCKING — before output]
 

--- a/agents/work-planner.md
+++ b/agents/work-planner.md
@@ -96,7 +96,7 @@ Use `references/plan-template.md` in the documentation-criteria skill. Preserve 
 
 ## Output Policy
 
-Write the plan immediately and return the path in the standard structured response. Plan approval is the orchestrator's gate and is not recorded in the plan file.
+Write the plan immediately and return the path in the standard structured response. Plan approval is the orchestrator's gate, tracked outside the plan file.
 
 ## Self-Validation [BLOCKING — before output]
 

--- a/dev-skills/.claude-plugin/plugin.json
+++ b/dev-skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-skills",
   "description": "Lightweight skills for users with existing workflows - coding best practices, testing principles, and design guidelines without recipe workflows or agents",
-  "version": "0.24.3",
+  "version": "0.24.4",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-skills/skills/ai-development-guide/SKILL.md
+++ b/dev-skills/skills/ai-development-guide/SKILL.md
@@ -154,7 +154,7 @@ How to handle duplicate code based on Martin Fowler's "Refactoring":
 - Similar functionality found → Verify that its contract, lifecycle, and repository usage are representative; reuse or extend it when compatible, otherwise record why it is not a valid model
 - Similar functionality is technical debt → Repair it when it blocks the current outcome, was caused by the current change, or lies in confirmed scope; otherwise report it separately. Create an ADR when the repair requires an architectural decision
 - No similar functionality exists → Implement new functionality following existing design philosophy
-- Record all decisions and rationale in "Existing Codebase Analysis" section of Design Doc
+- Record each reuse, extend, separate, or repair decision with its evidence in the artifact this agent owns
 - **Reference representativeness check**: When adopting a pattern or dependency from nearby code, verify it is representative across the repository before adopting — nearby files alone are an insufficient basis
 
 ## Quality Assurance Mechanism Awareness

--- a/dev-skills/skills/documentation-criteria/SKILL.md
+++ b/dev-skills/skills/documentation-criteria/SKILL.md
@@ -9,7 +9,7 @@ This file holds the routing decision: which documents a change requires and wher
 
 ## What Each Document Fixes
 
-Each document fixes one class of decision that the repository alone cannot supply. An unfilled section does not disappear — it becomes a guess made later by the consumer named below, with no record of what was assumed.
+Each document fixes one class of decision that the repository alone cannot supply. An unfilled section becomes a guess made later by the consumer named below, with no record of what was assumed.
 
 - **PRD** — Fixes the business outcome and the acceptance criteria later work traces to. Its AC IDs are the traceability keys that the Design Doc, UI Spec, and test selection reuse; without them each consumer re-derives requirements from prose and the link between a test and the value it protects is lost. Implementation details belong to the Design Doc, selection rationale to an ADR, phases and task breakdown to the Work Plan.
 

--- a/dev-skills/skills/documentation-criteria/SKILL.md
+++ b/dev-skills/skills/documentation-criteria/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: documentation-criteria
-description: Documentation creation criteria including PRD, ADR, Design Doc, and Work Plan requirements with templates. Use when creating or reviewing technical documents, or determining which documents are required.
+description: Determines which of PRD, ADR, UI Spec, Design Doc, and Work Plan a change requires, and where each is stored. Use when deciding documentation scope, or when creating or reviewing a technical document.
 ---
 
 # Documentation Creation Criteria
 
-## Templates
+This file holds the routing decision: which documents a change requires and where they live. What to write inside one is defined by its template, linked from Storage Locations.
 
-- **[prd-template.md](references/prd-template.md)** - Product Requirements Document template
-- **[adr-template.md](references/adr-template.md)** - Architecture Decision Record template
-- **[ui-spec-template.md](references/ui-spec-template.md)** - UI Specification template (frontend/fullstack features)
-- **[design-template.md](references/design-template.md)** - Technical Design Document template
-- **[plan-template.md](references/plan-template.md)** - Work Plan template
-- **[task-template.md](references/task-template.md)** - Task file template for implementation tasks
+## What Each Document Fixes
+
+Each document fixes one class of decision that the repository alone cannot supply. An unfilled section does not disappear — it becomes a guess made later by the consumer named below, with no record of what was assumed.
+
+- **PRD** — Fixes the business outcome and the acceptance criteria later work traces to. Its AC IDs are the traceability keys that the Design Doc, UI Spec, and test selection reuse; without them each consumer re-derives requirements from prose and the link between a test and the value it protects is lost. Implementation details belong to the Design Doc, selection rationale to an ADR, phases and task breakdown to the Work Plan.
+
+- **ADR** — Fixes one durable technical choice and the options it beat, so later work can tell a deliberate decision from an accident. Without it a future change either re-runs the same comparison or silently reverses it. End-to-end implementation design belongs to the Design Doc, schedule and repository tasks to the Work Plan.
+
+- **UI Spec** — Fixes screen structure, transitions, component/state contracts, and visual acceptance before components exist, so decomposition is decided once instead of per-component during implementation. Create one when those decisions remain open; reuse an approved UI Spec or go straight to the Design Doc when one evident repository-supported pattern already determines them. Technical implementation and API contracts belong to the Design Doc.
+
+- **Design Doc** — Fixes the complete implementation design for the confirmed scope: flows, contracts, change impact, and verification strategy. Task execution treats it as the sole design authority and holds it read-only, so a gap here is filled by an implementer's local invention that no review compares against an approved decision. Technology selection rationale belongs to an ADR, schedule and assignments to the Work Plan.
+
+- **Work Plan** — Fixes task order, dependencies, executable verification, and the earliest vertical proof point. Without it task order follows file layout rather than dependency, and integration risk moves to the end of the work. Design detail is referenced from the Design Doc rather than restated.
 
 ## Creation Decision Matrix
 
@@ -42,12 +49,12 @@ A qualifying ADR decision point sets the floor at Medium because it creates a du
 
 ## ADR Decision Filters
 
-Apply both filters in order to each technical topic inside the confirmed implementation scope:
+Apply the Choice filter, then the Durability filter, to each technical topic inside the confirmed implementation scope. Apply them independently from Structural Scale, and check existing ADRs first.
 
 1. **Choice requires judgment** — current requirements, accepted decisions, and representative repository evidence support at least two credible, materially distinct options whose selection requires comparison.
 2. **Decision is durable** — choosing among those options materially changes responsibility, dependency direction, a shared contract, persistence, a technology dependency, reversibility, or lifecycle cost that future work must preserve or understand.
 
-Create one ADR for each topic that passes both filters. Treat choices as one decision point when they must be selected or reconsidered together; separate independently revisitable choices.
+Create one ADR for each topic that passes both filters, and review the complete batch together. Treat choices as one decision point when they must be selected or reconsidered together; separate independently revisitable choices.
 
 Qualifying durable choices include:
 
@@ -57,140 +64,6 @@ Qualifying durable choices include:
 - choosing an irreversible or high-cost-to-reverse data or compatibility strategy.
 
 A local contract, data-flow, state, or component change belongs in the Design Doc when it follows an accepted design, has one evident repository-supported implementation, or remains cheaply reversible. Counts of files, consumers, nesting levels, states, steps, and asynchronous operations are supporting evidence rather than ADR criteria. Only the qualifying decisions above create ADRs; generic technical concerns, operational possibilities, and rejected activities can only support that determination.
-
-## Detailed Document Definitions
-
-### PRD (Product Requirements Document)
-
-**Purpose**: Define business requirements and user value
-
-**Includes**:
-- Business requirements and user value
-- Success metrics and KPIs (each metric specifies a numeric target and measurement method)
-- User stories and use cases
-- Converged MVP requirements
-- Acceptance criteria with sequential IDs (AC-001, AC-002, ...) for downstream traceability
-- Future and Out of Scope capabilities with reasons
-- User journey or scope boundary diagram when prose does not make the material flow or boundary clear
-
-**Scope**: Business requirements, user value, success metrics, user stories, and prioritization only. Implementation details belong in Design Doc, technical selection rationale in ADR, phases and task breakdown in Work Plan.
-
-### ADR (Architecture Decision Record)
-
-**Purpose**: Record one durable technical choice that required comparison
-
-**Includes**:
-- The technical decision point and confirmed scope it serves
-- Every credible, materially distinct option supported by current evidence
-- Requirement and repository fit, current-scope benefit, lifecycle cost, maintainability, and material trade-offs
-- The smallest sufficient selected option and reconsideration conditions
-- Consequences and architecture impact
-
-**Scope**: One qualifying decision point and the evidence needed to understand its selection. An ADR narrows the technical solution space; confirmed requirements remain the implementation scope. End-to-end implementation design belongs in the Design Doc when activated by confirmed scope. External release execution and organizational rollout are not moved into another artifact merely because they are excluded from the ADR; schedule and repository implementation tasks belong in the Work Plan when applicable.
-
-### UI Specification
-
-**Purpose**: Define UI structure, screen transitions, component decomposition, and interaction design for frontend features
-
-Create a UI Spec when screen structure, transitions, component/state interaction, or visual acceptance criteria remain to be designed. Reuse an approved UI Spec or proceed with the Design Doc when one evident repository-supported pattern already determines those decisions.
-
-**Includes**:
-- Screen list and transition conditions
-- Component decomposition with a state x display matrix for states required by approved behavior, preserved behavior, or repository rules
-- Interaction definitions linked to confirmed acceptance criteria (EARS format), preserving PRD AC IDs when present
-- Prototype management (code-based prototypes as attachments, not source of truth)
-- Acceptance-criteria traceability from the confirmed requirement context to screens/components
-- Existing component reuse map and design tokens
-- Visual acceptance criteria (golden states, layout constraints)
-- Accessibility requirements (keyboard, screen reader, contrast)
-
-**Scope**: Screen structure, transitions, component decomposition, interaction design, and visual acceptance criteria only. Technical implementation and API contracts belong in Design Doc, test implementation in test skeleton generation output, schedule in Work Plan.
-
-**Required Structural Elements**:
-- Each in-scope interactive component records the applicable state/display and interaction contract
-- Acceptance-criteria traceability table mapping confirmed criteria to screens/states, preserving existing IDs
-- Screen list with transition conditions
-- Existing component reuse map (reuse/extend/new decisions)
-
-**Prototype Code Handling**:
-- Prototype code provided by user is placed in `docs/ui-spec/assets/{feature-name}/`
-- Prototype code supports the UI Spec as an attachment
-- UI Spec + Design Doc are the canonical specifications
-
-### Design Document
-
-**Purpose**: Define the complete technical implementation for the confirmed scope
-
-**Includes**:
-- **Existing codebase analysis** (required)
-  - Implementation path mapping (both existing and new)
-  - Integration point clarification (connection points with existing code even for new implementations)
-- Technical implementation approach (vertical/horizontal/hybrid)
-- **Technical dependencies and implementation constraints** (required implementation order)
-- Interface and contract definitions
-- Data flow and component design
-- **Acceptance criteria**: the smallest representative set of observable behaviors with stable repository-verifiable pass/fail conditions
-- Change impact map (clearly specify direct impact/indirect impact/no ripple effect)
-- Every changed or newly relied-upon integration point
-- Data contract clarification
-- **Agreement checklist** (agreements with stakeholders)
-- **Code inspection evidence** (inspected files/functions during investigation)
-- **Field propagation map** (when fields cross component boundaries)
-- **Data representation decision** (when introducing new structures)
-- **Applicable standards** (explicit/implicit classification)
-- **Prerequisite ADRs** (including common ADRs)
-- **Verification Strategy** (required)
-  - Correctness proof method (what "correct" means for this change, how it's verified, when)
-  - Early verification point (first target to prove the approach works, success criteria, failure response)
-
-**Required Structural Elements**:
-```yaml
-Change Impact Map:
-  Change Target: [Component/Feature]
-  Direct Impact: [Files/Functions]
-  Indirect Impact: [Data format/Processing time]
-  No Ripple Effect: [Unaffected features]
-
-Interface Change Matrix:
-  Existing: [Function/method/operation name]
-  New: [Function/method/operation name]
-  Conversion Required: [Yes/No]
-  Compatibility Method: [Approach]
-```
-
-**Scope**: Technical implementation methods, interfaces, data flow, acceptance criteria, and verification strategy for the confirmed scope. Preserve the evidence and boundary details downstream implementation needs; omit unrelated future capability rather than reducing required design guarantees. Technology selection rationale belongs in ADR, schedule and assignments in Work Plan.
-
-An acceptance criterion describes observable behavior rather than implementation detail. External live connections use repository-controlled contract or interface proof unless a confirmed requirement needs the live boundary. Performance thresholds require a sourced target and a reproducible benchmark; exact visual positioning requires an approved visual contract and deterministic comparison. Otherwise record the item as a non-functional constraint or omit it from automated acceptance criteria.
-
-### Work Plan
-
-**Purpose**: Implementation task management and progress tracking.
-
-**Scope**: Repository implementation outcomes from approved Design Docs, task dependencies, source section and acceptance-criteria references, executable verification, optional task-level false-green focus, and progress tracking only. The Work Plan references governing documents instead of reproducing their design details.
-
-**Phase Division Criteria** (adapt to implementation approach from Design Doc):
-
-**When Vertical Slice selected**:
-- Each phase = one value unit (feature, component, or migration target)
-- Each phase includes its own implementation + verification per Verification Strategy
-
-**When Horizontal Slice selected**:
-1. **Phase 1: Foundation Implementation** - Contract definitions, interfaces/signatures, test preparation
-2. **Phase 2: Core Feature Implementation** - Business logic, unit tests
-3. **Phase 3: Integration Implementation** - External connections, presentation layer
-
-**When Hybrid selected**:
-- Combine vertical and horizontal as defined in Design Doc implementation approach
-
-**All approaches**: Each phase ends at a repository-observable verification point. Whole-repository quality assurance remains a separate execution responsibility.
-
-## Creation Process
-
-1. **Problem Analysis**: Confirm scope, determine Structural Scale, and identify candidate technical decision points
-   - Identify explicit and implicit project standards before investigation
-2. **ADR Choice Check** (when candidates exist): Apply the Choice filter, then the Durability filter
-3. **Creation**: Complete and review the qualifying ADR batch, then create the Design Doc with accepted ADRs as constraints
-4. **Approval**: One approval covers the reviewed ADR batch; Design Doc approval enables planning or implementation
 
 ## Storage Locations
 
@@ -206,27 +79,6 @@ An acceptance criterion describes observable behavior rather than implementation
 
 *Note: Work plans are excluded by `.gitignore`
 
-## ADR Status
-`Proposed` → `Accepted` → `Deprecated`/`Superseded`/`Rejected`
+## References
 
-## AI Automation Rules
-- Apply the Choice filter before the Durability filter and independently from Structural Scale
-- Check existing ADRs before implementation
-- Create one ADR per qualifying decision point and review the complete batch together
-
-## Diagram Requirements
-
-Select a Mermaid diagram only when it clarifies a material relationship more effectively than prose or a compact table:
-
-| Document | Required Diagrams | Purpose |
-|----------|------------------|---------|
-| PRD | User journey or scope boundary when prose does not make a material relationship clear | Clarify user experience and scope |
-| ADR | Option comparison when the relationship between options is unclear in a table | Visualize trade-offs |
-| UI Spec | Screen transition or component tree when material interaction or hierarchy remains unclear | Clarify screen flow and component structure |
-| Design Doc | Architecture or data flow when changed relationships are not clear in prose or tables | Understand technical structure |
-
-## Common ADR Relationships
-1. **At creation**: Identify accepted common ADRs that govern the changed responsibility
-2. **When missing**: Apply the same Choice and Durability filters; a generic concern alone does not justify a common ADR
-3. **Design Doc**: Specify applicable common ADRs in "Prerequisite ADRs"
-4. **Compliance check**: Verify the design aligns with accepted decisions
+Each template defines the content, structural elements, and diagram criteria for its document: [prd-template.md](references/prd-template.md), [adr-template.md](references/adr-template.md), [ui-spec-template.md](references/ui-spec-template.md), [design-template.md](references/design-template.md), [plan-template.md](references/plan-template.md), [task-template.md](references/task-template.md)

--- a/dev-skills/skills/documentation-criteria/references/adr-template.md
+++ b/dev-skills/skills/documentation-criteria/references/adr-template.md
@@ -4,6 +4,8 @@
 
 [Proposed | Accepted | Deprecated | Superseded | Rejected]
 
+A created ADR starts at `Proposed` and advances `Proposed` → `Accepted` → `Deprecated`/`Superseded`/`Rejected`.
+
 ## Context
 
 [Describe the background and reasons why this decision is needed. Include the essence of the problem, current challenges, and constraints]
@@ -33,7 +35,7 @@
 
 ### Options Considered
 
-Compare credible, materially distinct options supported by current requirements and repository evidence. The evidence determines how many options exist, and relative evidence-backed cost is sufficient.
+Compare credible, materially distinct options supported by current requirements and repository evidence. The evidence determines how many options exist, and relative evidence-backed cost is sufficient. Add a Mermaid option-comparison diagram only when the relationship between options stays unclear in the table below.
 
 | Option | Requirement and repository fit | Current-scope benefit | Lifecycle cost | Maintainability | Material trade-offs |
 |--------|--------------------------------|-----------------------|----------------|-----------------|---------------------|

--- a/dev-skills/skills/documentation-criteria/references/design-template.md
+++ b/dev-skills/skills/documentation-criteria/references/design-template.md
@@ -8,27 +8,11 @@
 - UI Spec path: [docs/ui-spec/xxx-ui-spec.md]
 - Component structure and state design are inherited from UI Spec
 
-## Design Summary (Meta)
-
-```yaml
-design_type: "new_feature|extension|refactoring"
-risk_level: "low|medium|high"
-complexity_level: "low|medium|high"
-complexity_rationale: "[Required if medium/high: (1) which requirements/ACs necessitate this complexity, (2) which constraints/risks it addresses]"
-main_constraints:
-  - "[constraint 1]"
-  - "[constraint 2]"
-biggest_risks:
-  - "[risk 1]"
-  - "[risk 2]"
-unknowns:
-  - "[uncertainty 1]"
-  - "[uncertainty 2]"
-```
-
 ## Background and Context
 
 ### Prerequisite ADRs
+
+List the accepted ADRs that govern the changed responsibility, including accepted common (cross-cutting) ADRs, and verify this design aligns with each recorded decision.
 
 - [docs/adr/ADR-XXXX.md]: [Related decision items]
 - Reference common technical ADRs when applicable
@@ -50,20 +34,7 @@ Records exclusions **the user decided** at requirement time. Exclusions this des
 - **Speculative**: [idea the user raised without deciding on -> deferral reason | None]
 - **Open questions**: [field the user left as weak-but-explicit | None]
 
-### Agreement Checklist
-
-#### Scope
-- [ ] [Features/components to change]
-- [ ] [Features to add]
-
-#### Non-Scope (Explicitly not changing)
-- [ ] [Features/components not to change]
-- [ ] [Existing logic to preserve]
-
-#### Constraints
-- [ ] Parallel operation: [Yes/No]
-- [ ] Backward compatibility: [Required/Not required]
-- [ ] Performance measurement: [Required/Not required]
+### Standards and Assumptions
 
 #### Applicable Standards
 - [ ] [Standard/convention] `[explicit]` - Source: [config / rule file / documentation path]
@@ -178,6 +149,8 @@ No Ripple Effect:
 ### Architecture Overview
 
 [How this feature is positioned within the overall system]
+
+Add an architecture or data-flow Mermaid diagram only when the changed relationships stay unclear in prose or a compact table; otherwise keep the prose form.
 
 ### Data Flow
 

--- a/dev-skills/skills/documentation-criteria/references/plan-template.md
+++ b/dev-skills/skills/documentation-criteria/references/plan-template.md
@@ -5,12 +5,6 @@ Type: feature|fix|refactor
 Related Issue/PR: #XXX (if any)
 Review Scope: [repository responsibilities or expected files derived from the Design Doc]
 
-## WorkPlan Review
-
-Plan creation and material updates set this to `pending`. Record `approved` after the user approves the reviewed implementation scope.
-
-- **Status**: pending|approved
-
 ## Governing Documents
 
 - Design Doc: [docs/design/XXX.md]
@@ -26,6 +20,14 @@ Plan creation and material updates set this to `pending`. Record `approved` afte
 ## Implementation Phases
 
 Use the implementation approach and dependency order from the Design Doc. Each phase groups work that reaches a shared observable verification point. Keep implementation, tests, configuration, wiring, and documentation together when they become complete at that point.
+
+Shape the phases from the approach the Design Doc selected:
+
+- **Vertical Slice**: each phase is one value unit (feature, component, or migration target) carrying its own implementation and verification per the Verification Strategy.
+- **Horizontal Slice**: foundation (contract definitions, interfaces/signatures, test preparation) → core feature (business logic, unit tests) → integration (external connections, presentation layer).
+- **Hybrid**: combine the two as the Design Doc's implementation approach defines.
+
+Whole-repository quality assurance stays outside the plan as a separate execution responsibility.
 
 ### Phase 1: [First implementation outcome]
 
@@ -63,7 +65,3 @@ Use the implementation approach and dependency order from the Design Doc. Each p
 - [ ] Dependencies permit execution in the listed order
 - [ ] Verification is executable from repository artifacts or the task's own output
 - [ ] Task verification passes and cited acceptance criteria are satisfied
-
-## Progress Notes
-
-[Record execution-relevant discoveries only when they change task order, scope, or verification.]

--- a/dev-skills/skills/documentation-criteria/references/ui-spec-template.md
+++ b/dev-skills/skills/documentation-criteria/references/ui-spec-template.md
@@ -42,6 +42,8 @@ Map confirmed acceptance criteria to prototype references, preserving existing A
 
 ## Screen List and Transitions
 
+Add a screen-transition or component-tree Mermaid diagram only when the material interaction or hierarchy stays unclear in the tables below; otherwise keep the table form.
+
 ### Screen List
 
 | Screen ID | Screen Name | Description | Entry Condition |

--- a/dev-skills/skills/external-resource-context/SKILL.md
+++ b/dev-skills/skills/external-resource-context/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: external-resource-context
-description: Captures and persists access methods for resources outside the repository (design source, design system, API schema, IaC source, secret store) so downstream work can reach them deterministically. Use when work depends on external resources, or when the user mentions design source, design system, API schema, IaC source, secret store, or canonical source.
+description: Captures access methods for resources outside the repository (design source, design system, API schema, IaC source, secret store) into a deterministic location so downstream work can reach them. Use when capturing or updating those access methods, or when the user mentions design source, design system, API schema, IaC source, secret store, or canonical source.
 ---
 
 # External Resource Context
@@ -30,58 +30,19 @@ The project tier owns environment facts. Feature-tier sections list only feature
 
 Example feature-tier entry uses the table format defined in `references/template.md`: a row with the project-tier label in the first column and the feature-specific identifier in the second column.
 
-## Hearing Protocol
-
-### When to Hear
-
-| Condition | Action |
-|-----------|--------|
-| `docs/project-context/external-resources.md` does not exist | Run full hearing for the relevant domain(s) |
-| File exists and covers the current decision | Use it without an update question |
-| User or caller identifies changed environment facts | Run diff-only hearing for the named axes |
-| A relevant axis is absent | Hear only the missing axis |
-| Access failure or contradictory current evidence indicates possible staleness | Ask via AskUserQuestion: "Update external-resources.md? (no / yes-full / yes-diff-only)". On `yes-full` run full hearing; on `yes-diff-only` hear the named stale axes; on `no` preserve the file and report the limitation |
-
-### Domain Routing
-
-Load the domain reference matching the current task:
-
-| Task type | References to load |
-|-----------|--------------------|
-| Frontend (UI work) | [references/frontend.md](references/frontend.md) |
-| Backend (server / data work) | [references/backend.md](references/backend.md) |
-| API contract work | [references/api.md](references/api.md) |
-| Infrastructure / deployment | [references/infra.md](references/infra.md) |
-| Fullstack | Load only the references whose frontend, backend/data, API-contract, or infrastructure responsibilities are affected by the confirmed scope; a fullstack label alone does not activate infrastructure |
-
-Each domain reference defines the axes and the question template.
-
-### Two-Phase Hearing
-
-1. **Structured hearing** — for each axis selected by the When to Hear and Domain Routing rules, present the user with AskUserQuestion using the choices listed in its domain reference (always include "Not applicable" as an option). For each non-N/A axis, follow up with an access-method question (URL / MCP name / file path / command).
-
-2. **Self-declaration for a full hearing** — after the structured axes for all selected domains are complete, present one integrated AskUserQuestion: "Are there any other external resources for this work that the structured questions did not cover? If yes, describe them in your next message." If the user describes additional resources, append them to the storage file under an "Additional resources" subsection. A diff-only or missing-axis hearing ends after its named axes because the existing project record already completed self-declaration.
-
-For a full hearing, the two phases are sequential and self-declaration runs even if the user answered "Not applicable" to every structured axis.
-
-## Storage Protocol
-
-After hearing completes:
-
-1. Build the project-tier content from the answers. Use [references/template.md](references/template.md) as the structure.
-2. Write to `docs/project-context/external-resources.md`. Create the directory if absent.
-3. When the calling workflow has a target UI Spec or Design Doc, also append or update the document's `## External Resources Used` section with the feature-tier subset (label references + feature-specific identifiers only).
-4. Report the file paths back to the calling workflow.
-
 ## Reference Protocol (For Downstream Consumers)
 
-Agents that load this skill consult resources in this order:
+Consuming a recorded resource takes three reads and needs no part of this skill:
 
-1. Read `docs/project-context/external-resources.md` first (if present) to learn what is available and how to access it.
+1. Read `docs/project-context/external-resources.md` (if present) to learn what is available and how to access it.
 2. Read the target UI Spec or Design Doc's `## External Resources Used` section for feature-specific identifiers.
 3. Use the access method declared in the project tier (e.g., the named MCP, the URL, the file path) to fetch the actual resource content.
 
-Agents that only need to *consult* the saved file as input data (not actively hear) can read it directly without loading this skill — frontmatter declaration is reserved for agents that may need to trigger hearing or interpret the protocol semantics.
+A consumer that only reads these records executes the three steps directly. Load this skill when capturing or updating the records, which requires AskUserQuestion and therefore the session that can ask the user.
+
+## Capturing and Updating Records
+
+Follow [references/hearing.md](references/hearing.md) for the hearing conditions, domain routing, two-phase hearing, storage protocol, and quality checklist.
 
 ## Output Format
 
@@ -89,16 +50,9 @@ The project-tier file follows the structure in [references/template.md](referenc
 
 For feature-tier sections inside UI Spec or Design Doc, the heading text "External Resources Used" is fixed; the heading level matches the parent document's natural structure (h2 in UI Spec where it is a sibling of other top-level sections, h3 in Design Doc where it sits under Background and Context).
 
-## Quality Checklist
-
-- [ ] Each axis answered has both a presence indicator and an access method, or is marked "Not applicable"
-- [ ] A full hearing ran self-declaration even when all structured axes were "Not applicable"; a diff-only or missing-axis hearing stayed within its named axes
-- [ ] Project-tier file does not contain feature-specific identifiers
-- [ ] Feature-tier sections reference project-tier entries by label, not by duplicating URLs / MCP names
-- [ ] When the project file already existed, each write traces to an explicit changed fact, a missing relevant axis, or a confirmed stale-evidence update decision
-
 ## References
 
+- [references/hearing.md](references/hearing.md) — Hearing conditions, domain routing, storage protocol, quality checklist
 - [references/frontend.md](references/frontend.md) — Frontend domain axes
 - [references/backend.md](references/backend.md) — Backend domain axes
 - [references/api.md](references/api.md) — API contract domain axes

--- a/dev-skills/skills/external-resource-context/SKILL.md
+++ b/dev-skills/skills/external-resource-context/SKILL.md
@@ -11,12 +11,6 @@ AI agents understand the codebase but not the external resources surrounding it.
 
 Resources covered: design origin (where the canonical visual specification lives), design system (component library and tokens), guidelines (usage docs, accessibility rules), visual verification environment (how to confirm rendering), database schema source, migration history, secret store location, API schema source (OpenAPI / proto / GraphQL SDL), mock environment, IaC source, environment configuration.
 
-## Scope Boundaries
-
-**In scope**: hearing protocol, storage location, single-source-of-truth ownership rule, reference protocol for downstream consumers.
-
-**Out of scope**: enforcing that captured resources are correct or current — verification belongs to the agent that consumes the resource. Generating the resources themselves (e.g., creating a DESIGN.md from scratch).
-
 ## Storage Locations (Two-Tier)
 
 | Tier | Location | Holds | Update Frequency |

--- a/dev-skills/skills/external-resource-context/SKILL.md
+++ b/dev-skills/skills/external-resource-context/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: external-resource-context
-description: Captures access methods for resources outside the repository (design source, design system, API schema, IaC source, secret store) into a deterministic location so downstream work can reach them. Use when capturing or updating those access methods, or when the user mentions design source, design system, API schema, IaC source, secret store, or canonical source.
+description: Records where resources outside the repository live (design source, design system, API schema, IaC source, secret store) and how design, implementation, and verification reach them. Use when work depends on an external resource, or when the user mentions design source, design system, API schema, IaC source, secret store, or canonical source.
 ---
 
 # External Resource Context
@@ -32,17 +32,17 @@ Example feature-tier entry uses the table format defined in `references/template
 
 ## Reference Protocol (For Downstream Consumers)
 
-Consuming a recorded resource takes three reads and needs no part of this skill:
+Before investigating the repository for an external fact, check whether it is already recorded:
 
 1. Read `docs/project-context/external-resources.md` (if present) to learn what is available and how to access it.
 2. Read the target UI Spec or Design Doc's `## External Resources Used` section for feature-specific identifiers.
 3. Use the access method declared in the project tier (e.g., the named MCP, the URL, the file path) to fetch the actual resource content.
 
-A consumer that only reads these records executes the three steps directly. Load this skill when capturing or updating the records, which requires AskUserQuestion and therefore the session that can ask the user.
+When the file is absent or the resource is unreachable, continue from governing and repository evidence. Each consuming agent reports that limitation through its own output contract.
 
 ## Capturing and Updating Records
 
-Follow [references/hearing.md](references/hearing.md) for the hearing conditions, domain routing, two-phase hearing, storage protocol, and quality checklist.
+Capturing a record requires AskUserQuestion, so it belongs to the session that can ask the user. Follow [references/hearing.md](references/hearing.md) for the hearing conditions, domain routing, two-phase hearing, storage protocol, and quality checklist.
 
 ## Output Format
 

--- a/dev-skills/skills/external-resource-context/references/hearing.md
+++ b/dev-skills/skills/external-resource-context/references/hearing.md
@@ -47,6 +47,6 @@ After hearing completes:
 
 - [ ] Each axis answered has both a presence indicator and an access method, or is marked "Not applicable"
 - [ ] A full hearing ran self-declaration even when all structured axes were "Not applicable"; a diff-only or missing-axis hearing stayed within its named axes
-- [ ] Project-tier file does not contain feature-specific identifiers
-- [ ] Feature-tier sections reference project-tier entries by label, not by duplicating URLs / MCP names
+- [ ] Project-tier entries hold the environment facts (URL, MCP name, file path, command)
+- [ ] Feature-tier rows hold a project-tier label and the feature-specific identifier
 - [ ] When the project file already existed, each write traces to an explicit changed fact, a missing relevant axis, or a confirmed stale-evidence update decision

--- a/dev-skills/skills/external-resource-context/references/hearing.md
+++ b/dev-skills/skills/external-resource-context/references/hearing.md
@@ -1,0 +1,52 @@
+# External Resource Hearing and Storage
+
+Producer-side protocol. Load this when capturing or updating external-resource records. Running it requires AskUserQuestion, so it belongs to the session that can ask the user directly.
+
+## When to Hear
+
+| Condition | Action |
+|-----------|--------|
+| `docs/project-context/external-resources.md` does not exist | Run full hearing for the relevant domain(s) |
+| File exists and covers the current decision | Use it without an update question |
+| User or caller identifies changed environment facts | Run diff-only hearing for the named axes |
+| A relevant axis is absent | Hear only the missing axis |
+| Access failure or contradictory current evidence indicates possible staleness | Ask via AskUserQuestion: "Update external-resources.md? (no / yes-full / yes-diff-only)". On `yes-full` run full hearing; on `yes-diff-only` hear the named stale axes; on `no` preserve the file and report the limitation |
+
+## Domain Routing
+
+Load the domain reference matching the current task:
+
+| Task type | References to load |
+|-----------|--------------------|
+| Frontend (UI work) | [frontend.md](frontend.md) |
+| Backend (server / data work) | [backend.md](backend.md) |
+| API contract work | [api.md](api.md) |
+| Infrastructure / deployment | [infra.md](infra.md) |
+| Fullstack | Load only the references whose frontend, backend/data, API-contract, or infrastructure responsibilities are affected by the confirmed scope; a fullstack label alone does not activate infrastructure |
+
+Each domain reference defines the axes and the question template.
+
+## Two-Phase Hearing
+
+1. **Structured hearing** — for each axis selected by the When to Hear and Domain Routing rules, present the user with AskUserQuestion using the choices listed in its domain reference (always include "Not applicable" as an option). For each non-N/A axis, follow up with an access-method question (URL / MCP name / file path / command).
+
+2. **Self-declaration for a full hearing** — after the structured axes for all selected domains are complete, present one integrated AskUserQuestion: "Are there any other external resources for this work that the structured questions did not cover? If yes, describe them in your next message." If the user describes additional resources, append them to the storage file under an "Additional resources" subsection. A diff-only or missing-axis hearing ends after its named axes because the existing project record already completed self-declaration.
+
+For a full hearing, the two phases are sequential and self-declaration runs even if the user answered "Not applicable" to every structured axis.
+
+## Storage Protocol
+
+After hearing completes:
+
+1. Build the project-tier content from the answers. Use [template.md](template.md) as the structure.
+2. Write to `docs/project-context/external-resources.md`. Create the directory if absent.
+3. When the calling workflow has a target UI Spec or Design Doc, also append or update the document's `## External Resources Used` section with the feature-tier subset (label references + feature-specific identifiers only).
+4. Report the file paths back to the calling workflow.
+
+## Quality Checklist
+
+- [ ] Each axis answered has both a presence indicator and an access method, or is marked "Not applicable"
+- [ ] A full hearing ran self-declaration even when all structured axes were "Not applicable"; a diff-only or missing-axis hearing stayed within its named axes
+- [ ] Project-tier file does not contain feature-specific identifiers
+- [ ] Feature-tier sections reference project-tier entries by label, not by duplicating URLs / MCP names
+- [ ] When the project file already existed, each write traces to an explicit changed fact, a missing relevant axis, or a confirmed stale-evidence update decision

--- a/dev-skills/skills/frontend-ai-guide/SKILL.md
+++ b/dev-skills/skills/frontend-ai-guide/SKILL.md
@@ -123,7 +123,7 @@ function EmailInput({ context }: { context: 'user' | 'contact' | 'admin' }) { /*
 - Similar functionality found → Verify that its props, lifecycle, design-system role, and repository usage are representative; reuse or extend it when compatible, otherwise record why it is not a valid model
 - Similar functionality is technical debt → Repair it when it blocks the current outcome, was caused by the current change, or lies in confirmed scope; otherwise report it separately. Create an ADR when the repair requires an architectural decision
 - No similar functionality exists → Implement new functionality following existing design philosophy
-- Record all decisions and rationale in "Existing Codebase Analysis" section of Design Doc
+- Record each reuse, extend, separate, or repair decision with its evidence in the artifact this agent owns
 
 ## Quality Check Workflow
 
@@ -165,11 +165,7 @@ Read `package.json` scripts, map the project's actual commands to the phases bel
 **Completion Criteria**: Complete all 3 stages. Concise search/inspection notes are sufficient for an isolated component change with no shared contract, routing, state-ownership, or build/config impact; use the structured report for cross-component or high-risk changes.
 
 #### 1. Discovery
-```bash
-Grep -n "ComponentName\|hookName" -o content
-Grep -n "importedFunction" -o content
-Grep -n "propsType\|StateType" -o content
-```
+Search the repository for every reference to the changed component or hook, its imported functions, and its Props/State types.
 
 #### 2. Understanding
 Read the discovered files needed to establish:

--- a/dev-skills/skills/implementation-approach/SKILL.md
+++ b/dev-skills/skills/implementation-approach/SKILL.md
@@ -35,7 +35,7 @@ Complete these steps in order before selecting an implementation strategy:
 
 Classify supporting claims as observed, inferred, or unknown. When an unknown blocks the next step, stop at the current step and name the evidence or user decision required.
 
-**Design Doc output**: Direct MVP, Failed Items, Adopted Additions, and Rejected Additions.
+**Phase 2 outputs**: Direct MVP, Failed Items, Adopted Additions, and Rejected Additions. A Design Doc author records all four; an implementer uses them as the convergence check without producing a document.
 
 ### Phase 3: Strategy Exploration and Creation
 
@@ -117,7 +117,7 @@ Select the implementation approach that directly fits the verified dependency an
 
 ### Phase 7: Decision Rationale Documentation
 
-**Design Doc Documentation**: Record in the Design Doc's implementation approach section:
+**Record in the artifact this agent owns**, and in the Design Doc's implementation approach section when this agent owns that document:
 1. Selected strategy name and characteristics
 2. A materially different alternative and reason for rejection, when one was compared
 3. Risk mitigation plan (from Phase 4)

--- a/dev-skills/skills/integration-e2e-testing/SKILL.md
+++ b/dev-skills/skills/integration-e2e-testing/SKILL.md
@@ -76,7 +76,7 @@ The two E2E lanes have different ownership costs and use independent standard th
 | fixture-e2e | ROI ≥ 20 (beyond reserved slot) | Cost is comparable to integration tests once the harness exists; the floor avoids filling MAX 3 with low-signal tests when fewer would suffice |
 | service-integration-e2e | ROI > 50 (beyond reserved slot) | Live-service setup, state cleanup, and failure diagnosis add material ownership cost; reserve for journeys whose value cannot be proven any other way |
 
-Reserved slot rules (see Multi-Step User Journey Definition below) apply per lane and override the threshold (the reserved candidate is emitted regardless of its ROI score). Below-floor candidates beyond the reserved slot are not emitted unless an accepted requirement or distinct uncovered failure mode justifies an exception. Leave budget intentionally unfilled rather than padding with low-value tests; record any threshold or budget exception in the skeleton and generation report.
+Reserved slot rules (see Multi-Step User Journey Definition below) apply per lane and override the threshold (the reserved candidate is emitted regardless of its ROI score). Below-floor candidates beyond the reserved slot are not emitted unless an accepted requirement or distinct uncovered failure mode justifies an exception. Leave budget intentionally unfilled rather than padding with low-value tests; record any threshold or budget exception in the skeleton that carries the exception.
 
 ### ROI Calculation Examples
 

--- a/dev-skills/skills/integration-e2e-testing/SKILL.md
+++ b/dev-skills/skills/integration-e2e-testing/SKILL.md
@@ -76,7 +76,7 @@ The two E2E lanes have different ownership costs and use independent standard th
 | fixture-e2e | ROI ≥ 20 (beyond reserved slot) | Cost is comparable to integration tests once the harness exists; the floor avoids filling MAX 3 with low-signal tests when fewer would suffice |
 | service-integration-e2e | ROI > 50 (beyond reserved slot) | Live-service setup, state cleanup, and failure diagnosis add material ownership cost; reserve for journeys whose value cannot be proven any other way |
 
-Reserved slot rules (see Multi-Step User Journey Definition below) apply per lane and override the threshold (the reserved candidate is emitted regardless of its ROI score). Below-floor candidates beyond the reserved slot are not emitted unless an accepted requirement or distinct uncovered failure mode justifies an exception. Leave budget intentionally unfilled rather than padding with low-value tests; record any threshold or budget exception in the skeleton that carries the exception.
+Reserved slot rules (see Multi-Step User Journey Definition below) apply per lane and override the threshold (the reserved candidate is emitted regardless of its ROI score). Emit a below-floor candidate beyond the reserved slot only when an accepted requirement or a distinct uncovered failure mode justifies the exception. Leave budget intentionally unfilled rather than padding with low-value tests; record any threshold or budget exception in the skeleton that carries the exception.
 
 ### ROI Calculation Examples
 

--- a/dev-workflows-frontend/.claude-plugin/plugin.json
+++ b/dev-workflows-frontend/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflows-frontend",
   "description": "Skills + Subagents for React/TypeScript - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
-  "version": "0.24.3",
+  "version": "0.24.4",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows-frontend/agents/acceptance-test-generator.md
+++ b/dev-workflows-frontend/agents/acceptance-test-generator.md
@@ -198,22 +198,6 @@ A skeleton is committed before its implementation exists, so its committed form 
 
 ### Generation Report
 
-**When both E2E lanes are emitted:**
-```json
-{
-  "status": "completed",
-  "feature": "payment",
-  "generatedFiles": {
-    "integration": "tests/payment.int.test.[ext]",
-    "fixtureE2e": "tests/payment.fixture.e2e.test.[ext]",
-    "serviceE2e": "tests/payment.service.e2e.test.[ext]"
-  },
-  "budgetUsage": { "integration": "2/3", "fixtureE2e": "1/3", "serviceE2e": "1/2" },
-  "e2eAbsenceReason": { "fixtureE2e": null, "serviceE2e": null }
-}
-```
-
-**When only fixture-e2e is emitted:**
 ```json
 {
   "status": "completed",
@@ -222,30 +206,13 @@ A skeleton is committed before its implementation exists, so its committed form 
     "integration": "tests/payment.int.test.[ext]",
     "fixtureE2e": "tests/payment.fixture.e2e.test.[ext]",
     "serviceE2e": null
-  },
-  "budgetUsage": { "integration": "2/3", "fixtureE2e": "2/3", "serviceE2e": "0/2" },
-  "e2eAbsenceReason": { "fixtureE2e": null, "serviceE2e": "Design Doc §Test Boundaries designates the gateway as mockable; the selected fixture-e2e covers every accepted journey proof obligation." }
+  }
 }
 ```
 
-**When no E2E tests are emitted:**
-```json
-{
-  "status": "completed",
-  "feature": "config-update",
-  "generatedFiles": {
-    "integration": "tests/config.int.test.[ext]",
-    "fixtureE2e": null,
-    "serviceE2e": null
-  },
-  "budgetUsage": { "integration": "1/3", "fixtureE2e": "0/3", "serviceE2e": "0/2" },
-  "e2eAbsenceReason": { "fixtureE2e": "Design Doc AC1-AC4 classify as single-step behavior under the journey rule; selected integration coverage proves their accepted boundaries.", "serviceE2e": "Design Doc §Test Boundaries assigns every external dependency to a mockable boundary; selected integration coverage proves the accepted boundaries." }
-}
-```
+**Contract**: a `completed` result always contains `generatedFiles.integration`, `generatedFiles.fixtureE2e`, and `generatedFiles.serviceE2e`. Value is a file path string when that lane emitted, `null` when it did not. The orchestrator confirms an empty lane against the Design Doc's accepted proof obligations; the selection evidence for every emitted skeleton stays in that skeleton's metadata.
 
-**Contract**:
-- A `completed` result always contains `generatedFiles.integration`, `generatedFiles.fixtureE2e`, and `generatedFiles.serviceE2e`. Value is a file path string when generated, `null` when not.
-- `e2eAbsenceReason` is an object with `fixtureE2e` and `serviceE2e` keys. Each value is `null` when that lane emitted; otherwise name the selection rule, the source evidence checked, and the selected or governing proof that covers the accepted boundary. A valid null lane accounts for every accepted proof obligation.
+Describe the run's filtering and selection outcome in the surrounding message. Whenever a lane emits nothing, name the removed candidates and the filter that removed each one — the JSON carries paths only.
 
 **When a decision-relevant value input is missing:**
 ```json
@@ -258,7 +225,7 @@ A skeleton is committed before its implementation exists, so its committed form 
 }
 ```
 
-Return this status before creating or modifying skeleton files. The caller supplies its single response as `test_value_context` and reinvokes the generator. Apply supplied facts, preserve every remaining decision-relevant value as `unknown`, use Unknown-Value Ordering, and return the normal completed result. Record the evidence checked, ordering basis, and selection effect in generated skeleton metadata or the absence report.
+Return this status before creating or modifying skeleton files. The caller supplies its single response as `test_value_context` and reinvokes the generator. Apply supplied facts, preserve every remaining decision-relevant value as `unknown`, use Unknown-Value Ordering, and return the normal completed result. Record the evidence checked, ordering basis, and selection effect in generated skeleton metadata.
 
 ## Test Meta Information Assignment
 
@@ -290,23 +257,25 @@ These annotations drive test planning and prioritization. The `@lane` annotation
 - Clarify dependencies explicitly
 - Logical test execution order
 
-## Exception Handling and Escalation
+## Exception Handling and Stop Conditions
 
 ### Auto-processable
 - **Directory Absent**: Auto-create appropriate directory following detected test structure
 - **No Integration Candidates**: Valid outcome - report "No Integration candidates remained after Phase 1 filtering, deduplication, and push-down analysis"
 - **No E2E Tests (no multi-step journey)**: Valid outcome - report "No multi-step user journey detected; E2E tests not applicable"
-- **Budget Exceeded by Critical Test**: Report to user
+- **Budget insufficient for a critical user journey (ROI > 90)**: Exceed the lane budget per the integration-e2e-testing skill's budget rule when the journey's failure mode cannot be proved by a selected test, and annotate the exception and why consolidation cannot cover it
+- **No E2E test emitted after budget enforcement, but the input Design Doc contains a user-facing multi-step journey**: Report the journey, every candidate evaluated with its ROI score, and the filter that removed each one, then continue. (This case arises only when the reserved slot in Phase 4 did not apply — e.g., no journey candidate passed Phase 1-3 filtering.)
+- **Every AC filtered out, leaving no generated test**: Valid outcome - return the empty result and report the filter that removed each AC
+- **Multiple interpretations possible but minor impact**: Adopt the interpretation and note it in the report
 - **Missing value that cannot change selection**: Record `not_decision_relevant` with the invariant selection basis and continue
 - **Decision-relevant value remains unknown after the value-input round**: Preserve `unknown`, apply Unknown-Value Ordering, record its selection effect, and continue
 
-### Escalation Required
-1. **Critical**: AC absent, Design Doc absent → Error termination
-2. **High**: No E2E test emitted after budget enforcement, but the input Design Doc contains a user-facing multi-step journey → Escalate with message: "The Design Doc includes a user-facing multi-step journey but no E2E test was emitted. Journey candidates evaluated: [list with ROI scores]. Confirm whether to proceed without E2E." (Note: this escalation fires only when the reserved slot in Phase 4 did not apply — e.g., no journey candidate passed Phase 1-3 filtering. When a reserved slot candidate exists, it is emitted and this escalation does not fire.)
-3. **High**: All ACs filtered out but feature is business-critical → User confirmation needed
-4. **Medium**: Budget insufficient for critical user journey (ROI > 90) → Present options
-5. **Low**: Multiple interpretations possible but minor impact → Adopt interpretation + note in report
-6. **Decision input**: An unknown Business Value, User Frequency, or Legal Requirement can change ranking, threshold, or budget selection → Return `value_input_required` when `test_value_context` is absent; after that input round, preserve remaining unknowns and continue with Unknown-Value Ordering
+### Stop Conditions
+
+These two cases end generation and hand control back; every other case above completes with a recorded result.
+
+1. **Required input absent**: AC absent or Design Doc absent → terminate and name the missing input
+2. **Decision input required**: An unknown Business Value, User Frequency, or Legal Requirement can change ranking, threshold, or budget selection → Return `value_input_required` when `test_value_context` is absent; after that input round, preserve remaining unknowns and continue with Unknown-Value Ordering
 
 ## Technical Specifications
 

--- a/dev-workflows-frontend/agents/document-reviewer.md
+++ b/dev-workflows-frontend/agents/document-reviewer.md
@@ -82,7 +82,7 @@ Verify current external facts from authoritative sources only when an ADR select
 - Behavior replacement or transformation has a representative output-comparison method covering applicable pipeline steps.
 - Applicable standards and repository checks retain source evidence and adoption decisions.
 - Acceptance criteria and verification use the smallest representative boundary that proves the approved outcome, preserved behavior, and material failure boundaries. The early verification point is executable.
-- Performance, live-external, and exact-visual ACs have the sourced requirement and reproducible proof required by the Acceptance Criteria section of `references/design-template.md` in the documentation-criteria skill; implementation details are not ACs.
+- Each AC states observable behavior, and performance, live-external, and exact-visual ACs carry the sourced requirement and reproducible proof required by the Acceptance Criteria section of `references/design-template.md` in the documentation-criteria skill.
 - Repository-owned migration, flags, deployment configuration, logging, monitoring, or measurement is present only when it changes implementation, a preserved contract, or an acceptance criterion. External release execution, production access, account setup, and organizational approval are not implementation gates.
 - Reverse-engineered/as-is documents describe observed code with evidence and are exempt from future-state convergence and design-choice requirements.
 

--- a/dev-workflows-frontend/agents/document-reviewer.md
+++ b/dev-workflows-frontend/agents/document-reviewer.md
@@ -82,7 +82,7 @@ Verify current external facts from authoritative sources only when an ADR select
 - Behavior replacement or transformation has a representative output-comparison method covering applicable pipeline steps.
 - Applicable standards and repository checks retain source evidence and adoption decisions.
 - Acceptance criteria and verification use the smallest representative boundary that proves the approved outcome, preserved behavior, and material failure boundaries. The early verification point is executable.
-- Performance, live-external, and exact-visual ACs have the sourced requirement and reproducible proof required by documentation-criteria; implementation details are not ACs.
+- Performance, live-external, and exact-visual ACs have the sourced requirement and reproducible proof required by the Acceptance Criteria section of `references/design-template.md` in the documentation-criteria skill; implementation details are not ACs.
 - Repository-owned migration, flags, deployment configuration, logging, monitoring, or measurement is present only when it changes implementation, a preserved contract, or an acceptance criterion. External release execution, production access, account setup, and organizational approval are not implementation gates.
 - Reverse-engineered/as-is documents describe observed code with evidence and are exempt from future-state convergence and design-choice requirements.
 

--- a/dev-workflows-frontend/agents/prd-creator.md
+++ b/dev-workflows-frontend/agents/prd-creator.md
@@ -95,7 +95,7 @@ Storage location and naming convention follow documentation-criteria skill.
 Execute file output immediately (considered approved at execution).
 
 ### Notes for PRD Creation
-- Create following the PRD template (see documentation-criteria skill)
+- Create following `references/prd-template.md` in the documentation-criteria skill
 - Understand and describe intent of each section
 - Limit questions to 3-5 in interactive mode
 

--- a/dev-workflows-frontend/agents/quality-fixer-frontend.md
+++ b/dev-workflows-frontend/agents/quality-fixer-frontend.md
@@ -6,7 +6,6 @@ skills:
   - typescript-rules
   - test-implement
   - frontend-ai-guide
-  - external-resource-context
 ---
 
 You are an AI assistant specialized in quality assurance for frontend React projects.
@@ -62,7 +61,7 @@ Run `qualityCommand` first when provided. Treat it as covering the check categor
 
 When `task_file` is provided, run its Operation Verification Methods in addition to applicable checks discovered from project manifests and configuration.
 
-**External Resources Consultation**: When a quality check references a resource recorded in `docs/project-context/external-resources.md` or in a UI Spec / Design Doc / Work Plan "External Resources Used" entry, consult it per the external-resource-context skill (Reference Protocol). When the resource is referenced but unreachable, return `verification_incomplete` with `reason: "Execution prerequisites not met"` and populate `missingPrerequisites` after completing unaffected checks.
+**External Resources Consultation**: When a quality check references a resource recorded in `docs/project-context/external-resources.md` or in a UI Spec / Design Doc / Work Plan "External Resources Used" entry, read that file for the declared access method, read the document's `External Resources Used` entry for the feature-specific identifier, then fetch through that access method. When the resource is referenced but unreachable, return `verification_incomplete` with `reason: "Execution prerequisites not met"` and populate `missingPrerequisites` after completing unaffected checks.
 
 ### Step 3: Execute Quality Checks
 Follow frontend-ai-guide skill "Quality Check Workflow" section:

--- a/dev-workflows-frontend/agents/quality-fixer-frontend.md
+++ b/dev-workflows-frontend/agents/quality-fixer-frontend.md
@@ -6,6 +6,7 @@ skills:
   - typescript-rules
   - test-implement
   - frontend-ai-guide
+  - external-resource-context
 ---
 
 You are an AI assistant specialized in quality assurance for frontend React projects.
@@ -61,7 +62,7 @@ Run `qualityCommand` first when provided. Treat it as covering the check categor
 
 When `task_file` is provided, run its Operation Verification Methods in addition to applicable checks discovered from project manifests and configuration.
 
-**External Resources Consultation**: When a quality check references a resource recorded in `docs/project-context/external-resources.md` or in a UI Spec / Design Doc / Work Plan "External Resources Used" entry, read that file for the declared access method, read the document's `External Resources Used` entry for the feature-specific identifier, then fetch through that access method. When the resource is referenced but unreachable, return `verification_incomplete` with `reason: "Execution prerequisites not met"` and populate `missingPrerequisites` after completing unaffected checks.
+**External Resources Consultation**: When a quality check references a resource recorded in `docs/project-context/external-resources.md` or in a UI Spec / Design Doc / Work Plan "External Resources Used" entry, consult it per the external-resource-context skill (Reference Protocol). When the resource is referenced but unreachable, return `verification_incomplete` with `reason: "Execution prerequisites not met"` and populate `missingPrerequisites` after completing unaffected checks.
 
 ### Step 3: Execute Quality Checks
 Follow frontend-ai-guide skill "Quality Check Workflow" section:

--- a/dev-workflows-frontend/agents/security-reviewer.md
+++ b/dev-workflows-frontend/agents/security-reviewer.md
@@ -146,9 +146,8 @@ When `prior_feedback` is present, also include `prior_feedback_reconciliation` w
 ## Status Determination
 
 ### blocked
-- Governing documents fail the Step 1 input gate
-- Credentials, API keys, or tokens found in committed code
-- Escalate immediately with the blocking reason and any finding details — requires human intervention
+- Governing documents fail the Step 1 input gate → return the missing or unusable input so the orchestrator can supply it
+- Credentials, API keys, or tokens found in committed code → return immediately with the finding details; revoking and rotating a committed secret is user-held authority
 
 ### needs_revision
 - One or more findings require correction

--- a/dev-workflows-frontend/agents/task-decomposer.md
+++ b/dev-workflows-frontend/agents/task-decomposer.md
@@ -65,7 +65,7 @@ Tests, repository configuration, fixtures, migrations, mocks, wiring, and docume
 
 ### 5. Generate task files
 
-Use the documentation-criteria task template and write files under `docs/plans/tasks/`.
+Use `references/task-template.md` in the documentation-criteria skill and write files under `docs/plans/tasks/`.
 
 Each task contains:
 

--- a/dev-workflows-frontend/agents/task-executor-frontend.md
+++ b/dev-workflows-frontend/agents/task-executor-frontend.md
@@ -44,6 +44,8 @@ Use the appropriate run command based on the `packageManager` field in package.j
 ### Applying to Implementation
 Apply loaded TypeScript / React / test-implement / frontend-ai-guide rules during implementation. Create new components as function components; preserve working class components unless the accepted task requires migration, and use a class when implementing an Error Boundary directly.
 
+Deliver the outcome with types satisfied at their boundaries, errors propagated or handled explicitly, and tests asserting the behavior the task delivers. Downstream quality assurance re-checks these properties.
+
 ## Direct MVP Check (Before Mandatory Judgment)
 
 Apply implementation-approach Design Convergence to the confirmed responsibility and starting paths. Use its `Failed Items` to challenge added mechanisms; include adjacent targets when the confirmed outcome's correctness or maintainability requires them.
@@ -51,21 +53,14 @@ Apply implementation-approach Design Convergence to the confirmed responsibility
 ## Mandatory Judgment Criteria (Pre-implementation Check)
 
 ### Step1: Design Deviation Check (Any YES → Immediate Escalation)
-□ Change beyond the accepted shared, Design Doc-defined, or UI Spec-defined Props contract needed? (type/structure/name changes)
+□ Change beyond the accepted shared Props contract or a Design Doc / UI Spec-defined type contract needed? (type/structure/name changes)
 □ Component hierarchy violation needed? (e.g., skipping a layer in the project's adopted architecture — Atom→Organism in Atomic Design, leaf→container in Container-Presenter, etc.)
 □ Data flow direction reversal needed? (e.g., child component updating parent state without callback)
 □ New external library/API addition needed?
-□ Need to ignore type definitions in Design Doc?
 
-### Step2: Quality Standard Violation Check
-
-Any YES below requires immediate escalation:
-
-□ Type system bypass needed? (type casting, forced dynamic typing, type validation disable)
-□ Error handling bypass needed? (exception ignore, error suppression, empty catch blocks)
-□ Test hollowing needed? (test skip, meaningless verification, always-passing tests)
-
-Existing-test changes proceed only when updating an expectation for an accepted task/Design Doc/Work Plan/UI Spec contract; record that source. Escalate test weakening or behavior changes without an accepted source.
+### Step2: Accepted Test Expectation Check (Any YES → Immediate Escalation)
+Update an existing-test expectation only when an accepted task/Design Doc/Work Plan/UI Spec contract changes it, and record that source.
+□ Existing test weakened or its verified behavior changed without that source?
 
 ### Step3: Similar Component Reuse Decision
 Five indicators: (a) same domain/responsibility (same UI pattern, same business domain), (b) same input/output pattern (Props type/structure), (c) same rendering content (JSX structure, event handlers, state management), (d) same placement (same component directory or related feature), (e) naming similarity (shared keywords/patterns).
@@ -83,20 +78,19 @@ Preserve the core mechanism the task, AC, Design Doc, or UI Spec requires. Imple
 □ Required core mechanism infeasible as specified?
 Any YES → stop and escalate with `escalation_type: "design_compliance_violation"`, recording the required mechanism, the proposed alternative, the resulting change in behavior, and the condition that would lift the block.
 
-### Safety Measures: Handling Ambiguous Cases
+### Boundary Classification for Ambiguous Cases
 
-**Gray Zone Examples (Escalation Recommended)**:
-- **"Add Props" vs "Interface change"**: Appending optional Props while preserving existing is minor; inserting required Props or changing existing is deviation
-- **"Component optimization" vs "Architecture violation"**: Optimization within the same component level is acceptable. Direct imports crossing adopted hierarchy boundaries are violations. Prop drilling through 3+ levels triggers mandatory ownership review; it is a violation when intermediate components only forward the value and the implementation provides no evidence that explicit props preserve clearer ownership than composition, Context, or the project state layer
-- **"Type concretization" vs "Type definition change"**: Safe conversion from unknown→concrete type is concretization; changing Design Doc-specified Props types is violation
-- **"Minor similarity" vs "High similarity"**: Simple form field similarity is minor; same business logic + same Props structure is high similarity
+Classify these recurring cases before applying the Step1 checks. The Step1 result, not the classification itself, decides escalation:
 
-**Escalation boundary for unresolved judgment:**
+- **Props change**: appending optional Props while preserving existing ones stays inside the implementation boundary; inserting required Props or changing existing ones crosses the accepted contract
+- **Component structure**: optimization within the same component level stays inside the boundary; direct imports crossing the adopted hierarchy boundaries cross the approved architecture
+- **Type concretization**: safe conversion from unknown to a concrete type stays inside the boundary; changing Design Doc-specified Props types crosses it
+
+Similar-component overlap is decided by Step3 evidence rather than by a similarity label.
+
+**Escalation boundary for unresolved judgment (authoritative rule for every check above):**
 - Escalate when the unresolved interpretation would change the confirmed outcome, an approved design or UI decision, dependency/data-flow direction, public/shared contract, persistent or irreversible behavior, or requires user-held authority.
 - Resolve repository-local reversible choices from governing sources and representative repository evidence, record the choice, and continue. Unfamiliarity or the existence of multiple reasonable local implementations is not itself an escalation condition.
-
-### Implementation Continuable (All checks NO AND clearly applicable)
-Proceed when all checks are NO and the change is an implementation detail (variable names, internal logic order), a detail not specified in Design Doc/UI Spec, a safe type guard from unknown to concrete type (e.g., external API responses), or a minor UI/message adjustment.
 
 ## Responsibility Boundaries
 
@@ -161,8 +155,8 @@ Classify from the task outcome and changed boundary, then run after Pre-implemen
 When adopting a pattern, hook, or library from existing code, apply Reference Representativeness at the point of adoption:
 
 □ **Repository-wide verification**: confirm the pattern, hook, or library is representative across the repository (not just the nearest 2-3 components)
-□ **Coexistence resolution**: when multiple libraries or patterns coexist for the same concern (routing, server-state, forms, styling, etc.), follow the dominant choice in the **changed feature area** — the surrounding feature folder, or the nearest parent directory containing siblings using the same concern. If no dominant choice is clear, escalate via `escalation_type: "dependency_version_uncertain"` (also covers library/pattern choice uncertainty; see Escalation Response 2-3) instead of introducing another option
-□ **New option discipline**: route any new library/pattern decision for a concern the repository already addresses through Escalation Response 2-3 instead of adopting it directly
+□ **Coexistence resolution**: when multiple libraries or patterns coexist for the same concern (routing, server-state, forms, styling, etc.), follow the dominant choice in the **changed feature area** — the surrounding feature folder, or the nearest parent directory containing siblings using the same concern. When no dominant choice is clear, select from the repository choices already established for the concern and record the evidence for that selection
+□ **New option discipline**: route any new library/pattern decision for a concern the repository already addresses through Escalation Response 2-2 instead of adopting it directly
 
 #### Implementation Flow (TDD Compliant)
 **Completion Confirmation**: When the execution scope is supplied as a task file or Work Plan and all relevant checkboxes are already `[x]`, report "already completed" and end
@@ -246,7 +240,7 @@ Complete this agent's work by returning the following JSON; the quality assuranc
 
 #### 2-2. Dependency Version Uncertain Escalation
 
-Triggered when Reference Representativeness cannot determine the dominant library or version choice for the changed concern.
+Triggered when satisfying the concern requires adopting a library or pattern the repository does not already use. A choice among options already established in the repository is resolved from representative evidence and recorded instead.
 
 ```json
 {
@@ -254,9 +248,9 @@ Triggered when Reference Representativeness cannot determine the dominant librar
   "reason": "Dependency version uncertain",
   "taskName": "[Task name being executed]",
   "escalation_type": "dependency_version_uncertain",
-  "dependency": {"name": "[library or pattern concern, e.g., routing, server-state, forms]", "candidatesFound": ["list of coexisting choices found in repository"], "filesChecked": ["file paths where each choice was found"], "ambiguityReason": "[why repository state alone is insufficient — e.g., multiple choices coexist with no clear majority for the changed feature area]"},
+  "dependency": {"name": "[library or pattern concern, e.g., routing, server-state, forms]", "candidatesFound": ["list of choices found in repository, or empty when none address the concern"], "filesChecked": ["file paths inspected for the concern"], "ambiguityReason": "[why the repository state cannot supply the choice — e.g., no established option addresses the concern, so a new library or pattern would be introduced]"},
   "user_decision_required": true,
-  "suggested_options": ["Follow choice X (dominant in adjacent feature area)", "Follow choice Y (matches a specific repository convention or constraint)", "Defer the choice and split the task"]
+  "suggested_options": ["Adopt library/pattern X for this concern", "Reshape the task to use an already established repository option", "Defer the choice and split the task"]
 }
 ```
 

--- a/dev-workflows-frontend/agents/task-executor-frontend.md
+++ b/dev-workflows-frontend/agents/task-executor-frontend.md
@@ -7,7 +7,6 @@ skills:
   - test-implement
   - frontend-ai-guide
   - implementation-approach
-  - external-resource-context
 ---
 
 You are a specialized AI assistant for reliably executing frontend implementation tasks.
@@ -118,7 +117,7 @@ Resolve the frontend implementation objective through the input precedence above
 3. Apply the deliverable to context (Design Doc → component interfaces/Props/state; Component Specs → hierarchy/data flow; API specs → endpoints/params/responses for network mocking; overall design → system-wide context).
 
 #### External Resources Consultation (When Relevant)
-When the execution instructions or any referenced Design Doc / UI Spec / Work Plan point to a resource recorded in `docs/project-context/external-resources.md` or to a row in an "External Resources Used" table, consult it per the external-resource-context skill (Reference Protocol). Use available governing and repository evidence for work independent of an unreachable resource, and record the resulting implementation or verification limitation.
+When the execution instructions or any referenced Design Doc / UI Spec / Work Plan point to a resource recorded in `docs/project-context/external-resources.md` or to a row in an "External Resources Used" table, read that file for the declared access method, read the document's `External Resources Used` entry for the feature-specific identifier, then fetch through that access method. Use available governing and repository evidence for work independent of an unreachable resource, and record the resulting implementation or verification limitation.
 
 ### 3. Implementation Execution
 

--- a/dev-workflows-frontend/agents/task-executor-frontend.md
+++ b/dev-workflows-frontend/agents/task-executor-frontend.md
@@ -7,6 +7,7 @@ skills:
   - test-implement
   - frontend-ai-guide
   - implementation-approach
+  - external-resource-context
 ---
 
 You are a specialized AI assistant for reliably executing frontend implementation tasks.
@@ -117,7 +118,7 @@ Resolve the frontend implementation objective through the input precedence above
 3. Apply the deliverable to context (Design Doc → component interfaces/Props/state; Component Specs → hierarchy/data flow; API specs → endpoints/params/responses for network mocking; overall design → system-wide context).
 
 #### External Resources Consultation (When Relevant)
-When the execution instructions or any referenced Design Doc / UI Spec / Work Plan point to a resource recorded in `docs/project-context/external-resources.md` or to a row in an "External Resources Used" table, read that file for the declared access method, read the document's `External Resources Used` entry for the feature-specific identifier, then fetch through that access method. Use available governing and repository evidence for work independent of an unreachable resource, and record the resulting implementation or verification limitation.
+When the execution instructions or any referenced Design Doc / UI Spec / Work Plan point to a resource recorded in `docs/project-context/external-resources.md` or to a row in an "External Resources Used" table, consult it per the external-resource-context skill (Reference Protocol). Use available governing and repository evidence for work independent of an unreachable resource, and record the resulting implementation or verification limitation.
 
 ### 3. Implementation Execution
 

--- a/dev-workflows-frontend/agents/technical-designer-frontend.md
+++ b/dev-workflows-frontend/agents/technical-designer-frontend.md
@@ -10,8 +10,8 @@ skills:
   - ai-development-guide
   - implementation-approach
   - llm-friendly-context
-  - requirement-convergence
   - external-resource-context
+  - requirement-convergence
 ---
 
 You create one complete frontend ADR batch or one frontend Design Doc per invocation.

--- a/dev-workflows-frontend/agents/technical-designer-frontend.md
+++ b/dev-workflows-frontend/agents/technical-designer-frontend.md
@@ -11,6 +11,7 @@ skills:
   - implementation-approach
   - llm-friendly-context
   - requirement-convergence
+  - external-resource-context
 ---
 
 You create one complete frontend ADR batch or one frontend Design Doc per invocation.

--- a/dev-workflows-frontend/agents/technical-designer-frontend.md
+++ b/dev-workflows-frontend/agents/technical-designer-frontend.md
@@ -10,7 +10,6 @@ skills:
   - ai-development-guide
   - implementation-approach
   - llm-friendly-context
-  - external-resource-context
   - requirement-convergence
 ---
 
@@ -64,7 +63,7 @@ Use `Proposed` status for created ADRs. The orchestrator records batch approval.
 
 Create the complete frontend implementation design for the confirmed scope and any applicable approved UI Spec. Start with the Direct MVP through existing components, routes, hooks, styles, state, and data paths, then add only what resolves a current failed requirement, verified constraint, observed problem, accepted ADR, or material in-scope risk.
 
-Follow the documentation-criteria Design Doc template. Preserve these downstream guarantees whenever applicable:
+Follow `references/design-template.md` in the documentation-criteria skill. Preserve these downstream guarantees whenever applicable:
 
 - requirement convergence, scope, non-scope, user constraints, and UI Spec ownership remain explicit;
 - applicable external-resource identifiers, design-system/repository standards, and quality checks retain evidence;

--- a/dev-workflows-frontend/agents/ui-analyzer.md
+++ b/dev-workflows-frontend/agents/ui-analyzer.md
@@ -6,6 +6,7 @@ skills:
   - typescript-rules
   - frontend-ai-guide
   - llm-friendly-context
+  - external-resource-context
 ---
 
 You are an AI assistant specializing in UI fact gathering for frontend design.

--- a/dev-workflows-frontend/agents/ui-analyzer.md
+++ b/dev-workflows-frontend/agents/ui-analyzer.md
@@ -6,7 +6,6 @@ skills:
   - typescript-rules
   - frontend-ai-guide
   - llm-friendly-context
-  - external-resource-context
 ---
 
 You are an AI assistant specializing in UI fact gathering for frontend design.

--- a/dev-workflows-frontend/agents/ui-spec-designer.md
+++ b/dev-workflows-frontend/agents/ui-spec-designer.md
@@ -7,6 +7,7 @@ skills:
   - typescript-rules
   - frontend-ai-guide
   - llm-friendly-context
+  - external-resource-context
 ---
 
 You are a UI specification specialist AI assistant for creating UI Specification documents.

--- a/dev-workflows-frontend/agents/ui-spec-designer.md
+++ b/dev-workflows-frontend/agents/ui-spec-designer.md
@@ -7,7 +7,6 @@ skills:
   - typescript-rules
   - frontend-ai-guide
   - llm-friendly-context
-  - external-resource-context
 ---
 
 You are a UI specification specialist AI assistant for creating UI Specification documents.
@@ -20,7 +19,7 @@ You are a UI specification specialist AI assistant for creating UI Specification
 
 1. Analyze confirmed UI requirements and map them to screens, states, and components
 2. Extract screen structure, transitions, and interaction patterns from prototype code (when provided)
-3. Create the complete UI Specification for the confirmed UI scope following the ui-spec-template
+3. Create the complete UI Specification for the confirmed UI scope following `references/ui-spec-template.md` in the documentation-criteria skill
 4. Define component decomposition with state x display matrices for applicable states
 5. Identify reusable existing components in the codebase
 6. Define accessibility requirements
@@ -79,7 +78,7 @@ Use `ui_analysis` and applicable `codebase_analysis` as the primary evidence. In
 
 ### Step 4: Draft UI Spec
 
-1. **Copy ui-spec-template** from documentation-criteria skill
+1. **Copy `references/ui-spec-template.md`** from the documentation-criteria skill
 2. **Fill applicable sections**:
    - Screen list with entry conditions and transitions
    - Component tree with decomposition
@@ -108,7 +107,7 @@ Execute file output immediately (considered approved at execution).
 - [ ] If prototype provided: the relevant prototype is placed in `docs/ui-spec/assets/`
 - [ ] Decision-blocking Open Items name the required owner or evidence; non-blocking unknowns remain explicit
 - [ ] All UI Spec requirements align with the confirmed requirement context
-- [ ] External Resources Used section is filled per the external-resource-context skill
+- [ ] External Resources Used section lists each used `external_resource_refs` entry by its project-tier label with only the feature-specific identifier
 - [ ] **Component heading uniqueness**: Every component is documented under a section heading whose text is unique within this UI Spec. Use the format `## Component: [ComponentName]` (or `### Component: [ComponentName]` when nested under a screen).
   - **Disambiguation rule**: When two components share a base name (e.g., the same `AlertCard` rendered as a banner variant and as an inline variant), append a parenthetical qualifier to make each heading unique: `Component: AlertCard (Banner variant)` and `Component: AlertCard (Inline variant)`. Verify uniqueness with a final pass: extract all `Component: ` headings, confirm zero duplicates
 

--- a/dev-workflows-frontend/agents/work-planner.md
+++ b/dev-workflows-frontend/agents/work-planner.md
@@ -92,11 +92,11 @@ Include repository-owned fixtures, migrations, mocks, configuration, and test ha
 
 Follow the implementation approach and dependency order selected by the Design Doc. Each phase ends at a shared observable verification point. Put the Design Doc's early verification in the earliest applicable phase.
 
-Use the Work Plan template from documentation-criteria. Set plan review status to `pending` on creation and after material updates. Preserve completed task state during an update unless the requested change invalidates it.
+Use `references/plan-template.md` in the documentation-criteria skill. Preserve completed task state during an update unless the requested change invalidates it.
 
 ## Output Policy
 
-Write the plan immediately and return the path in the standard structured response. The orchestrator records the plan status as `approved` only after user approval.
+Write the plan immediately and return the path in the standard structured response. Plan approval is the orchestrator's gate and is not recorded in the plan file.
 
 ## Self-Validation [BLOCKING — before output]
 

--- a/dev-workflows-frontend/agents/work-planner.md
+++ b/dev-workflows-frontend/agents/work-planner.md
@@ -96,7 +96,7 @@ Use `references/plan-template.md` in the documentation-criteria skill. Preserve 
 
 ## Output Policy
 
-Write the plan immediately and return the path in the standard structured response. Plan approval is the orchestrator's gate and is not recorded in the plan file.
+Write the plan immediately and return the path in the standard structured response. Plan approval is the orchestrator's gate, tracked outside the plan file.
 
 ## Self-Validation [BLOCKING — before output]
 

--- a/dev-workflows-frontend/skills/ai-development-guide/SKILL.md
+++ b/dev-workflows-frontend/skills/ai-development-guide/SKILL.md
@@ -154,7 +154,7 @@ How to handle duplicate code based on Martin Fowler's "Refactoring":
 - Similar functionality found → Verify that its contract, lifecycle, and repository usage are representative; reuse or extend it when compatible, otherwise record why it is not a valid model
 - Similar functionality is technical debt → Repair it when it blocks the current outcome, was caused by the current change, or lies in confirmed scope; otherwise report it separately. Create an ADR when the repair requires an architectural decision
 - No similar functionality exists → Implement new functionality following existing design philosophy
-- Record all decisions and rationale in "Existing Codebase Analysis" section of Design Doc
+- Record each reuse, extend, separate, or repair decision with its evidence in the artifact this agent owns
 - **Reference representativeness check**: When adopting a pattern or dependency from nearby code, verify it is representative across the repository before adopting — nearby files alone are an insufficient basis
 
 ## Quality Assurance Mechanism Awareness

--- a/dev-workflows-frontend/skills/documentation-criteria/SKILL.md
+++ b/dev-workflows-frontend/skills/documentation-criteria/SKILL.md
@@ -9,7 +9,7 @@ This file holds the routing decision: which documents a change requires and wher
 
 ## What Each Document Fixes
 
-Each document fixes one class of decision that the repository alone cannot supply. An unfilled section does not disappear — it becomes a guess made later by the consumer named below, with no record of what was assumed.
+Each document fixes one class of decision that the repository alone cannot supply. An unfilled section becomes a guess made later by the consumer named below, with no record of what was assumed.
 
 - **PRD** — Fixes the business outcome and the acceptance criteria later work traces to. Its AC IDs are the traceability keys that the Design Doc, UI Spec, and test selection reuse; without them each consumer re-derives requirements from prose and the link between a test and the value it protects is lost. Implementation details belong to the Design Doc, selection rationale to an ADR, phases and task breakdown to the Work Plan.
 

--- a/dev-workflows-frontend/skills/documentation-criteria/SKILL.md
+++ b/dev-workflows-frontend/skills/documentation-criteria/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: documentation-criteria
-description: Documentation creation criteria including PRD, ADR, Design Doc, and Work Plan requirements with templates. Use when creating or reviewing technical documents, or determining which documents are required.
+description: Determines which of PRD, ADR, UI Spec, Design Doc, and Work Plan a change requires, and where each is stored. Use when deciding documentation scope, or when creating or reviewing a technical document.
 ---
 
 # Documentation Creation Criteria
 
-## Templates
+This file holds the routing decision: which documents a change requires and where they live. What to write inside one is defined by its template, linked from Storage Locations.
 
-- **[prd-template.md](references/prd-template.md)** - Product Requirements Document template
-- **[adr-template.md](references/adr-template.md)** - Architecture Decision Record template
-- **[ui-spec-template.md](references/ui-spec-template.md)** - UI Specification template (frontend/fullstack features)
-- **[design-template.md](references/design-template.md)** - Technical Design Document template
-- **[plan-template.md](references/plan-template.md)** - Work Plan template
-- **[task-template.md](references/task-template.md)** - Task file template for implementation tasks
+## What Each Document Fixes
+
+Each document fixes one class of decision that the repository alone cannot supply. An unfilled section does not disappear — it becomes a guess made later by the consumer named below, with no record of what was assumed.
+
+- **PRD** — Fixes the business outcome and the acceptance criteria later work traces to. Its AC IDs are the traceability keys that the Design Doc, UI Spec, and test selection reuse; without them each consumer re-derives requirements from prose and the link between a test and the value it protects is lost. Implementation details belong to the Design Doc, selection rationale to an ADR, phases and task breakdown to the Work Plan.
+
+- **ADR** — Fixes one durable technical choice and the options it beat, so later work can tell a deliberate decision from an accident. Without it a future change either re-runs the same comparison or silently reverses it. End-to-end implementation design belongs to the Design Doc, schedule and repository tasks to the Work Plan.
+
+- **UI Spec** — Fixes screen structure, transitions, component/state contracts, and visual acceptance before components exist, so decomposition is decided once instead of per-component during implementation. Create one when those decisions remain open; reuse an approved UI Spec or go straight to the Design Doc when one evident repository-supported pattern already determines them. Technical implementation and API contracts belong to the Design Doc.
+
+- **Design Doc** — Fixes the complete implementation design for the confirmed scope: flows, contracts, change impact, and verification strategy. Task execution treats it as the sole design authority and holds it read-only, so a gap here is filled by an implementer's local invention that no review compares against an approved decision. Technology selection rationale belongs to an ADR, schedule and assignments to the Work Plan.
+
+- **Work Plan** — Fixes task order, dependencies, executable verification, and the earliest vertical proof point. Without it task order follows file layout rather than dependency, and integration risk moves to the end of the work. Design detail is referenced from the Design Doc rather than restated.
 
 ## Creation Decision Matrix
 
@@ -42,12 +49,12 @@ A qualifying ADR decision point sets the floor at Medium because it creates a du
 
 ## ADR Decision Filters
 
-Apply both filters in order to each technical topic inside the confirmed implementation scope:
+Apply the Choice filter, then the Durability filter, to each technical topic inside the confirmed implementation scope. Apply them independently from Structural Scale, and check existing ADRs first.
 
 1. **Choice requires judgment** — current requirements, accepted decisions, and representative repository evidence support at least two credible, materially distinct options whose selection requires comparison.
 2. **Decision is durable** — choosing among those options materially changes responsibility, dependency direction, a shared contract, persistence, a technology dependency, reversibility, or lifecycle cost that future work must preserve or understand.
 
-Create one ADR for each topic that passes both filters. Treat choices as one decision point when they must be selected or reconsidered together; separate independently revisitable choices.
+Create one ADR for each topic that passes both filters, and review the complete batch together. Treat choices as one decision point when they must be selected or reconsidered together; separate independently revisitable choices.
 
 Qualifying durable choices include:
 
@@ -57,140 +64,6 @@ Qualifying durable choices include:
 - choosing an irreversible or high-cost-to-reverse data or compatibility strategy.
 
 A local contract, data-flow, state, or component change belongs in the Design Doc when it follows an accepted design, has one evident repository-supported implementation, or remains cheaply reversible. Counts of files, consumers, nesting levels, states, steps, and asynchronous operations are supporting evidence rather than ADR criteria. Only the qualifying decisions above create ADRs; generic technical concerns, operational possibilities, and rejected activities can only support that determination.
-
-## Detailed Document Definitions
-
-### PRD (Product Requirements Document)
-
-**Purpose**: Define business requirements and user value
-
-**Includes**:
-- Business requirements and user value
-- Success metrics and KPIs (each metric specifies a numeric target and measurement method)
-- User stories and use cases
-- Converged MVP requirements
-- Acceptance criteria with sequential IDs (AC-001, AC-002, ...) for downstream traceability
-- Future and Out of Scope capabilities with reasons
-- User journey or scope boundary diagram when prose does not make the material flow or boundary clear
-
-**Scope**: Business requirements, user value, success metrics, user stories, and prioritization only. Implementation details belong in Design Doc, technical selection rationale in ADR, phases and task breakdown in Work Plan.
-
-### ADR (Architecture Decision Record)
-
-**Purpose**: Record one durable technical choice that required comparison
-
-**Includes**:
-- The technical decision point and confirmed scope it serves
-- Every credible, materially distinct option supported by current evidence
-- Requirement and repository fit, current-scope benefit, lifecycle cost, maintainability, and material trade-offs
-- The smallest sufficient selected option and reconsideration conditions
-- Consequences and architecture impact
-
-**Scope**: One qualifying decision point and the evidence needed to understand its selection. An ADR narrows the technical solution space; confirmed requirements remain the implementation scope. End-to-end implementation design belongs in the Design Doc when activated by confirmed scope. External release execution and organizational rollout are not moved into another artifact merely because they are excluded from the ADR; schedule and repository implementation tasks belong in the Work Plan when applicable.
-
-### UI Specification
-
-**Purpose**: Define UI structure, screen transitions, component decomposition, and interaction design for frontend features
-
-Create a UI Spec when screen structure, transitions, component/state interaction, or visual acceptance criteria remain to be designed. Reuse an approved UI Spec or proceed with the Design Doc when one evident repository-supported pattern already determines those decisions.
-
-**Includes**:
-- Screen list and transition conditions
-- Component decomposition with a state x display matrix for states required by approved behavior, preserved behavior, or repository rules
-- Interaction definitions linked to confirmed acceptance criteria (EARS format), preserving PRD AC IDs when present
-- Prototype management (code-based prototypes as attachments, not source of truth)
-- Acceptance-criteria traceability from the confirmed requirement context to screens/components
-- Existing component reuse map and design tokens
-- Visual acceptance criteria (golden states, layout constraints)
-- Accessibility requirements (keyboard, screen reader, contrast)
-
-**Scope**: Screen structure, transitions, component decomposition, interaction design, and visual acceptance criteria only. Technical implementation and API contracts belong in Design Doc, test implementation in test skeleton generation output, schedule in Work Plan.
-
-**Required Structural Elements**:
-- Each in-scope interactive component records the applicable state/display and interaction contract
-- Acceptance-criteria traceability table mapping confirmed criteria to screens/states, preserving existing IDs
-- Screen list with transition conditions
-- Existing component reuse map (reuse/extend/new decisions)
-
-**Prototype Code Handling**:
-- Prototype code provided by user is placed in `docs/ui-spec/assets/{feature-name}/`
-- Prototype code supports the UI Spec as an attachment
-- UI Spec + Design Doc are the canonical specifications
-
-### Design Document
-
-**Purpose**: Define the complete technical implementation for the confirmed scope
-
-**Includes**:
-- **Existing codebase analysis** (required)
-  - Implementation path mapping (both existing and new)
-  - Integration point clarification (connection points with existing code even for new implementations)
-- Technical implementation approach (vertical/horizontal/hybrid)
-- **Technical dependencies and implementation constraints** (required implementation order)
-- Interface and contract definitions
-- Data flow and component design
-- **Acceptance criteria**: the smallest representative set of observable behaviors with stable repository-verifiable pass/fail conditions
-- Change impact map (clearly specify direct impact/indirect impact/no ripple effect)
-- Every changed or newly relied-upon integration point
-- Data contract clarification
-- **Agreement checklist** (agreements with stakeholders)
-- **Code inspection evidence** (inspected files/functions during investigation)
-- **Field propagation map** (when fields cross component boundaries)
-- **Data representation decision** (when introducing new structures)
-- **Applicable standards** (explicit/implicit classification)
-- **Prerequisite ADRs** (including common ADRs)
-- **Verification Strategy** (required)
-  - Correctness proof method (what "correct" means for this change, how it's verified, when)
-  - Early verification point (first target to prove the approach works, success criteria, failure response)
-
-**Required Structural Elements**:
-```yaml
-Change Impact Map:
-  Change Target: [Component/Feature]
-  Direct Impact: [Files/Functions]
-  Indirect Impact: [Data format/Processing time]
-  No Ripple Effect: [Unaffected features]
-
-Interface Change Matrix:
-  Existing: [Function/method/operation name]
-  New: [Function/method/operation name]
-  Conversion Required: [Yes/No]
-  Compatibility Method: [Approach]
-```
-
-**Scope**: Technical implementation methods, interfaces, data flow, acceptance criteria, and verification strategy for the confirmed scope. Preserve the evidence and boundary details downstream implementation needs; omit unrelated future capability rather than reducing required design guarantees. Technology selection rationale belongs in ADR, schedule and assignments in Work Plan.
-
-An acceptance criterion describes observable behavior rather than implementation detail. External live connections use repository-controlled contract or interface proof unless a confirmed requirement needs the live boundary. Performance thresholds require a sourced target and a reproducible benchmark; exact visual positioning requires an approved visual contract and deterministic comparison. Otherwise record the item as a non-functional constraint or omit it from automated acceptance criteria.
-
-### Work Plan
-
-**Purpose**: Implementation task management and progress tracking.
-
-**Scope**: Repository implementation outcomes from approved Design Docs, task dependencies, source section and acceptance-criteria references, executable verification, optional task-level false-green focus, and progress tracking only. The Work Plan references governing documents instead of reproducing their design details.
-
-**Phase Division Criteria** (adapt to implementation approach from Design Doc):
-
-**When Vertical Slice selected**:
-- Each phase = one value unit (feature, component, or migration target)
-- Each phase includes its own implementation + verification per Verification Strategy
-
-**When Horizontal Slice selected**:
-1. **Phase 1: Foundation Implementation** - Contract definitions, interfaces/signatures, test preparation
-2. **Phase 2: Core Feature Implementation** - Business logic, unit tests
-3. **Phase 3: Integration Implementation** - External connections, presentation layer
-
-**When Hybrid selected**:
-- Combine vertical and horizontal as defined in Design Doc implementation approach
-
-**All approaches**: Each phase ends at a repository-observable verification point. Whole-repository quality assurance remains a separate execution responsibility.
-
-## Creation Process
-
-1. **Problem Analysis**: Confirm scope, determine Structural Scale, and identify candidate technical decision points
-   - Identify explicit and implicit project standards before investigation
-2. **ADR Choice Check** (when candidates exist): Apply the Choice filter, then the Durability filter
-3. **Creation**: Complete and review the qualifying ADR batch, then create the Design Doc with accepted ADRs as constraints
-4. **Approval**: One approval covers the reviewed ADR batch; Design Doc approval enables planning or implementation
 
 ## Storage Locations
 
@@ -206,27 +79,6 @@ An acceptance criterion describes observable behavior rather than implementation
 
 *Note: Work plans are excluded by `.gitignore`
 
-## ADR Status
-`Proposed` → `Accepted` → `Deprecated`/`Superseded`/`Rejected`
+## References
 
-## AI Automation Rules
-- Apply the Choice filter before the Durability filter and independently from Structural Scale
-- Check existing ADRs before implementation
-- Create one ADR per qualifying decision point and review the complete batch together
-
-## Diagram Requirements
-
-Select a Mermaid diagram only when it clarifies a material relationship more effectively than prose or a compact table:
-
-| Document | Required Diagrams | Purpose |
-|----------|------------------|---------|
-| PRD | User journey or scope boundary when prose does not make a material relationship clear | Clarify user experience and scope |
-| ADR | Option comparison when the relationship between options is unclear in a table | Visualize trade-offs |
-| UI Spec | Screen transition or component tree when material interaction or hierarchy remains unclear | Clarify screen flow and component structure |
-| Design Doc | Architecture or data flow when changed relationships are not clear in prose or tables | Understand technical structure |
-
-## Common ADR Relationships
-1. **At creation**: Identify accepted common ADRs that govern the changed responsibility
-2. **When missing**: Apply the same Choice and Durability filters; a generic concern alone does not justify a common ADR
-3. **Design Doc**: Specify applicable common ADRs in "Prerequisite ADRs"
-4. **Compliance check**: Verify the design aligns with accepted decisions
+Each template defines the content, structural elements, and diagram criteria for its document: [prd-template.md](references/prd-template.md), [adr-template.md](references/adr-template.md), [ui-spec-template.md](references/ui-spec-template.md), [design-template.md](references/design-template.md), [plan-template.md](references/plan-template.md), [task-template.md](references/task-template.md)

--- a/dev-workflows-frontend/skills/documentation-criteria/references/adr-template.md
+++ b/dev-workflows-frontend/skills/documentation-criteria/references/adr-template.md
@@ -4,6 +4,8 @@
 
 [Proposed | Accepted | Deprecated | Superseded | Rejected]
 
+A created ADR starts at `Proposed` and advances `Proposed` → `Accepted` → `Deprecated`/`Superseded`/`Rejected`.
+
 ## Context
 
 [Describe the background and reasons why this decision is needed. Include the essence of the problem, current challenges, and constraints]
@@ -33,7 +35,7 @@
 
 ### Options Considered
 
-Compare credible, materially distinct options supported by current requirements and repository evidence. The evidence determines how many options exist, and relative evidence-backed cost is sufficient.
+Compare credible, materially distinct options supported by current requirements and repository evidence. The evidence determines how many options exist, and relative evidence-backed cost is sufficient. Add a Mermaid option-comparison diagram only when the relationship between options stays unclear in the table below.
 
 | Option | Requirement and repository fit | Current-scope benefit | Lifecycle cost | Maintainability | Material trade-offs |
 |--------|--------------------------------|-----------------------|----------------|-----------------|---------------------|

--- a/dev-workflows-frontend/skills/documentation-criteria/references/design-template.md
+++ b/dev-workflows-frontend/skills/documentation-criteria/references/design-template.md
@@ -8,27 +8,11 @@
 - UI Spec path: [docs/ui-spec/xxx-ui-spec.md]
 - Component structure and state design are inherited from UI Spec
 
-## Design Summary (Meta)
-
-```yaml
-design_type: "new_feature|extension|refactoring"
-risk_level: "low|medium|high"
-complexity_level: "low|medium|high"
-complexity_rationale: "[Required if medium/high: (1) which requirements/ACs necessitate this complexity, (2) which constraints/risks it addresses]"
-main_constraints:
-  - "[constraint 1]"
-  - "[constraint 2]"
-biggest_risks:
-  - "[risk 1]"
-  - "[risk 2]"
-unknowns:
-  - "[uncertainty 1]"
-  - "[uncertainty 2]"
-```
-
 ## Background and Context
 
 ### Prerequisite ADRs
+
+List the accepted ADRs that govern the changed responsibility, including accepted common (cross-cutting) ADRs, and verify this design aligns with each recorded decision.
 
 - [docs/adr/ADR-XXXX.md]: [Related decision items]
 - Reference common technical ADRs when applicable
@@ -50,20 +34,7 @@ Records exclusions **the user decided** at requirement time. Exclusions this des
 - **Speculative**: [idea the user raised without deciding on -> deferral reason | None]
 - **Open questions**: [field the user left as weak-but-explicit | None]
 
-### Agreement Checklist
-
-#### Scope
-- [ ] [Features/components to change]
-- [ ] [Features to add]
-
-#### Non-Scope (Explicitly not changing)
-- [ ] [Features/components not to change]
-- [ ] [Existing logic to preserve]
-
-#### Constraints
-- [ ] Parallel operation: [Yes/No]
-- [ ] Backward compatibility: [Required/Not required]
-- [ ] Performance measurement: [Required/Not required]
+### Standards and Assumptions
 
 #### Applicable Standards
 - [ ] [Standard/convention] `[explicit]` - Source: [config / rule file / documentation path]
@@ -178,6 +149,8 @@ No Ripple Effect:
 ### Architecture Overview
 
 [How this feature is positioned within the overall system]
+
+Add an architecture or data-flow Mermaid diagram only when the changed relationships stay unclear in prose or a compact table; otherwise keep the prose form.
 
 ### Data Flow
 

--- a/dev-workflows-frontend/skills/documentation-criteria/references/plan-template.md
+++ b/dev-workflows-frontend/skills/documentation-criteria/references/plan-template.md
@@ -5,12 +5,6 @@ Type: feature|fix|refactor
 Related Issue/PR: #XXX (if any)
 Review Scope: [repository responsibilities or expected files derived from the Design Doc]
 
-## WorkPlan Review
-
-Plan creation and material updates set this to `pending`. Record `approved` after the user approves the reviewed implementation scope.
-
-- **Status**: pending|approved
-
 ## Governing Documents
 
 - Design Doc: [docs/design/XXX.md]
@@ -26,6 +20,14 @@ Plan creation and material updates set this to `pending`. Record `approved` afte
 ## Implementation Phases
 
 Use the implementation approach and dependency order from the Design Doc. Each phase groups work that reaches a shared observable verification point. Keep implementation, tests, configuration, wiring, and documentation together when they become complete at that point.
+
+Shape the phases from the approach the Design Doc selected:
+
+- **Vertical Slice**: each phase is one value unit (feature, component, or migration target) carrying its own implementation and verification per the Verification Strategy.
+- **Horizontal Slice**: foundation (contract definitions, interfaces/signatures, test preparation) → core feature (business logic, unit tests) → integration (external connections, presentation layer).
+- **Hybrid**: combine the two as the Design Doc's implementation approach defines.
+
+Whole-repository quality assurance stays outside the plan as a separate execution responsibility.
 
 ### Phase 1: [First implementation outcome]
 
@@ -63,7 +65,3 @@ Use the implementation approach and dependency order from the Design Doc. Each p
 - [ ] Dependencies permit execution in the listed order
 - [ ] Verification is executable from repository artifacts or the task's own output
 - [ ] Task verification passes and cited acceptance criteria are satisfied
-
-## Progress Notes
-
-[Record execution-relevant discoveries only when they change task order, scope, or verification.]

--- a/dev-workflows-frontend/skills/documentation-criteria/references/ui-spec-template.md
+++ b/dev-workflows-frontend/skills/documentation-criteria/references/ui-spec-template.md
@@ -42,6 +42,8 @@ Map confirmed acceptance criteria to prototype references, preserving existing A
 
 ## Screen List and Transitions
 
+Add a screen-transition or component-tree Mermaid diagram only when the material interaction or hierarchy stays unclear in the tables below; otherwise keep the table form.
+
 ### Screen List
 
 | Screen ID | Screen Name | Description | Entry Condition |

--- a/dev-workflows-frontend/skills/external-resource-context/SKILL.md
+++ b/dev-workflows-frontend/skills/external-resource-context/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: external-resource-context
-description: Captures and persists access methods for resources outside the repository (design source, design system, API schema, IaC source, secret store) so downstream work can reach them deterministically. Use when work depends on external resources, or when the user mentions design source, design system, API schema, IaC source, secret store, or canonical source.
+description: Captures access methods for resources outside the repository (design source, design system, API schema, IaC source, secret store) into a deterministic location so downstream work can reach them. Use when capturing or updating those access methods, or when the user mentions design source, design system, API schema, IaC source, secret store, or canonical source.
 ---
 
 # External Resource Context
@@ -30,58 +30,19 @@ The project tier owns environment facts. Feature-tier sections list only feature
 
 Example feature-tier entry uses the table format defined in `references/template.md`: a row with the project-tier label in the first column and the feature-specific identifier in the second column.
 
-## Hearing Protocol
-
-### When to Hear
-
-| Condition | Action |
-|-----------|--------|
-| `docs/project-context/external-resources.md` does not exist | Run full hearing for the relevant domain(s) |
-| File exists and covers the current decision | Use it without an update question |
-| User or caller identifies changed environment facts | Run diff-only hearing for the named axes |
-| A relevant axis is absent | Hear only the missing axis |
-| Access failure or contradictory current evidence indicates possible staleness | Ask via AskUserQuestion: "Update external-resources.md? (no / yes-full / yes-diff-only)". On `yes-full` run full hearing; on `yes-diff-only` hear the named stale axes; on `no` preserve the file and report the limitation |
-
-### Domain Routing
-
-Load the domain reference matching the current task:
-
-| Task type | References to load |
-|-----------|--------------------|
-| Frontend (UI work) | [references/frontend.md](references/frontend.md) |
-| Backend (server / data work) | [references/backend.md](references/backend.md) |
-| API contract work | [references/api.md](references/api.md) |
-| Infrastructure / deployment | [references/infra.md](references/infra.md) |
-| Fullstack | Load only the references whose frontend, backend/data, API-contract, or infrastructure responsibilities are affected by the confirmed scope; a fullstack label alone does not activate infrastructure |
-
-Each domain reference defines the axes and the question template.
-
-### Two-Phase Hearing
-
-1. **Structured hearing** — for each axis selected by the When to Hear and Domain Routing rules, present the user with AskUserQuestion using the choices listed in its domain reference (always include "Not applicable" as an option). For each non-N/A axis, follow up with an access-method question (URL / MCP name / file path / command).
-
-2. **Self-declaration for a full hearing** — after the structured axes for all selected domains are complete, present one integrated AskUserQuestion: "Are there any other external resources for this work that the structured questions did not cover? If yes, describe them in your next message." If the user describes additional resources, append them to the storage file under an "Additional resources" subsection. A diff-only or missing-axis hearing ends after its named axes because the existing project record already completed self-declaration.
-
-For a full hearing, the two phases are sequential and self-declaration runs even if the user answered "Not applicable" to every structured axis.
-
-## Storage Protocol
-
-After hearing completes:
-
-1. Build the project-tier content from the answers. Use [references/template.md](references/template.md) as the structure.
-2. Write to `docs/project-context/external-resources.md`. Create the directory if absent.
-3. When the calling workflow has a target UI Spec or Design Doc, also append or update the document's `## External Resources Used` section with the feature-tier subset (label references + feature-specific identifiers only).
-4. Report the file paths back to the calling workflow.
-
 ## Reference Protocol (For Downstream Consumers)
 
-Agents that load this skill consult resources in this order:
+Consuming a recorded resource takes three reads and needs no part of this skill:
 
-1. Read `docs/project-context/external-resources.md` first (if present) to learn what is available and how to access it.
+1. Read `docs/project-context/external-resources.md` (if present) to learn what is available and how to access it.
 2. Read the target UI Spec or Design Doc's `## External Resources Used` section for feature-specific identifiers.
 3. Use the access method declared in the project tier (e.g., the named MCP, the URL, the file path) to fetch the actual resource content.
 
-Agents that only need to *consult* the saved file as input data (not actively hear) can read it directly without loading this skill — frontmatter declaration is reserved for agents that may need to trigger hearing or interpret the protocol semantics.
+A consumer that only reads these records executes the three steps directly. Load this skill when capturing or updating the records, which requires AskUserQuestion and therefore the session that can ask the user.
+
+## Capturing and Updating Records
+
+Follow [references/hearing.md](references/hearing.md) for the hearing conditions, domain routing, two-phase hearing, storage protocol, and quality checklist.
 
 ## Output Format
 
@@ -89,16 +50,9 @@ The project-tier file follows the structure in [references/template.md](referenc
 
 For feature-tier sections inside UI Spec or Design Doc, the heading text "External Resources Used" is fixed; the heading level matches the parent document's natural structure (h2 in UI Spec where it is a sibling of other top-level sections, h3 in Design Doc where it sits under Background and Context).
 
-## Quality Checklist
-
-- [ ] Each axis answered has both a presence indicator and an access method, or is marked "Not applicable"
-- [ ] A full hearing ran self-declaration even when all structured axes were "Not applicable"; a diff-only or missing-axis hearing stayed within its named axes
-- [ ] Project-tier file does not contain feature-specific identifiers
-- [ ] Feature-tier sections reference project-tier entries by label, not by duplicating URLs / MCP names
-- [ ] When the project file already existed, each write traces to an explicit changed fact, a missing relevant axis, or a confirmed stale-evidence update decision
-
 ## References
 
+- [references/hearing.md](references/hearing.md) — Hearing conditions, domain routing, storage protocol, quality checklist
 - [references/frontend.md](references/frontend.md) — Frontend domain axes
 - [references/backend.md](references/backend.md) — Backend domain axes
 - [references/api.md](references/api.md) — API contract domain axes

--- a/dev-workflows-frontend/skills/external-resource-context/SKILL.md
+++ b/dev-workflows-frontend/skills/external-resource-context/SKILL.md
@@ -11,12 +11,6 @@ AI agents understand the codebase but not the external resources surrounding it.
 
 Resources covered: design origin (where the canonical visual specification lives), design system (component library and tokens), guidelines (usage docs, accessibility rules), visual verification environment (how to confirm rendering), database schema source, migration history, secret store location, API schema source (OpenAPI / proto / GraphQL SDL), mock environment, IaC source, environment configuration.
 
-## Scope Boundaries
-
-**In scope**: hearing protocol, storage location, single-source-of-truth ownership rule, reference protocol for downstream consumers.
-
-**Out of scope**: enforcing that captured resources are correct or current — verification belongs to the agent that consumes the resource. Generating the resources themselves (e.g., creating a DESIGN.md from scratch).
-
 ## Storage Locations (Two-Tier)
 
 | Tier | Location | Holds | Update Frequency |

--- a/dev-workflows-frontend/skills/external-resource-context/SKILL.md
+++ b/dev-workflows-frontend/skills/external-resource-context/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: external-resource-context
-description: Captures access methods for resources outside the repository (design source, design system, API schema, IaC source, secret store) into a deterministic location so downstream work can reach them. Use when capturing or updating those access methods, or when the user mentions design source, design system, API schema, IaC source, secret store, or canonical source.
+description: Records where resources outside the repository live (design source, design system, API schema, IaC source, secret store) and how design, implementation, and verification reach them. Use when work depends on an external resource, or when the user mentions design source, design system, API schema, IaC source, secret store, or canonical source.
 ---
 
 # External Resource Context
@@ -32,17 +32,17 @@ Example feature-tier entry uses the table format defined in `references/template
 
 ## Reference Protocol (For Downstream Consumers)
 
-Consuming a recorded resource takes three reads and needs no part of this skill:
+Before investigating the repository for an external fact, check whether it is already recorded:
 
 1. Read `docs/project-context/external-resources.md` (if present) to learn what is available and how to access it.
 2. Read the target UI Spec or Design Doc's `## External Resources Used` section for feature-specific identifiers.
 3. Use the access method declared in the project tier (e.g., the named MCP, the URL, the file path) to fetch the actual resource content.
 
-A consumer that only reads these records executes the three steps directly. Load this skill when capturing or updating the records, which requires AskUserQuestion and therefore the session that can ask the user.
+When the file is absent or the resource is unreachable, continue from governing and repository evidence. Each consuming agent reports that limitation through its own output contract.
 
 ## Capturing and Updating Records
 
-Follow [references/hearing.md](references/hearing.md) for the hearing conditions, domain routing, two-phase hearing, storage protocol, and quality checklist.
+Capturing a record requires AskUserQuestion, so it belongs to the session that can ask the user. Follow [references/hearing.md](references/hearing.md) for the hearing conditions, domain routing, two-phase hearing, storage protocol, and quality checklist.
 
 ## Output Format
 

--- a/dev-workflows-frontend/skills/external-resource-context/references/hearing.md
+++ b/dev-workflows-frontend/skills/external-resource-context/references/hearing.md
@@ -47,6 +47,6 @@ After hearing completes:
 
 - [ ] Each axis answered has both a presence indicator and an access method, or is marked "Not applicable"
 - [ ] A full hearing ran self-declaration even when all structured axes were "Not applicable"; a diff-only or missing-axis hearing stayed within its named axes
-- [ ] Project-tier file does not contain feature-specific identifiers
-- [ ] Feature-tier sections reference project-tier entries by label, not by duplicating URLs / MCP names
+- [ ] Project-tier entries hold the environment facts (URL, MCP name, file path, command)
+- [ ] Feature-tier rows hold a project-tier label and the feature-specific identifier
 - [ ] When the project file already existed, each write traces to an explicit changed fact, a missing relevant axis, or a confirmed stale-evidence update decision

--- a/dev-workflows-frontend/skills/external-resource-context/references/hearing.md
+++ b/dev-workflows-frontend/skills/external-resource-context/references/hearing.md
@@ -1,0 +1,52 @@
+# External Resource Hearing and Storage
+
+Producer-side protocol. Load this when capturing or updating external-resource records. Running it requires AskUserQuestion, so it belongs to the session that can ask the user directly.
+
+## When to Hear
+
+| Condition | Action |
+|-----------|--------|
+| `docs/project-context/external-resources.md` does not exist | Run full hearing for the relevant domain(s) |
+| File exists and covers the current decision | Use it without an update question |
+| User or caller identifies changed environment facts | Run diff-only hearing for the named axes |
+| A relevant axis is absent | Hear only the missing axis |
+| Access failure or contradictory current evidence indicates possible staleness | Ask via AskUserQuestion: "Update external-resources.md? (no / yes-full / yes-diff-only)". On `yes-full` run full hearing; on `yes-diff-only` hear the named stale axes; on `no` preserve the file and report the limitation |
+
+## Domain Routing
+
+Load the domain reference matching the current task:
+
+| Task type | References to load |
+|-----------|--------------------|
+| Frontend (UI work) | [frontend.md](frontend.md) |
+| Backend (server / data work) | [backend.md](backend.md) |
+| API contract work | [api.md](api.md) |
+| Infrastructure / deployment | [infra.md](infra.md) |
+| Fullstack | Load only the references whose frontend, backend/data, API-contract, or infrastructure responsibilities are affected by the confirmed scope; a fullstack label alone does not activate infrastructure |
+
+Each domain reference defines the axes and the question template.
+
+## Two-Phase Hearing
+
+1. **Structured hearing** — for each axis selected by the When to Hear and Domain Routing rules, present the user with AskUserQuestion using the choices listed in its domain reference (always include "Not applicable" as an option). For each non-N/A axis, follow up with an access-method question (URL / MCP name / file path / command).
+
+2. **Self-declaration for a full hearing** — after the structured axes for all selected domains are complete, present one integrated AskUserQuestion: "Are there any other external resources for this work that the structured questions did not cover? If yes, describe them in your next message." If the user describes additional resources, append them to the storage file under an "Additional resources" subsection. A diff-only or missing-axis hearing ends after its named axes because the existing project record already completed self-declaration.
+
+For a full hearing, the two phases are sequential and self-declaration runs even if the user answered "Not applicable" to every structured axis.
+
+## Storage Protocol
+
+After hearing completes:
+
+1. Build the project-tier content from the answers. Use [template.md](template.md) as the structure.
+2. Write to `docs/project-context/external-resources.md`. Create the directory if absent.
+3. When the calling workflow has a target UI Spec or Design Doc, also append or update the document's `## External Resources Used` section with the feature-tier subset (label references + feature-specific identifiers only).
+4. Report the file paths back to the calling workflow.
+
+## Quality Checklist
+
+- [ ] Each axis answered has both a presence indicator and an access method, or is marked "Not applicable"
+- [ ] A full hearing ran self-declaration even when all structured axes were "Not applicable"; a diff-only or missing-axis hearing stayed within its named axes
+- [ ] Project-tier file does not contain feature-specific identifiers
+- [ ] Feature-tier sections reference project-tier entries by label, not by duplicating URLs / MCP names
+- [ ] When the project file already existed, each write traces to an explicit changed fact, a missing relevant axis, or a confirmed stale-evidence update decision

--- a/dev-workflows-frontend/skills/frontend-ai-guide/SKILL.md
+++ b/dev-workflows-frontend/skills/frontend-ai-guide/SKILL.md
@@ -123,7 +123,7 @@ function EmailInput({ context }: { context: 'user' | 'contact' | 'admin' }) { /*
 - Similar functionality found → Verify that its props, lifecycle, design-system role, and repository usage are representative; reuse or extend it when compatible, otherwise record why it is not a valid model
 - Similar functionality is technical debt → Repair it when it blocks the current outcome, was caused by the current change, or lies in confirmed scope; otherwise report it separately. Create an ADR when the repair requires an architectural decision
 - No similar functionality exists → Implement new functionality following existing design philosophy
-- Record all decisions and rationale in "Existing Codebase Analysis" section of Design Doc
+- Record each reuse, extend, separate, or repair decision with its evidence in the artifact this agent owns
 
 ## Quality Check Workflow
 
@@ -165,11 +165,7 @@ Read `package.json` scripts, map the project's actual commands to the phases bel
 **Completion Criteria**: Complete all 3 stages. Concise search/inspection notes are sufficient for an isolated component change with no shared contract, routing, state-ownership, or build/config impact; use the structured report for cross-component or high-risk changes.
 
 #### 1. Discovery
-```bash
-Grep -n "ComponentName\|hookName" -o content
-Grep -n "importedFunction" -o content
-Grep -n "propsType\|StateType" -o content
-```
+Search the repository for every reference to the changed component or hook, its imported functions, and its Props/State types.
 
 #### 2. Understanding
 Read the discovered files needed to establish:

--- a/dev-workflows-frontend/skills/implementation-approach/SKILL.md
+++ b/dev-workflows-frontend/skills/implementation-approach/SKILL.md
@@ -35,7 +35,7 @@ Complete these steps in order before selecting an implementation strategy:
 
 Classify supporting claims as observed, inferred, or unknown. When an unknown blocks the next step, stop at the current step and name the evidence or user decision required.
 
-**Design Doc output**: Direct MVP, Failed Items, Adopted Additions, and Rejected Additions.
+**Phase 2 outputs**: Direct MVP, Failed Items, Adopted Additions, and Rejected Additions. A Design Doc author records all four; an implementer uses them as the convergence check without producing a document.
 
 ### Phase 3: Strategy Exploration and Creation
 
@@ -117,7 +117,7 @@ Select the implementation approach that directly fits the verified dependency an
 
 ### Phase 7: Decision Rationale Documentation
 
-**Design Doc Documentation**: Record in the Design Doc's implementation approach section:
+**Record in the artifact this agent owns**, and in the Design Doc's implementation approach section when this agent owns that document:
 1. Selected strategy name and characteristics
 2. A materially different alternative and reason for rejection, when one was compared
 3. Risk mitigation plan (from Phase 4)

--- a/dev-workflows-frontend/skills/integration-e2e-testing/SKILL.md
+++ b/dev-workflows-frontend/skills/integration-e2e-testing/SKILL.md
@@ -76,7 +76,7 @@ The two E2E lanes have different ownership costs and use independent standard th
 | fixture-e2e | ROI ≥ 20 (beyond reserved slot) | Cost is comparable to integration tests once the harness exists; the floor avoids filling MAX 3 with low-signal tests when fewer would suffice |
 | service-integration-e2e | ROI > 50 (beyond reserved slot) | Live-service setup, state cleanup, and failure diagnosis add material ownership cost; reserve for journeys whose value cannot be proven any other way |
 
-Reserved slot rules (see Multi-Step User Journey Definition below) apply per lane and override the threshold (the reserved candidate is emitted regardless of its ROI score). Below-floor candidates beyond the reserved slot are not emitted unless an accepted requirement or distinct uncovered failure mode justifies an exception. Leave budget intentionally unfilled rather than padding with low-value tests; record any threshold or budget exception in the skeleton and generation report.
+Reserved slot rules (see Multi-Step User Journey Definition below) apply per lane and override the threshold (the reserved candidate is emitted regardless of its ROI score). Below-floor candidates beyond the reserved slot are not emitted unless an accepted requirement or distinct uncovered failure mode justifies an exception. Leave budget intentionally unfilled rather than padding with low-value tests; record any threshold or budget exception in the skeleton that carries the exception.
 
 ### ROI Calculation Examples
 

--- a/dev-workflows-frontend/skills/integration-e2e-testing/SKILL.md
+++ b/dev-workflows-frontend/skills/integration-e2e-testing/SKILL.md
@@ -76,7 +76,7 @@ The two E2E lanes have different ownership costs and use independent standard th
 | fixture-e2e | ROI ≥ 20 (beyond reserved slot) | Cost is comparable to integration tests once the harness exists; the floor avoids filling MAX 3 with low-signal tests when fewer would suffice |
 | service-integration-e2e | ROI > 50 (beyond reserved slot) | Live-service setup, state cleanup, and failure diagnosis add material ownership cost; reserve for journeys whose value cannot be proven any other way |
 
-Reserved slot rules (see Multi-Step User Journey Definition below) apply per lane and override the threshold (the reserved candidate is emitted regardless of its ROI score). Below-floor candidates beyond the reserved slot are not emitted unless an accepted requirement or distinct uncovered failure mode justifies an exception. Leave budget intentionally unfilled rather than padding with low-value tests; record any threshold or budget exception in the skeleton that carries the exception.
+Reserved slot rules (see Multi-Step User Journey Definition below) apply per lane and override the threshold (the reserved candidate is emitted regardless of its ROI score). Emit a below-floor candidate beyond the reserved slot only when an accepted requirement or a distinct uncovered failure mode justifies the exception. Leave budget intentionally unfilled rather than padding with low-value tests; record any threshold or budget exception in the skeleton that carries the exception.
 
 ### ROI Calculation Examples
 

--- a/dev-workflows-frontend/skills/recipe-front-build/SKILL.md
+++ b/dev-workflows-frontend/skills/recipe-front-build/SKILL.md
@@ -34,7 +34,7 @@ Before any task processing, locate the work plan. Resolution rule:
 1. List task files in `docs/plans/tasks/` matching the single-layer pattern `{plan-name}-task-*.md`. Layer-aware fullstack tasks (`{plan-name}-backend-task-*.md` / `{plan-name}-frontend-task-*.md`) are excluded here so a stale fullstack run does not redirect this recipe to the wrong work plan
 2. For each matched file, extract the `{plan-name}` prefix as the segment that appears before `-task-`
 3. When at least one task file matches, the work plan is `docs/plans/{plan-name}.md` for the prefix that has the most recent task-file mtime; ties broken by the lexicographically last `{plan-name}`
-4. When no task file matches the restricted pattern, the work plan is the most-recent-mtime non-template `.md` in `docs/plans/`
+4. When no task file matches the restricted pattern, the work plan is the most recently modified `.md` in `docs/plans/`
 
 ### Consumed Task Set
 

--- a/dev-workflows-frontend/skills/recipe-front-review/SKILL.md
+++ b/dev-workflows-frontend/skills/recipe-front-review/SKILL.md
@@ -36,13 +36,7 @@ Design Doc (uses most recent if omitted): $ARGUMENTS
 ## Execution Flow
 
 ### Step 1: Prerequisite Check
-```bash
-# Identify Design Doc
-ls docs/design/*.md | grep -v template | tail -1
-
-# Check implementation files
-git diff --name-only main...HEAD
-```
+Identify the review inputs: the most recently updated Design Doc under `docs/design/`, and the files changed on the current branch relative to its base.
 
 ### Step 2: Execute code-reviewer
 Invoke code-reviewer using Agent tool:
@@ -116,7 +110,7 @@ Run this step only when the user routed at least one finding to `d`. When no `d`
    - `prompt`: "Review updated Design Doc at [path] for consistency and completeness. doc_type: DesignDoc. review_context: update."
    - Run the Review Resolution Gate through its correction re-review, escalation, and convergence transitions, using technical-designer-frontend for rerouted corrections. Proceed only at its convergence condition.
 
-3. When multiple Design Docs exist (`ls docs/design/*.md | grep -v template | wc -l > 1`), invoke design-sync:
+3. When more than one Design Doc exists under `docs/design/`, invoke design-sync:
    - `subagent_type`: "dev-workflows-frontend:design-sync"
    - `description`: "Cross-DD consistency check"
    - `prompt`: "source_design: [updated DD path]"

--- a/dev-workflows-frontend/skills/recipe-update-doc/SKILL.md
+++ b/dev-workflows-frontend/skills/recipe-update-doc/SKILL.md
@@ -24,21 +24,21 @@ Before the first finding disposition, read `references/review-resolution.md` fro
 1. **Invoke named specialists for deliverable production** — pass deliverable paths between them and validate their results (see subagents-orchestration-guide "Orchestrator Execution Boundary")
 2. **Execute update flow**:
    - Identify target → Clarify changes → Update document → Review → Consistency check
-   - **Stop at every `[Stop: ...]` marker** → Wait for user approval before proceeding
+   - **Stop at the `[Stop: Final approval]` marker** → Wait for user approval before completing
 3. **Scope**: Complete when updated document receives approval
 
 At each Agent invocation below, build the prompt as a mechanical extraction: copy the named source values into the exact fields, apply only the declared serialization, then invoke immediately.
 
-**CRITICAL**: Execute document-reviewer and all stopping points — each serves as a quality gate for document accuracy.
+**CRITICAL**: Execute document-reviewer — it is the quality gate for document accuracy.
 
 ## Workflow Overview
 
 ```
-Target document → [Stop: Confirm changes]
+Target document → change clarification
                         ↓
               technical-designer / technical-designer-frontend / prd-creator (update mode)
                         ↓ (Design Doc only)
-              code-verifier → document-reviewer → [Stop: Review approval]
+              code-verifier → document-reviewer
                         ↓ (Design Doc only)
               design-sync → [Stop: Final approval]
 ```
@@ -47,7 +47,7 @@ Target document → [Stop: Confirm changes]
 
 **Included in this skill**:
 - Existing document identification and selection
-- Change content clarification with user
+- Change content clarification
 - Document update with appropriate agent (update mode)
 - Document review with document-reviewer
 - Consistency verification with design-sync (Design Doc only)
@@ -64,10 +64,7 @@ Target document: $ARGUMENTS
 
 ### Step 1: Target Document Identification
 
-```bash
-# Check existing documents
-ls docs/design/*.md docs/prd/*.md docs/adr/*.md 2>/dev/null | grep -v template
-```
+Discover the existing documents under `docs/design/`, `docs/prd/`, and `docs/adr/`.
 
 **Decision flow**:
 
@@ -97,16 +94,11 @@ Read the document and determine its layer from content signals:
 - **Minor changes** (clarification, typo fix, small scope adjustment): Update the existing ADR file
 - **Major changes** (decision reversal, significant scope change): Create a new ADR that supersedes the original
 
-### Step 3: Change Content Clarification [Stop]
+### Step 3: Change Content Clarification
 
-Use AskUserQuestion to clarify what changes are needed:
-- What sections need updating
-- Reason for the change (bug fix findings, spec change, review feedback, etc.)
-- Expected outcome after the update
+Determine which sections need updating, the reason for the change, and the expected outcome after the update. Derive them from the request and the target document. Use AskUserQuestion only for an item the request and document leave undetermined, and only when a different answer would change which sections are updated or what the update must achieve.
 
-Confirm understanding of changes with user before proceeding.
-
-Pass approved items, covered sections, and any stated total size budget to update or revision agents. Before the next approval gate, map every diff hunk to an approved item or required consistency update; request a scope decision for unmapped or over-budget changes.
+Pass the resulting items, covered sections, and any stated total size budget to update or revision agents. Before the next approval gate, map every diff hunk to an approved item or required consistency update; request a scope decision for unmapped or over-budget changes.
 
 ### Step 4: Document Update
 
@@ -119,13 +111,13 @@ prompt: |
   Existing Document: [path from Step 1]
 
   ## Changes Required
-  [user-approved Step 3 statements for the sections to update, reason, and expected outcome, copied verbatim]
+  [Step 3 statements for the sections to update, reason, and expected outcome, copied verbatim]
 
   Update the document to reflect the specified changes.
   Add change history entry.
 ```
 
-### Step 5: Document Review [Stop]
+### Step 5: Document Review
 
 **For Design Doc updates only**: Before document-reviewer, invoke code-verifier:
 ```
@@ -170,22 +162,18 @@ For each type, review consistency of the changed sections and their dependent st
 - On re-review pass `prior_feedback` as `[{id, disposition, reason?, evidence}]`
 - All actionable findings are `decline` and every `user_decision_required` item is resolved → Proceed to Step 6
 
-Present review result to user for approval.
+### Step 6: Consistency Verification and Final Approval `[Stop: Final approval]`
 
-### Step 6: Consistency Verification (Design Doc only) [Stop]
-
-**Skip condition**: Document type is PRD or ADR → Proceed to completion.
-
-For Design Doc, invoke design-sync:
+**For Design Doc only**, invoke design-sync first:
 ```
 subagent_type: design-sync
 description: "Verify consistency"
 prompt: "source_design: [path from Step 1]"
 ```
 
-**On consistency result**:
-- No conflicts → Present result to user for final approval
-- Conflicts detected → Apply the Review Resolution Gate using design-sync as a fresh verifier. Return `apply` conflicts to Step 4 for the owning document, rerun design-sync after correction, retain evidenced declines as complete, and request user input for `user_decision_required` or the Gate's escalation conditions. Present final approval at convergence.
+When conflicts are detected, apply the Review Resolution Gate using design-sync as a fresh verifier. Return `apply` conflicts to Step 4 for the owning document, rerun design-sync after correction, retain evidenced declines as complete, and request user input for `user_decision_required` or the Gate's escalation conditions.
+
+**For every document type**, present the updated document, the review outcome, any resolved declines, and the sync result when one ran. This is the only approval gate in the flow: wait for the user's decision before completing.
 
 ## Error Handling
 
@@ -197,7 +185,7 @@ prompt: "source_design: [path from Step 1]"
 ## Completion Criteria
 
 - [ ] Identified target document
-- [ ] Clarified change content with user
+- [ ] Change content determined from the request, the document, or a question whose answer changed the update
 - [ ] Updated document with appropriate agent (update mode)
 - [ ] Executed code-verifier before document-reviewer (Design Doc only)
 - [ ] Executed document-reviewer and addressed feedback

--- a/dev-workflows-frontend/skills/subagents-orchestration-guide/SKILL.md
+++ b/dev-workflows-frontend/skills/subagents-orchestration-guide/SKILL.md
@@ -284,8 +284,8 @@ Pass the Design Doc path. Work-planner maps governing sections and ACs to implem
 
 - Invoke acceptance-test-generator with `design_docs` as the applicable Design Doc path list, optional `ui_spec`, and the same `confirmed_requirement_context` used for design.
 - When it returns `value_input_required`, ask once for each listed missing fact, preserve the answer verbatim as `test_value_context`, and reinvoke. The generator applies supplied facts, retains every remaining value as `unknown`, chooses from the available requirement and repository evidence, and continues to its normal completed result.
-- Verify each non-null `generatedFiles.<lane>` path exists. For each null E2E lane, accept its `e2eAbsenceReason.<lane>` only when it names the selection rule, source evidence, and selected or governing proof covering the accepted boundary. Return an uncovered accepted proof obligation to the generator for completion.
-- Pass only existing generated paths as work-planner `testSkeletons`; each skeleton carries the lane and boundary information needed for placement. Consume valid null-lane reasons at this gate.
+- Verify each non-null `generatedFiles.<lane>` path exists. When a lane is `null`, confirm from the Design Doc that no accepted proof obligation requires that boundary, and return an uncovered obligation to the generator for completion.
+- Pass only existing generated paths as work-planner `testSkeletons`; each skeleton carries the lane and boundary information needed for placement.
 - Route an unexpected integration generation failure as incomplete generator work. A validated null E2E lane is complete.
 
 ## References

--- a/dev-workflows-frontend/skills/subagents-orchestration-guide/references/monorepo-flow.md
+++ b/dev-workflows-frontend/skills/subagents-orchestration-guide/references/monorepo-flow.md
@@ -27,7 +27,7 @@ This reference defines the orchestration flow for one feature spanning backend a
 | 11 | technical-designer-frontend | Frontend Design Doc with backend contracts, applicable UI Spec, and accepted ADR constraints | Frontend Design Doc |
 | 12 | code-verifier ×2 + orchestrator | Verify each Design Doc and apply Review Resolution | Resolved verification evidence |
 | 13 | document-reviewer ×2 | Review each Design Doc with resolved verification evidence | Reviews |
-| 14 | design-sync | Cross-layer consistency verification **[Stop]** | Sync status |
+| 14 | design-sync | Cross-layer consistency verification **[Stop when conflicts remain after Review Resolution]** | Sync status |
 | 15 | acceptance-test-generator | Integration/E2E skeletons selected from cross-layer contracts | Test skeletons |
 | 16 | work-planner | Work plan from both Design Docs | Work Plan |
 | 17 | document-reviewer | Work Plan review **[Stop: Batch approval]** | Approval |

--- a/dev-workflows-frontend/skills/task-analyzer/references/skills-index.yaml
+++ b/dev-workflows-frontend/skills/task-analyzer/references/skills-index.yaml
@@ -206,7 +206,6 @@ skills:
       - "references/template.md"
     sections:
       - "Purpose"
-      - "Scope Boundaries"
       - "Storage Locations (Two-Tier)"
       - "Reference Protocol (For Downstream Consumers)"
       - "Capturing and Updating Records"

--- a/dev-workflows-frontend/skills/task-analyzer/references/skills-index.yaml
+++ b/dev-workflows-frontend/skills/task-analyzer/references/skills-index.yaml
@@ -71,17 +71,12 @@ skills:
       - "Design Doc Culture - Google Engineering Practices"
       - "Single Source of Truth"
     sections:
-      - "Templates"
+      - "What Each Document Fixes"
       - "Creation Decision Matrix"
       - "Structural Scale"
       - "ADR Decision Filters"
-      - "Detailed Document Definitions"
-      - "Creation Process"
       - "Storage Locations"
-      - "ADR Status"
-      - "AI Automation Rules"
-      - "Diagram Requirements"
-      - "Common ADR Relationships"
+      - "References"
 
   implementation-approach:
     skill: "implementation-approach"
@@ -203,6 +198,7 @@ skills:
     tags: [cross-cutting, hearing-protocol, design-source, design-system, api-schema, iac-source, secrets, environment, two-tier-storage]
     typical-use: "Captures access methods for resources outside the repository (design origin, design system, API schema, IaC source, secrets, etc.) and persists them in a deterministic location for downstream agents"
     key-references:
+      - "references/hearing.md"
       - "references/frontend.md"
       - "references/backend.md"
       - "references/api.md"
@@ -212,11 +208,9 @@ skills:
       - "Purpose"
       - "Scope Boundaries"
       - "Storage Locations (Two-Tier)"
-      - "Hearing Protocol"
-      - "Storage Protocol"
       - "Reference Protocol (For Downstream Consumers)"
+      - "Capturing and Updating Records"
       - "Output Format"
-      - "Quality Checklist"
       - "References"
 
   requirement-convergence:

--- a/dev-workflows-fullstack/.claude-plugin/plugin.json
+++ b/dev-workflows-fullstack/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflows-fullstack",
   "description": "Skills + Subagents for fullstack development (backend + React/TypeScript) - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
-  "version": "0.24.3",
+  "version": "0.24.4",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows-fullstack/agents/acceptance-test-generator.md
+++ b/dev-workflows-fullstack/agents/acceptance-test-generator.md
@@ -198,22 +198,6 @@ A skeleton is committed before its implementation exists, so its committed form 
 
 ### Generation Report
 
-**When both E2E lanes are emitted:**
-```json
-{
-  "status": "completed",
-  "feature": "payment",
-  "generatedFiles": {
-    "integration": "tests/payment.int.test.[ext]",
-    "fixtureE2e": "tests/payment.fixture.e2e.test.[ext]",
-    "serviceE2e": "tests/payment.service.e2e.test.[ext]"
-  },
-  "budgetUsage": { "integration": "2/3", "fixtureE2e": "1/3", "serviceE2e": "1/2" },
-  "e2eAbsenceReason": { "fixtureE2e": null, "serviceE2e": null }
-}
-```
-
-**When only fixture-e2e is emitted:**
 ```json
 {
   "status": "completed",
@@ -222,30 +206,13 @@ A skeleton is committed before its implementation exists, so its committed form 
     "integration": "tests/payment.int.test.[ext]",
     "fixtureE2e": "tests/payment.fixture.e2e.test.[ext]",
     "serviceE2e": null
-  },
-  "budgetUsage": { "integration": "2/3", "fixtureE2e": "2/3", "serviceE2e": "0/2" },
-  "e2eAbsenceReason": { "fixtureE2e": null, "serviceE2e": "Design Doc §Test Boundaries designates the gateway as mockable; the selected fixture-e2e covers every accepted journey proof obligation." }
+  }
 }
 ```
 
-**When no E2E tests are emitted:**
-```json
-{
-  "status": "completed",
-  "feature": "config-update",
-  "generatedFiles": {
-    "integration": "tests/config.int.test.[ext]",
-    "fixtureE2e": null,
-    "serviceE2e": null
-  },
-  "budgetUsage": { "integration": "1/3", "fixtureE2e": "0/3", "serviceE2e": "0/2" },
-  "e2eAbsenceReason": { "fixtureE2e": "Design Doc AC1-AC4 classify as single-step behavior under the journey rule; selected integration coverage proves their accepted boundaries.", "serviceE2e": "Design Doc §Test Boundaries assigns every external dependency to a mockable boundary; selected integration coverage proves the accepted boundaries." }
-}
-```
+**Contract**: a `completed` result always contains `generatedFiles.integration`, `generatedFiles.fixtureE2e`, and `generatedFiles.serviceE2e`. Value is a file path string when that lane emitted, `null` when it did not. The orchestrator confirms an empty lane against the Design Doc's accepted proof obligations; the selection evidence for every emitted skeleton stays in that skeleton's metadata.
 
-**Contract**:
-- A `completed` result always contains `generatedFiles.integration`, `generatedFiles.fixtureE2e`, and `generatedFiles.serviceE2e`. Value is a file path string when generated, `null` when not.
-- `e2eAbsenceReason` is an object with `fixtureE2e` and `serviceE2e` keys. Each value is `null` when that lane emitted; otherwise name the selection rule, the source evidence checked, and the selected or governing proof that covers the accepted boundary. A valid null lane accounts for every accepted proof obligation.
+Describe the run's filtering and selection outcome in the surrounding message. Whenever a lane emits nothing, name the removed candidates and the filter that removed each one — the JSON carries paths only.
 
 **When a decision-relevant value input is missing:**
 ```json
@@ -258,7 +225,7 @@ A skeleton is committed before its implementation exists, so its committed form 
 }
 ```
 
-Return this status before creating or modifying skeleton files. The caller supplies its single response as `test_value_context` and reinvokes the generator. Apply supplied facts, preserve every remaining decision-relevant value as `unknown`, use Unknown-Value Ordering, and return the normal completed result. Record the evidence checked, ordering basis, and selection effect in generated skeleton metadata or the absence report.
+Return this status before creating or modifying skeleton files. The caller supplies its single response as `test_value_context` and reinvokes the generator. Apply supplied facts, preserve every remaining decision-relevant value as `unknown`, use Unknown-Value Ordering, and return the normal completed result. Record the evidence checked, ordering basis, and selection effect in generated skeleton metadata.
 
 ## Test Meta Information Assignment
 
@@ -290,23 +257,25 @@ These annotations drive test planning and prioritization. The `@lane` annotation
 - Clarify dependencies explicitly
 - Logical test execution order
 
-## Exception Handling and Escalation
+## Exception Handling and Stop Conditions
 
 ### Auto-processable
 - **Directory Absent**: Auto-create appropriate directory following detected test structure
 - **No Integration Candidates**: Valid outcome - report "No Integration candidates remained after Phase 1 filtering, deduplication, and push-down analysis"
 - **No E2E Tests (no multi-step journey)**: Valid outcome - report "No multi-step user journey detected; E2E tests not applicable"
-- **Budget Exceeded by Critical Test**: Report to user
+- **Budget insufficient for a critical user journey (ROI > 90)**: Exceed the lane budget per the integration-e2e-testing skill's budget rule when the journey's failure mode cannot be proved by a selected test, and annotate the exception and why consolidation cannot cover it
+- **No E2E test emitted after budget enforcement, but the input Design Doc contains a user-facing multi-step journey**: Report the journey, every candidate evaluated with its ROI score, and the filter that removed each one, then continue. (This case arises only when the reserved slot in Phase 4 did not apply — e.g., no journey candidate passed Phase 1-3 filtering.)
+- **Every AC filtered out, leaving no generated test**: Valid outcome - return the empty result and report the filter that removed each AC
+- **Multiple interpretations possible but minor impact**: Adopt the interpretation and note it in the report
 - **Missing value that cannot change selection**: Record `not_decision_relevant` with the invariant selection basis and continue
 - **Decision-relevant value remains unknown after the value-input round**: Preserve `unknown`, apply Unknown-Value Ordering, record its selection effect, and continue
 
-### Escalation Required
-1. **Critical**: AC absent, Design Doc absent → Error termination
-2. **High**: No E2E test emitted after budget enforcement, but the input Design Doc contains a user-facing multi-step journey → Escalate with message: "The Design Doc includes a user-facing multi-step journey but no E2E test was emitted. Journey candidates evaluated: [list with ROI scores]. Confirm whether to proceed without E2E." (Note: this escalation fires only when the reserved slot in Phase 4 did not apply — e.g., no journey candidate passed Phase 1-3 filtering. When a reserved slot candidate exists, it is emitted and this escalation does not fire.)
-3. **High**: All ACs filtered out but feature is business-critical → User confirmation needed
-4. **Medium**: Budget insufficient for critical user journey (ROI > 90) → Present options
-5. **Low**: Multiple interpretations possible but minor impact → Adopt interpretation + note in report
-6. **Decision input**: An unknown Business Value, User Frequency, or Legal Requirement can change ranking, threshold, or budget selection → Return `value_input_required` when `test_value_context` is absent; after that input round, preserve remaining unknowns and continue with Unknown-Value Ordering
+### Stop Conditions
+
+These two cases end generation and hand control back; every other case above completes with a recorded result.
+
+1. **Required input absent**: AC absent or Design Doc absent → terminate and name the missing input
+2. **Decision input required**: An unknown Business Value, User Frequency, or Legal Requirement can change ranking, threshold, or budget selection → Return `value_input_required` when `test_value_context` is absent; after that input round, preserve remaining unknowns and continue with Unknown-Value Ordering
 
 ## Technical Specifications
 

--- a/dev-workflows-fullstack/agents/document-reviewer.md
+++ b/dev-workflows-fullstack/agents/document-reviewer.md
@@ -82,7 +82,7 @@ Verify current external facts from authoritative sources only when an ADR select
 - Behavior replacement or transformation has a representative output-comparison method covering applicable pipeline steps.
 - Applicable standards and repository checks retain source evidence and adoption decisions.
 - Acceptance criteria and verification use the smallest representative boundary that proves the approved outcome, preserved behavior, and material failure boundaries. The early verification point is executable.
-- Performance, live-external, and exact-visual ACs have the sourced requirement and reproducible proof required by the Acceptance Criteria section of `references/design-template.md` in the documentation-criteria skill; implementation details are not ACs.
+- Each AC states observable behavior, and performance, live-external, and exact-visual ACs carry the sourced requirement and reproducible proof required by the Acceptance Criteria section of `references/design-template.md` in the documentation-criteria skill.
 - Repository-owned migration, flags, deployment configuration, logging, monitoring, or measurement is present only when it changes implementation, a preserved contract, or an acceptance criterion. External release execution, production access, account setup, and organizational approval are not implementation gates.
 - Reverse-engineered/as-is documents describe observed code with evidence and are exempt from future-state convergence and design-choice requirements.
 

--- a/dev-workflows-fullstack/agents/document-reviewer.md
+++ b/dev-workflows-fullstack/agents/document-reviewer.md
@@ -82,7 +82,7 @@ Verify current external facts from authoritative sources only when an ADR select
 - Behavior replacement or transformation has a representative output-comparison method covering applicable pipeline steps.
 - Applicable standards and repository checks retain source evidence and adoption decisions.
 - Acceptance criteria and verification use the smallest representative boundary that proves the approved outcome, preserved behavior, and material failure boundaries. The early verification point is executable.
-- Performance, live-external, and exact-visual ACs have the sourced requirement and reproducible proof required by documentation-criteria; implementation details are not ACs.
+- Performance, live-external, and exact-visual ACs have the sourced requirement and reproducible proof required by the Acceptance Criteria section of `references/design-template.md` in the documentation-criteria skill; implementation details are not ACs.
 - Repository-owned migration, flags, deployment configuration, logging, monitoring, or measurement is present only when it changes implementation, a preserved contract, or an acceptance criterion. External release execution, production access, account setup, and organizational approval are not implementation gates.
 - Reverse-engineered/as-is documents describe observed code with evidence and are exempt from future-state convergence and design-choice requirements.
 

--- a/dev-workflows-fullstack/agents/prd-creator.md
+++ b/dev-workflows-fullstack/agents/prd-creator.md
@@ -95,7 +95,7 @@ Storage location and naming convention follow documentation-criteria skill.
 Execute file output immediately (considered approved at execution).
 
 ### Notes for PRD Creation
-- Create following the PRD template (see documentation-criteria skill)
+- Create following `references/prd-template.md` in the documentation-criteria skill
 - Understand and describe intent of each section
 - Limit questions to 3-5 in interactive mode
 

--- a/dev-workflows-fullstack/agents/quality-fixer-frontend.md
+++ b/dev-workflows-fullstack/agents/quality-fixer-frontend.md
@@ -6,7 +6,6 @@ skills:
   - typescript-rules
   - test-implement
   - frontend-ai-guide
-  - external-resource-context
 ---
 
 You are an AI assistant specialized in quality assurance for frontend React projects.
@@ -62,7 +61,7 @@ Run `qualityCommand` first when provided. Treat it as covering the check categor
 
 When `task_file` is provided, run its Operation Verification Methods in addition to applicable checks discovered from project manifests and configuration.
 
-**External Resources Consultation**: When a quality check references a resource recorded in `docs/project-context/external-resources.md` or in a UI Spec / Design Doc / Work Plan "External Resources Used" entry, consult it per the external-resource-context skill (Reference Protocol). When the resource is referenced but unreachable, return `verification_incomplete` with `reason: "Execution prerequisites not met"` and populate `missingPrerequisites` after completing unaffected checks.
+**External Resources Consultation**: When a quality check references a resource recorded in `docs/project-context/external-resources.md` or in a UI Spec / Design Doc / Work Plan "External Resources Used" entry, read that file for the declared access method, read the document's `External Resources Used` entry for the feature-specific identifier, then fetch through that access method. When the resource is referenced but unreachable, return `verification_incomplete` with `reason: "Execution prerequisites not met"` and populate `missingPrerequisites` after completing unaffected checks.
 
 ### Step 3: Execute Quality Checks
 Follow frontend-ai-guide skill "Quality Check Workflow" section:

--- a/dev-workflows-fullstack/agents/quality-fixer-frontend.md
+++ b/dev-workflows-fullstack/agents/quality-fixer-frontend.md
@@ -6,6 +6,7 @@ skills:
   - typescript-rules
   - test-implement
   - frontend-ai-guide
+  - external-resource-context
 ---
 
 You are an AI assistant specialized in quality assurance for frontend React projects.
@@ -61,7 +62,7 @@ Run `qualityCommand` first when provided. Treat it as covering the check categor
 
 When `task_file` is provided, run its Operation Verification Methods in addition to applicable checks discovered from project manifests and configuration.
 
-**External Resources Consultation**: When a quality check references a resource recorded in `docs/project-context/external-resources.md` or in a UI Spec / Design Doc / Work Plan "External Resources Used" entry, read that file for the declared access method, read the document's `External Resources Used` entry for the feature-specific identifier, then fetch through that access method. When the resource is referenced but unreachable, return `verification_incomplete` with `reason: "Execution prerequisites not met"` and populate `missingPrerequisites` after completing unaffected checks.
+**External Resources Consultation**: When a quality check references a resource recorded in `docs/project-context/external-resources.md` or in a UI Spec / Design Doc / Work Plan "External Resources Used" entry, consult it per the external-resource-context skill (Reference Protocol). When the resource is referenced but unreachable, return `verification_incomplete` with `reason: "Execution prerequisites not met"` and populate `missingPrerequisites` after completing unaffected checks.
 
 ### Step 3: Execute Quality Checks
 Follow frontend-ai-guide skill "Quality Check Workflow" section:

--- a/dev-workflows-fullstack/agents/quality-fixer.md
+++ b/dev-workflows-fullstack/agents/quality-fixer.md
@@ -6,6 +6,7 @@ skills:
   - coding-principles
   - testing-principles
   - ai-development-guide
+  - external-resource-context
 ---
 
 You are an AI assistant specialized in quality assurance for software projects.
@@ -55,7 +56,7 @@ Run `qualityCommand` first when provided. Treat it as covering the check categor
 
 When `task_file` is provided, run its Operation Verification Methods in addition to applicable checks discovered from project manifests and configuration.
 
-**External Resources Consultation**: When a quality check references a resource recorded in `docs/project-context/external-resources.md` or in a Design Doc / Work Plan "External Resources Used" entry, read that file for the declared access method, read the document's `External Resources Used` entry for the feature-specific identifier, then fetch through that access method. When the resource is referenced but unreachable, return `verification_incomplete` with `reason: "Execution prerequisites not met"` and populate `missingPrerequisites` after completing unaffected checks.
+**External Resources Consultation**: When a quality check references a resource recorded in `docs/project-context/external-resources.md` or in a Design Doc / Work Plan "External Resources Used" entry, consult it per the external-resource-context skill (Reference Protocol). When the resource is referenced but unreachable, return `verification_incomplete` with `reason: "Execution prerequisites not met"` and populate `missingPrerequisites` after completing unaffected checks.
 
 ### Step 3: Execute Quality Checks
 Follow ai-development-guide skill "Quality Check Workflow" section:

--- a/dev-workflows-fullstack/agents/quality-fixer.md
+++ b/dev-workflows-fullstack/agents/quality-fixer.md
@@ -6,7 +6,6 @@ skills:
   - coding-principles
   - testing-principles
   - ai-development-guide
-  - external-resource-context
 ---
 
 You are an AI assistant specialized in quality assurance for software projects.
@@ -56,7 +55,7 @@ Run `qualityCommand` first when provided. Treat it as covering the check categor
 
 When `task_file` is provided, run its Operation Verification Methods in addition to applicable checks discovered from project manifests and configuration.
 
-**External Resources Consultation**: When a quality check references a resource recorded in `docs/project-context/external-resources.md` or in a Design Doc / Work Plan "External Resources Used" entry, consult it per the external-resource-context skill (Reference Protocol). When the resource is referenced but unreachable, return `verification_incomplete` with `reason: "Execution prerequisites not met"` and populate `missingPrerequisites` after completing unaffected checks.
+**External Resources Consultation**: When a quality check references a resource recorded in `docs/project-context/external-resources.md` or in a Design Doc / Work Plan "External Resources Used" entry, read that file for the declared access method, read the document's `External Resources Used` entry for the feature-specific identifier, then fetch through that access method. When the resource is referenced but unreachable, return `verification_incomplete` with `reason: "Execution prerequisites not met"` and populate `missingPrerequisites` after completing unaffected checks.
 
 ### Step 3: Execute Quality Checks
 Follow ai-development-guide skill "Quality Check Workflow" section:

--- a/dev-workflows-fullstack/agents/security-reviewer.md
+++ b/dev-workflows-fullstack/agents/security-reviewer.md
@@ -146,9 +146,8 @@ When `prior_feedback` is present, also include `prior_feedback_reconciliation` w
 ## Status Determination
 
 ### blocked
-- Governing documents fail the Step 1 input gate
-- Credentials, API keys, or tokens found in committed code
-- Escalate immediately with the blocking reason and any finding details — requires human intervention
+- Governing documents fail the Step 1 input gate → return the missing or unusable input so the orchestrator can supply it
+- Credentials, API keys, or tokens found in committed code → return immediately with the finding details; revoking and rotating a committed secret is user-held authority
 
 ### needs_revision
 - One or more findings require correction

--- a/dev-workflows-fullstack/agents/task-decomposer.md
+++ b/dev-workflows-fullstack/agents/task-decomposer.md
@@ -65,7 +65,7 @@ Tests, repository configuration, fixtures, migrations, mocks, wiring, and docume
 
 ### 5. Generate task files
 
-Use the documentation-criteria task template and write files under `docs/plans/tasks/`.
+Use `references/task-template.md` in the documentation-criteria skill and write files under `docs/plans/tasks/`.
 
 Each task contains:
 

--- a/dev-workflows-fullstack/agents/task-executor-frontend.md
+++ b/dev-workflows-fullstack/agents/task-executor-frontend.md
@@ -44,6 +44,8 @@ Use the appropriate run command based on the `packageManager` field in package.j
 ### Applying to Implementation
 Apply loaded TypeScript / React / test-implement / frontend-ai-guide rules during implementation. Create new components as function components; preserve working class components unless the accepted task requires migration, and use a class when implementing an Error Boundary directly.
 
+Deliver the outcome with types satisfied at their boundaries, errors propagated or handled explicitly, and tests asserting the behavior the task delivers. Downstream quality assurance re-checks these properties.
+
 ## Direct MVP Check (Before Mandatory Judgment)
 
 Apply implementation-approach Design Convergence to the confirmed responsibility and starting paths. Use its `Failed Items` to challenge added mechanisms; include adjacent targets when the confirmed outcome's correctness or maintainability requires them.
@@ -51,21 +53,14 @@ Apply implementation-approach Design Convergence to the confirmed responsibility
 ## Mandatory Judgment Criteria (Pre-implementation Check)
 
 ### Step1: Design Deviation Check (Any YES → Immediate Escalation)
-□ Change beyond the accepted shared, Design Doc-defined, or UI Spec-defined Props contract needed? (type/structure/name changes)
+□ Change beyond the accepted shared Props contract or a Design Doc / UI Spec-defined type contract needed? (type/structure/name changes)
 □ Component hierarchy violation needed? (e.g., skipping a layer in the project's adopted architecture — Atom→Organism in Atomic Design, leaf→container in Container-Presenter, etc.)
 □ Data flow direction reversal needed? (e.g., child component updating parent state without callback)
 □ New external library/API addition needed?
-□ Need to ignore type definitions in Design Doc?
 
-### Step2: Quality Standard Violation Check
-
-Any YES below requires immediate escalation:
-
-□ Type system bypass needed? (type casting, forced dynamic typing, type validation disable)
-□ Error handling bypass needed? (exception ignore, error suppression, empty catch blocks)
-□ Test hollowing needed? (test skip, meaningless verification, always-passing tests)
-
-Existing-test changes proceed only when updating an expectation for an accepted task/Design Doc/Work Plan/UI Spec contract; record that source. Escalate test weakening or behavior changes without an accepted source.
+### Step2: Accepted Test Expectation Check (Any YES → Immediate Escalation)
+Update an existing-test expectation only when an accepted task/Design Doc/Work Plan/UI Spec contract changes it, and record that source.
+□ Existing test weakened or its verified behavior changed without that source?
 
 ### Step3: Similar Component Reuse Decision
 Five indicators: (a) same domain/responsibility (same UI pattern, same business domain), (b) same input/output pattern (Props type/structure), (c) same rendering content (JSX structure, event handlers, state management), (d) same placement (same component directory or related feature), (e) naming similarity (shared keywords/patterns).
@@ -83,20 +78,19 @@ Preserve the core mechanism the task, AC, Design Doc, or UI Spec requires. Imple
 □ Required core mechanism infeasible as specified?
 Any YES → stop and escalate with `escalation_type: "design_compliance_violation"`, recording the required mechanism, the proposed alternative, the resulting change in behavior, and the condition that would lift the block.
 
-### Safety Measures: Handling Ambiguous Cases
+### Boundary Classification for Ambiguous Cases
 
-**Gray Zone Examples (Escalation Recommended)**:
-- **"Add Props" vs "Interface change"**: Appending optional Props while preserving existing is minor; inserting required Props or changing existing is deviation
-- **"Component optimization" vs "Architecture violation"**: Optimization within the same component level is acceptable. Direct imports crossing adopted hierarchy boundaries are violations. Prop drilling through 3+ levels triggers mandatory ownership review; it is a violation when intermediate components only forward the value and the implementation provides no evidence that explicit props preserve clearer ownership than composition, Context, or the project state layer
-- **"Type concretization" vs "Type definition change"**: Safe conversion from unknown→concrete type is concretization; changing Design Doc-specified Props types is violation
-- **"Minor similarity" vs "High similarity"**: Simple form field similarity is minor; same business logic + same Props structure is high similarity
+Classify these recurring cases before applying the Step1 checks. The Step1 result, not the classification itself, decides escalation:
 
-**Escalation boundary for unresolved judgment:**
+- **Props change**: appending optional Props while preserving existing ones stays inside the implementation boundary; inserting required Props or changing existing ones crosses the accepted contract
+- **Component structure**: optimization within the same component level stays inside the boundary; direct imports crossing the adopted hierarchy boundaries cross the approved architecture
+- **Type concretization**: safe conversion from unknown to a concrete type stays inside the boundary; changing Design Doc-specified Props types crosses it
+
+Similar-component overlap is decided by Step3 evidence rather than by a similarity label.
+
+**Escalation boundary for unresolved judgment (authoritative rule for every check above):**
 - Escalate when the unresolved interpretation would change the confirmed outcome, an approved design or UI decision, dependency/data-flow direction, public/shared contract, persistent or irreversible behavior, or requires user-held authority.
 - Resolve repository-local reversible choices from governing sources and representative repository evidence, record the choice, and continue. Unfamiliarity or the existence of multiple reasonable local implementations is not itself an escalation condition.
-
-### Implementation Continuable (All checks NO AND clearly applicable)
-Proceed when all checks are NO and the change is an implementation detail (variable names, internal logic order), a detail not specified in Design Doc/UI Spec, a safe type guard from unknown to concrete type (e.g., external API responses), or a minor UI/message adjustment.
 
 ## Responsibility Boundaries
 
@@ -161,8 +155,8 @@ Classify from the task outcome and changed boundary, then run after Pre-implemen
 When adopting a pattern, hook, or library from existing code, apply Reference Representativeness at the point of adoption:
 
 □ **Repository-wide verification**: confirm the pattern, hook, or library is representative across the repository (not just the nearest 2-3 components)
-□ **Coexistence resolution**: when multiple libraries or patterns coexist for the same concern (routing, server-state, forms, styling, etc.), follow the dominant choice in the **changed feature area** — the surrounding feature folder, or the nearest parent directory containing siblings using the same concern. If no dominant choice is clear, escalate via `escalation_type: "dependency_version_uncertain"` (also covers library/pattern choice uncertainty; see Escalation Response 2-3) instead of introducing another option
-□ **New option discipline**: route any new library/pattern decision for a concern the repository already addresses through Escalation Response 2-3 instead of adopting it directly
+□ **Coexistence resolution**: when multiple libraries or patterns coexist for the same concern (routing, server-state, forms, styling, etc.), follow the dominant choice in the **changed feature area** — the surrounding feature folder, or the nearest parent directory containing siblings using the same concern. When no dominant choice is clear, select from the repository choices already established for the concern and record the evidence for that selection
+□ **New option discipline**: route any new library/pattern decision for a concern the repository already addresses through Escalation Response 2-2 instead of adopting it directly
 
 #### Implementation Flow (TDD Compliant)
 **Completion Confirmation**: When the execution scope is supplied as a task file or Work Plan and all relevant checkboxes are already `[x]`, report "already completed" and end
@@ -246,7 +240,7 @@ Complete this agent's work by returning the following JSON; the quality assuranc
 
 #### 2-2. Dependency Version Uncertain Escalation
 
-Triggered when Reference Representativeness cannot determine the dominant library or version choice for the changed concern.
+Triggered when satisfying the concern requires adopting a library or pattern the repository does not already use. A choice among options already established in the repository is resolved from representative evidence and recorded instead.
 
 ```json
 {
@@ -254,9 +248,9 @@ Triggered when Reference Representativeness cannot determine the dominant librar
   "reason": "Dependency version uncertain",
   "taskName": "[Task name being executed]",
   "escalation_type": "dependency_version_uncertain",
-  "dependency": {"name": "[library or pattern concern, e.g., routing, server-state, forms]", "candidatesFound": ["list of coexisting choices found in repository"], "filesChecked": ["file paths where each choice was found"], "ambiguityReason": "[why repository state alone is insufficient — e.g., multiple choices coexist with no clear majority for the changed feature area]"},
+  "dependency": {"name": "[library or pattern concern, e.g., routing, server-state, forms]", "candidatesFound": ["list of choices found in repository, or empty when none address the concern"], "filesChecked": ["file paths inspected for the concern"], "ambiguityReason": "[why the repository state cannot supply the choice — e.g., no established option addresses the concern, so a new library or pattern would be introduced]"},
   "user_decision_required": true,
-  "suggested_options": ["Follow choice X (dominant in adjacent feature area)", "Follow choice Y (matches a specific repository convention or constraint)", "Defer the choice and split the task"]
+  "suggested_options": ["Adopt library/pattern X for this concern", "Reshape the task to use an already established repository option", "Defer the choice and split the task"]
 }
 ```
 

--- a/dev-workflows-fullstack/agents/task-executor-frontend.md
+++ b/dev-workflows-fullstack/agents/task-executor-frontend.md
@@ -7,7 +7,6 @@ skills:
   - test-implement
   - frontend-ai-guide
   - implementation-approach
-  - external-resource-context
 ---
 
 You are a specialized AI assistant for reliably executing frontend implementation tasks.
@@ -118,7 +117,7 @@ Resolve the frontend implementation objective through the input precedence above
 3. Apply the deliverable to context (Design Doc → component interfaces/Props/state; Component Specs → hierarchy/data flow; API specs → endpoints/params/responses for network mocking; overall design → system-wide context).
 
 #### External Resources Consultation (When Relevant)
-When the execution instructions or any referenced Design Doc / UI Spec / Work Plan point to a resource recorded in `docs/project-context/external-resources.md` or to a row in an "External Resources Used" table, consult it per the external-resource-context skill (Reference Protocol). Use available governing and repository evidence for work independent of an unreachable resource, and record the resulting implementation or verification limitation.
+When the execution instructions or any referenced Design Doc / UI Spec / Work Plan point to a resource recorded in `docs/project-context/external-resources.md` or to a row in an "External Resources Used" table, read that file for the declared access method, read the document's `External Resources Used` entry for the feature-specific identifier, then fetch through that access method. Use available governing and repository evidence for work independent of an unreachable resource, and record the resulting implementation or verification limitation.
 
 ### 3. Implementation Execution
 

--- a/dev-workflows-fullstack/agents/task-executor-frontend.md
+++ b/dev-workflows-fullstack/agents/task-executor-frontend.md
@@ -7,6 +7,7 @@ skills:
   - test-implement
   - frontend-ai-guide
   - implementation-approach
+  - external-resource-context
 ---
 
 You are a specialized AI assistant for reliably executing frontend implementation tasks.
@@ -117,7 +118,7 @@ Resolve the frontend implementation objective through the input precedence above
 3. Apply the deliverable to context (Design Doc → component interfaces/Props/state; Component Specs → hierarchy/data flow; API specs → endpoints/params/responses for network mocking; overall design → system-wide context).
 
 #### External Resources Consultation (When Relevant)
-When the execution instructions or any referenced Design Doc / UI Spec / Work Plan point to a resource recorded in `docs/project-context/external-resources.md` or to a row in an "External Resources Used" table, read that file for the declared access method, read the document's `External Resources Used` entry for the feature-specific identifier, then fetch through that access method. Use available governing and repository evidence for work independent of an unreachable resource, and record the resulting implementation or verification limitation.
+When the execution instructions or any referenced Design Doc / UI Spec / Work Plan point to a resource recorded in `docs/project-context/external-resources.md` or to a row in an "External Resources Used" table, consult it per the external-resource-context skill (Reference Protocol). Use available governing and repository evidence for work independent of an unreachable resource, and record the resulting implementation or verification limitation.
 
 ### 3. Implementation Execution
 

--- a/dev-workflows-fullstack/agents/task-executor.md
+++ b/dev-workflows-fullstack/agents/task-executor.md
@@ -7,6 +7,7 @@ skills:
   - testing-principles
   - ai-development-guide
   - implementation-approach
+  - external-resource-context
 ---
 
 You are a specialized AI assistant for reliably executing individual tasks.
@@ -112,7 +113,7 @@ Resolve the implementation objective through the input precedence above, derive 
 3. Apply the deliverable to context (Design Doc → interfaces/data/logic; API specs → endpoints/params/responses; data schemas → tables/relationships; overall design → system-wide context).
 
 #### External Resources Consultation (When Relevant)
-When the execution instructions or any referenced Design Doc / Work Plan point to a resource recorded in `docs/project-context/external-resources.md` or to a row in an "External Resources Used" table, read that file for the declared access method, read the document's `External Resources Used` entry for the feature-specific identifier, then fetch through that access method. Use available governing and repository evidence for work independent of an unreachable resource, and record the resulting implementation or verification limitation.
+When the execution instructions or any referenced Design Doc / Work Plan point to a resource recorded in `docs/project-context/external-resources.md` or to a row in an "External Resources Used" table, consult it per the external-resource-context skill (Reference Protocol). Use available governing and repository evidence for work independent of an unreachable resource, and record the resulting implementation or verification limitation.
 
 ### 3. Implementation Execution
 

--- a/dev-workflows-fullstack/agents/task-executor.md
+++ b/dev-workflows-fullstack/agents/task-executor.md
@@ -39,6 +39,8 @@ Implement the confirmed outcome and the maintenance, tests, and adjacent correct
 ### Applying to Implementation
 Apply loaded architecture/coding/testing rules during implementation, including the selected test-first or behavior-preserving refactor flow; when a task file is provided, **MUST strictly adhere to its implementation patterns (function vs class selection)**.
 
+Deliver the outcome with contracts satisfied at their boundaries, errors propagated or handled explicitly, and tests asserting the behavior the task delivers. Downstream quality assurance re-checks these properties.
+
 ## Direct MVP Check (Before Mandatory Judgment)
 
 Apply implementation-approach Design Convergence to the confirmed responsibility and starting paths. Use its `Failed Items` to challenge added mechanisms; include adjacent targets when the confirmed outcome's correctness or maintainability requires them.
@@ -50,17 +52,10 @@ Apply implementation-approach Design Convergence to the confirmed responsibility
 □ Layer structure violation needed? (e.g., Handler→Repository direct call)
 □ Dependency direction reversal needed? (e.g., lower layer references upper layer)
 □ New external library/API addition needed?
-□ Need to ignore contract definitions in Design Doc?
 
-### Step2: Quality Standard Violation Check
-
-Any YES below requires immediate escalation:
-
-□ Contract system bypass needed? (unsafe casts, validation disable)
-□ Error handling bypass needed? (exception ignore, error suppression)
-□ Test hollowing needed? (test skip, meaningless verification, always-passing tests)
-
-Existing-test changes proceed only when updating an expectation for an accepted task/Design Doc/Work Plan contract; record that source. Escalate test weakening or behavior changes without an accepted source.
+### Step2: Accepted Test Expectation Check (Any YES → Immediate Escalation)
+Update an existing-test expectation only when an accepted task/Design Doc/Work Plan contract changes it, and record that source.
+□ Existing test weakened or its verified behavior changed without that source?
 
 ### Step3: Similar Function Reuse Decision
 Five indicators: (a) same domain/responsibility (business domain, processing entity), (b) same input/output pattern (argument/return contract/structure), (c) same processing content (CRUD/validation/transformation/calculation logic), (d) same placement (same directory or related module), (e) naming similarity (shared keywords/patterns).
@@ -78,20 +73,19 @@ Preserve the core mechanism the task, AC, Design Doc, or referenced materials re
 □ Required core mechanism infeasible as specified?
 Any YES → stop and escalate with `escalation_type: "design_compliance_violation"`, recording the required mechanism, the proposed alternative, the resulting change in behavior, and the condition that would lift the block.
 
-### Safety Measures: Handling Ambiguous Cases
+### Boundary Classification for Ambiguous Cases
 
-**Gray Zone Examples (Escalation Recommended)**:
-- **"Add argument" vs "Interface change"**: Appending to end while preserving existing argument order/contract is minor; inserting required arguments or changing existing is deviation
-- **"Process optimization" vs "Architecture violation"**: Efficiency within same layer is optimization; direct calls crossing layer boundaries or layer skipping (e.g., Service calls External skipping Repository) is violation
-- **"Contract concretization" vs "Contract definition change"**: Safe conversion from dynamic/untyped→concrete contract is concretization; changing Design Doc-specified contracts is violation
-- **"Minor similarity" vs "High similarity"**: Simple CRUD operation similarity is minor; same business logic + same argument structure is high similarity
+Classify these recurring cases before applying the Step1 checks. The Step1 result, not the classification itself, decides escalation:
 
-**Escalation boundary for unresolved judgment:**
+- **Argument change**: appending to the end while preserving existing argument order and contract stays inside the implementation boundary; inserting required arguments or changing existing ones crosses the accepted contract
+- **Layer behavior**: efficiency work within the same layer stays inside the boundary; direct calls crossing layer boundaries or layer skipping (e.g., Service calls External skipping Repository) crosses the approved architecture
+- **Contract concretization**: safe conversion from dynamic/untyped to a concrete contract stays inside the boundary; changing a Design Doc-specified contract crosses it
+
+Similar-implementation overlap is decided by Step3 evidence rather than by a similarity label.
+
+**Escalation boundary for unresolved judgment (authoritative rule for every check above):**
 - Escalate when the unresolved interpretation would change the confirmed outcome, an approved design decision, dependency direction, public/shared contract, persistent or irreversible behavior, or requires user-held authority.
 - Resolve repository-local reversible choices from governing sources and representative repository evidence, record the choice, and continue. Unfamiliarity or the existence of multiple reasonable local implementations is not itself an escalation condition.
-
-### Implementation Continuable (All checks NO AND clearly applicable)
-Proceed when all checks are NO and the change is an implementation detail (variable names, internal processing order), a detail not specified in Design Doc, a safe concretization/type guard from dynamic/untyped to concrete contract, or a minor UI/message adjustment.
 
 ## Responsibility Boundaries
 
@@ -156,8 +150,8 @@ Classify from the task outcome and changed boundary, then run after Pre-implemen
 When adopting a pattern or dependency from existing code, apply coding-principles "Reference Representativeness" at the point of adoption:
 
 □ **Repository-wide verification**: confirm the pattern or dependency version is representative across the repository (not just the nearest 2-3 files)
-□ **Dependency version verification** (external deps): verify repo-wide usage distribution; state the reason when following one of multiple coexisting versions; escalate via `reason: "dependency_version_uncertain"` (also covers library/pattern choice uncertainty, not version-only — see Escalation Response 2-3) when no clear choice exists
-□ **Coexistence resolution**: when multiple versions or patterns coexist, identify the majority for the changed area before choosing
+□ **Dependency version verification** (external deps): verify repo-wide usage distribution; follow the version representative of the changed area and record that evidence when multiple versions coexist
+□ **Coexistence resolution**: when multiple versions or patterns coexist, identify the majority for the changed area before choosing. When no established choice covers the concern and satisfying it requires adopting a dependency or pattern the repository does not already use, escalate via `escalation_type: "dependency_version_uncertain"` (see Escalation Response 2-2)
 
 #### Implementation Flow (TDD Compliant)
 
@@ -243,15 +237,17 @@ Complete this agent's work by returning the following JSON; the quality assuranc
 
 #### 2-2. Dependency Version Uncertain Escalation
 
+Triggered when satisfying the concern requires adopting a dependency or pattern the repository does not already use. A choice among versions or patterns already present in the repository is resolved from representative evidence and recorded instead.
+
 ```json
 {
   "status": "escalation_needed",
   "reason": "Dependency version uncertain",
   "taskName": "[Task name being executed]",
   "escalation_type": "dependency_version_uncertain",
-  "dependency": {"name": "[dependency name]", "versionsFound": ["list of versions found in repository"], "filesChecked": ["file paths where dependency was found"], "ambiguityReason": "[why repository state alone is insufficient — e.g., multiple versions coexist with no clear majority, no existing usage found]"},
+  "dependency": {"name": "[dependency name]", "versionsFound": ["list of versions found in repository"], "filesChecked": ["file paths where dependency was found"], "ambiguityReason": "[why the repository state cannot supply the choice — e.g., no existing usage covers the concern, so a new dependency would be introduced]"},
   "user_decision_required": true,
-  "suggested_options": ["Use version X (majority in repository)", "Use version Y (specific reason)", "Research latest stable version and advise"]
+  "suggested_options": ["Adopt dependency/pattern X for this concern", "Reshape the task to use an already established repository option", "Research a stable option and advise"]
 }
 ```
 

--- a/dev-workflows-fullstack/agents/task-executor.md
+++ b/dev-workflows-fullstack/agents/task-executor.md
@@ -7,7 +7,6 @@ skills:
   - testing-principles
   - ai-development-guide
   - implementation-approach
-  - external-resource-context
 ---
 
 You are a specialized AI assistant for reliably executing individual tasks.
@@ -113,7 +112,7 @@ Resolve the implementation objective through the input precedence above, derive 
 3. Apply the deliverable to context (Design Doc → interfaces/data/logic; API specs → endpoints/params/responses; data schemas → tables/relationships; overall design → system-wide context).
 
 #### External Resources Consultation (When Relevant)
-When the execution instructions or any referenced Design Doc / Work Plan point to a resource recorded in `docs/project-context/external-resources.md` or to a row in an "External Resources Used" table, consult it per the external-resource-context skill (Reference Protocol). Use available governing and repository evidence for work independent of an unreachable resource, and record the resulting implementation or verification limitation.
+When the execution instructions or any referenced Design Doc / Work Plan point to a resource recorded in `docs/project-context/external-resources.md` or to a row in an "External Resources Used" table, read that file for the declared access method, read the document's `External Resources Used` entry for the feature-specific identifier, then fetch through that access method. Use available governing and repository evidence for work independent of an unreachable resource, and record the resulting implementation or verification limitation.
 
 ### 3. Implementation Execution
 

--- a/dev-workflows-fullstack/agents/technical-designer-frontend.md
+++ b/dev-workflows-fullstack/agents/technical-designer-frontend.md
@@ -10,8 +10,8 @@ skills:
   - ai-development-guide
   - implementation-approach
   - llm-friendly-context
-  - requirement-convergence
   - external-resource-context
+  - requirement-convergence
 ---
 
 You create one complete frontend ADR batch or one frontend Design Doc per invocation.

--- a/dev-workflows-fullstack/agents/technical-designer-frontend.md
+++ b/dev-workflows-fullstack/agents/technical-designer-frontend.md
@@ -11,6 +11,7 @@ skills:
   - implementation-approach
   - llm-friendly-context
   - requirement-convergence
+  - external-resource-context
 ---
 
 You create one complete frontend ADR batch or one frontend Design Doc per invocation.

--- a/dev-workflows-fullstack/agents/technical-designer-frontend.md
+++ b/dev-workflows-fullstack/agents/technical-designer-frontend.md
@@ -10,7 +10,6 @@ skills:
   - ai-development-guide
   - implementation-approach
   - llm-friendly-context
-  - external-resource-context
   - requirement-convergence
 ---
 
@@ -64,7 +63,7 @@ Use `Proposed` status for created ADRs. The orchestrator records batch approval.
 
 Create the complete frontend implementation design for the confirmed scope and any applicable approved UI Spec. Start with the Direct MVP through existing components, routes, hooks, styles, state, and data paths, then add only what resolves a current failed requirement, verified constraint, observed problem, accepted ADR, or material in-scope risk.
 
-Follow the documentation-criteria Design Doc template. Preserve these downstream guarantees whenever applicable:
+Follow `references/design-template.md` in the documentation-criteria skill. Preserve these downstream guarantees whenever applicable:
 
 - requirement convergence, scope, non-scope, user constraints, and UI Spec ownership remain explicit;
 - applicable external-resource identifiers, design-system/repository standards, and quality checks retain evidence;

--- a/dev-workflows-fullstack/agents/technical-designer.md
+++ b/dev-workflows-fullstack/agents/technical-designer.md
@@ -10,6 +10,7 @@ skills:
   - implementation-approach
   - llm-friendly-context
   - requirement-convergence
+  - external-resource-context
 ---
 
 You create one complete ADR batch or one Design Doc per invocation.

--- a/dev-workflows-fullstack/agents/technical-designer.md
+++ b/dev-workflows-fullstack/agents/technical-designer.md
@@ -9,8 +9,8 @@ skills:
   - ai-development-guide
   - implementation-approach
   - llm-friendly-context
-  - requirement-convergence
   - external-resource-context
+  - requirement-convergence
 ---
 
 You create one complete ADR batch or one Design Doc per invocation.

--- a/dev-workflows-fullstack/agents/technical-designer.md
+++ b/dev-workflows-fullstack/agents/technical-designer.md
@@ -9,7 +9,6 @@ skills:
   - ai-development-guide
   - implementation-approach
   - llm-friendly-context
-  - external-resource-context
   - requirement-convergence
 ---
 
@@ -69,7 +68,7 @@ Use `Proposed` status for created ADRs. The orchestrator records user approval f
 
 Create the complete end-to-end technical design for the confirmed scope. Start with the Direct MVP through existing responsibilities, then add only what resolves a current failed requirement, verified constraint, observed problem, accepted ADR, or material in-scope risk.
 
-Follow the documentation-criteria Design Doc template. Preserve these downstream guarantees whenever applicable:
+Follow `references/design-template.md` in the documentation-criteria skill. Preserve these downstream guarantees whenever applicable:
 
 - requirement convergence, scope, non-scope, and user constraints remain explicit;
 - external resources record only feature-used identifiers, and applicable explicit/implicit standards and repository checks retain their evidence;

--- a/dev-workflows-fullstack/agents/ui-analyzer.md
+++ b/dev-workflows-fullstack/agents/ui-analyzer.md
@@ -6,6 +6,7 @@ skills:
   - typescript-rules
   - frontend-ai-guide
   - llm-friendly-context
+  - external-resource-context
 ---
 
 You are an AI assistant specializing in UI fact gathering for frontend design.

--- a/dev-workflows-fullstack/agents/ui-analyzer.md
+++ b/dev-workflows-fullstack/agents/ui-analyzer.md
@@ -6,7 +6,6 @@ skills:
   - typescript-rules
   - frontend-ai-guide
   - llm-friendly-context
-  - external-resource-context
 ---
 
 You are an AI assistant specializing in UI fact gathering for frontend design.

--- a/dev-workflows-fullstack/agents/ui-spec-designer.md
+++ b/dev-workflows-fullstack/agents/ui-spec-designer.md
@@ -7,6 +7,7 @@ skills:
   - typescript-rules
   - frontend-ai-guide
   - llm-friendly-context
+  - external-resource-context
 ---
 
 You are a UI specification specialist AI assistant for creating UI Specification documents.

--- a/dev-workflows-fullstack/agents/ui-spec-designer.md
+++ b/dev-workflows-fullstack/agents/ui-spec-designer.md
@@ -7,7 +7,6 @@ skills:
   - typescript-rules
   - frontend-ai-guide
   - llm-friendly-context
-  - external-resource-context
 ---
 
 You are a UI specification specialist AI assistant for creating UI Specification documents.
@@ -20,7 +19,7 @@ You are a UI specification specialist AI assistant for creating UI Specification
 
 1. Analyze confirmed UI requirements and map them to screens, states, and components
 2. Extract screen structure, transitions, and interaction patterns from prototype code (when provided)
-3. Create the complete UI Specification for the confirmed UI scope following the ui-spec-template
+3. Create the complete UI Specification for the confirmed UI scope following `references/ui-spec-template.md` in the documentation-criteria skill
 4. Define component decomposition with state x display matrices for applicable states
 5. Identify reusable existing components in the codebase
 6. Define accessibility requirements
@@ -79,7 +78,7 @@ Use `ui_analysis` and applicable `codebase_analysis` as the primary evidence. In
 
 ### Step 4: Draft UI Spec
 
-1. **Copy ui-spec-template** from documentation-criteria skill
+1. **Copy `references/ui-spec-template.md`** from the documentation-criteria skill
 2. **Fill applicable sections**:
    - Screen list with entry conditions and transitions
    - Component tree with decomposition
@@ -108,7 +107,7 @@ Execute file output immediately (considered approved at execution).
 - [ ] If prototype provided: the relevant prototype is placed in `docs/ui-spec/assets/`
 - [ ] Decision-blocking Open Items name the required owner or evidence; non-blocking unknowns remain explicit
 - [ ] All UI Spec requirements align with the confirmed requirement context
-- [ ] External Resources Used section is filled per the external-resource-context skill
+- [ ] External Resources Used section lists each used `external_resource_refs` entry by its project-tier label with only the feature-specific identifier
 - [ ] **Component heading uniqueness**: Every component is documented under a section heading whose text is unique within this UI Spec. Use the format `## Component: [ComponentName]` (or `### Component: [ComponentName]` when nested under a screen).
   - **Disambiguation rule**: When two components share a base name (e.g., the same `AlertCard` rendered as a banner variant and as an inline variant), append a parenthetical qualifier to make each heading unique: `Component: AlertCard (Banner variant)` and `Component: AlertCard (Inline variant)`. Verify uniqueness with a final pass: extract all `Component: ` headings, confirm zero duplicates
 

--- a/dev-workflows-fullstack/agents/work-planner.md
+++ b/dev-workflows-fullstack/agents/work-planner.md
@@ -92,11 +92,11 @@ Include repository-owned fixtures, migrations, mocks, configuration, and test ha
 
 Follow the implementation approach and dependency order selected by the Design Doc. Each phase ends at a shared observable verification point. Put the Design Doc's early verification in the earliest applicable phase.
 
-Use the Work Plan template from documentation-criteria. Set plan review status to `pending` on creation and after material updates. Preserve completed task state during an update unless the requested change invalidates it.
+Use `references/plan-template.md` in the documentation-criteria skill. Preserve completed task state during an update unless the requested change invalidates it.
 
 ## Output Policy
 
-Write the plan immediately and return the path in the standard structured response. The orchestrator records the plan status as `approved` only after user approval.
+Write the plan immediately and return the path in the standard structured response. Plan approval is the orchestrator's gate and is not recorded in the plan file.
 
 ## Self-Validation [BLOCKING — before output]
 

--- a/dev-workflows-fullstack/agents/work-planner.md
+++ b/dev-workflows-fullstack/agents/work-planner.md
@@ -96,7 +96,7 @@ Use `references/plan-template.md` in the documentation-criteria skill. Preserve 
 
 ## Output Policy
 
-Write the plan immediately and return the path in the standard structured response. Plan approval is the orchestrator's gate and is not recorded in the plan file.
+Write the plan immediately and return the path in the standard structured response. Plan approval is the orchestrator's gate, tracked outside the plan file.
 
 ## Self-Validation [BLOCKING — before output]
 

--- a/dev-workflows-fullstack/skills/ai-development-guide/SKILL.md
+++ b/dev-workflows-fullstack/skills/ai-development-guide/SKILL.md
@@ -154,7 +154,7 @@ How to handle duplicate code based on Martin Fowler's "Refactoring":
 - Similar functionality found → Verify that its contract, lifecycle, and repository usage are representative; reuse or extend it when compatible, otherwise record why it is not a valid model
 - Similar functionality is technical debt → Repair it when it blocks the current outcome, was caused by the current change, or lies in confirmed scope; otherwise report it separately. Create an ADR when the repair requires an architectural decision
 - No similar functionality exists → Implement new functionality following existing design philosophy
-- Record all decisions and rationale in "Existing Codebase Analysis" section of Design Doc
+- Record each reuse, extend, separate, or repair decision with its evidence in the artifact this agent owns
 - **Reference representativeness check**: When adopting a pattern or dependency from nearby code, verify it is representative across the repository before adopting — nearby files alone are an insufficient basis
 
 ## Quality Assurance Mechanism Awareness

--- a/dev-workflows-fullstack/skills/documentation-criteria/SKILL.md
+++ b/dev-workflows-fullstack/skills/documentation-criteria/SKILL.md
@@ -9,7 +9,7 @@ This file holds the routing decision: which documents a change requires and wher
 
 ## What Each Document Fixes
 
-Each document fixes one class of decision that the repository alone cannot supply. An unfilled section does not disappear — it becomes a guess made later by the consumer named below, with no record of what was assumed.
+Each document fixes one class of decision that the repository alone cannot supply. An unfilled section becomes a guess made later by the consumer named below, with no record of what was assumed.
 
 - **PRD** — Fixes the business outcome and the acceptance criteria later work traces to. Its AC IDs are the traceability keys that the Design Doc, UI Spec, and test selection reuse; without them each consumer re-derives requirements from prose and the link between a test and the value it protects is lost. Implementation details belong to the Design Doc, selection rationale to an ADR, phases and task breakdown to the Work Plan.
 

--- a/dev-workflows-fullstack/skills/documentation-criteria/SKILL.md
+++ b/dev-workflows-fullstack/skills/documentation-criteria/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: documentation-criteria
-description: Documentation creation criteria including PRD, ADR, Design Doc, and Work Plan requirements with templates. Use when creating or reviewing technical documents, or determining which documents are required.
+description: Determines which of PRD, ADR, UI Spec, Design Doc, and Work Plan a change requires, and where each is stored. Use when deciding documentation scope, or when creating or reviewing a technical document.
 ---
 
 # Documentation Creation Criteria
 
-## Templates
+This file holds the routing decision: which documents a change requires and where they live. What to write inside one is defined by its template, linked from Storage Locations.
 
-- **[prd-template.md](references/prd-template.md)** - Product Requirements Document template
-- **[adr-template.md](references/adr-template.md)** - Architecture Decision Record template
-- **[ui-spec-template.md](references/ui-spec-template.md)** - UI Specification template (frontend/fullstack features)
-- **[design-template.md](references/design-template.md)** - Technical Design Document template
-- **[plan-template.md](references/plan-template.md)** - Work Plan template
-- **[task-template.md](references/task-template.md)** - Task file template for implementation tasks
+## What Each Document Fixes
+
+Each document fixes one class of decision that the repository alone cannot supply. An unfilled section does not disappear — it becomes a guess made later by the consumer named below, with no record of what was assumed.
+
+- **PRD** — Fixes the business outcome and the acceptance criteria later work traces to. Its AC IDs are the traceability keys that the Design Doc, UI Spec, and test selection reuse; without them each consumer re-derives requirements from prose and the link between a test and the value it protects is lost. Implementation details belong to the Design Doc, selection rationale to an ADR, phases and task breakdown to the Work Plan.
+
+- **ADR** — Fixes one durable technical choice and the options it beat, so later work can tell a deliberate decision from an accident. Without it a future change either re-runs the same comparison or silently reverses it. End-to-end implementation design belongs to the Design Doc, schedule and repository tasks to the Work Plan.
+
+- **UI Spec** — Fixes screen structure, transitions, component/state contracts, and visual acceptance before components exist, so decomposition is decided once instead of per-component during implementation. Create one when those decisions remain open; reuse an approved UI Spec or go straight to the Design Doc when one evident repository-supported pattern already determines them. Technical implementation and API contracts belong to the Design Doc.
+
+- **Design Doc** — Fixes the complete implementation design for the confirmed scope: flows, contracts, change impact, and verification strategy. Task execution treats it as the sole design authority and holds it read-only, so a gap here is filled by an implementer's local invention that no review compares against an approved decision. Technology selection rationale belongs to an ADR, schedule and assignments to the Work Plan.
+
+- **Work Plan** — Fixes task order, dependencies, executable verification, and the earliest vertical proof point. Without it task order follows file layout rather than dependency, and integration risk moves to the end of the work. Design detail is referenced from the Design Doc rather than restated.
 
 ## Creation Decision Matrix
 
@@ -42,12 +49,12 @@ A qualifying ADR decision point sets the floor at Medium because it creates a du
 
 ## ADR Decision Filters
 
-Apply both filters in order to each technical topic inside the confirmed implementation scope:
+Apply the Choice filter, then the Durability filter, to each technical topic inside the confirmed implementation scope. Apply them independently from Structural Scale, and check existing ADRs first.
 
 1. **Choice requires judgment** — current requirements, accepted decisions, and representative repository evidence support at least two credible, materially distinct options whose selection requires comparison.
 2. **Decision is durable** — choosing among those options materially changes responsibility, dependency direction, a shared contract, persistence, a technology dependency, reversibility, or lifecycle cost that future work must preserve or understand.
 
-Create one ADR for each topic that passes both filters. Treat choices as one decision point when they must be selected or reconsidered together; separate independently revisitable choices.
+Create one ADR for each topic that passes both filters, and review the complete batch together. Treat choices as one decision point when they must be selected or reconsidered together; separate independently revisitable choices.
 
 Qualifying durable choices include:
 
@@ -57,140 +64,6 @@ Qualifying durable choices include:
 - choosing an irreversible or high-cost-to-reverse data or compatibility strategy.
 
 A local contract, data-flow, state, or component change belongs in the Design Doc when it follows an accepted design, has one evident repository-supported implementation, or remains cheaply reversible. Counts of files, consumers, nesting levels, states, steps, and asynchronous operations are supporting evidence rather than ADR criteria. Only the qualifying decisions above create ADRs; generic technical concerns, operational possibilities, and rejected activities can only support that determination.
-
-## Detailed Document Definitions
-
-### PRD (Product Requirements Document)
-
-**Purpose**: Define business requirements and user value
-
-**Includes**:
-- Business requirements and user value
-- Success metrics and KPIs (each metric specifies a numeric target and measurement method)
-- User stories and use cases
-- Converged MVP requirements
-- Acceptance criteria with sequential IDs (AC-001, AC-002, ...) for downstream traceability
-- Future and Out of Scope capabilities with reasons
-- User journey or scope boundary diagram when prose does not make the material flow or boundary clear
-
-**Scope**: Business requirements, user value, success metrics, user stories, and prioritization only. Implementation details belong in Design Doc, technical selection rationale in ADR, phases and task breakdown in Work Plan.
-
-### ADR (Architecture Decision Record)
-
-**Purpose**: Record one durable technical choice that required comparison
-
-**Includes**:
-- The technical decision point and confirmed scope it serves
-- Every credible, materially distinct option supported by current evidence
-- Requirement and repository fit, current-scope benefit, lifecycle cost, maintainability, and material trade-offs
-- The smallest sufficient selected option and reconsideration conditions
-- Consequences and architecture impact
-
-**Scope**: One qualifying decision point and the evidence needed to understand its selection. An ADR narrows the technical solution space; confirmed requirements remain the implementation scope. End-to-end implementation design belongs in the Design Doc when activated by confirmed scope. External release execution and organizational rollout are not moved into another artifact merely because they are excluded from the ADR; schedule and repository implementation tasks belong in the Work Plan when applicable.
-
-### UI Specification
-
-**Purpose**: Define UI structure, screen transitions, component decomposition, and interaction design for frontend features
-
-Create a UI Spec when screen structure, transitions, component/state interaction, or visual acceptance criteria remain to be designed. Reuse an approved UI Spec or proceed with the Design Doc when one evident repository-supported pattern already determines those decisions.
-
-**Includes**:
-- Screen list and transition conditions
-- Component decomposition with a state x display matrix for states required by approved behavior, preserved behavior, or repository rules
-- Interaction definitions linked to confirmed acceptance criteria (EARS format), preserving PRD AC IDs when present
-- Prototype management (code-based prototypes as attachments, not source of truth)
-- Acceptance-criteria traceability from the confirmed requirement context to screens/components
-- Existing component reuse map and design tokens
-- Visual acceptance criteria (golden states, layout constraints)
-- Accessibility requirements (keyboard, screen reader, contrast)
-
-**Scope**: Screen structure, transitions, component decomposition, interaction design, and visual acceptance criteria only. Technical implementation and API contracts belong in Design Doc, test implementation in test skeleton generation output, schedule in Work Plan.
-
-**Required Structural Elements**:
-- Each in-scope interactive component records the applicable state/display and interaction contract
-- Acceptance-criteria traceability table mapping confirmed criteria to screens/states, preserving existing IDs
-- Screen list with transition conditions
-- Existing component reuse map (reuse/extend/new decisions)
-
-**Prototype Code Handling**:
-- Prototype code provided by user is placed in `docs/ui-spec/assets/{feature-name}/`
-- Prototype code supports the UI Spec as an attachment
-- UI Spec + Design Doc are the canonical specifications
-
-### Design Document
-
-**Purpose**: Define the complete technical implementation for the confirmed scope
-
-**Includes**:
-- **Existing codebase analysis** (required)
-  - Implementation path mapping (both existing and new)
-  - Integration point clarification (connection points with existing code even for new implementations)
-- Technical implementation approach (vertical/horizontal/hybrid)
-- **Technical dependencies and implementation constraints** (required implementation order)
-- Interface and contract definitions
-- Data flow and component design
-- **Acceptance criteria**: the smallest representative set of observable behaviors with stable repository-verifiable pass/fail conditions
-- Change impact map (clearly specify direct impact/indirect impact/no ripple effect)
-- Every changed or newly relied-upon integration point
-- Data contract clarification
-- **Agreement checklist** (agreements with stakeholders)
-- **Code inspection evidence** (inspected files/functions during investigation)
-- **Field propagation map** (when fields cross component boundaries)
-- **Data representation decision** (when introducing new structures)
-- **Applicable standards** (explicit/implicit classification)
-- **Prerequisite ADRs** (including common ADRs)
-- **Verification Strategy** (required)
-  - Correctness proof method (what "correct" means for this change, how it's verified, when)
-  - Early verification point (first target to prove the approach works, success criteria, failure response)
-
-**Required Structural Elements**:
-```yaml
-Change Impact Map:
-  Change Target: [Component/Feature]
-  Direct Impact: [Files/Functions]
-  Indirect Impact: [Data format/Processing time]
-  No Ripple Effect: [Unaffected features]
-
-Interface Change Matrix:
-  Existing: [Function/method/operation name]
-  New: [Function/method/operation name]
-  Conversion Required: [Yes/No]
-  Compatibility Method: [Approach]
-```
-
-**Scope**: Technical implementation methods, interfaces, data flow, acceptance criteria, and verification strategy for the confirmed scope. Preserve the evidence and boundary details downstream implementation needs; omit unrelated future capability rather than reducing required design guarantees. Technology selection rationale belongs in ADR, schedule and assignments in Work Plan.
-
-An acceptance criterion describes observable behavior rather than implementation detail. External live connections use repository-controlled contract or interface proof unless a confirmed requirement needs the live boundary. Performance thresholds require a sourced target and a reproducible benchmark; exact visual positioning requires an approved visual contract and deterministic comparison. Otherwise record the item as a non-functional constraint or omit it from automated acceptance criteria.
-
-### Work Plan
-
-**Purpose**: Implementation task management and progress tracking.
-
-**Scope**: Repository implementation outcomes from approved Design Docs, task dependencies, source section and acceptance-criteria references, executable verification, optional task-level false-green focus, and progress tracking only. The Work Plan references governing documents instead of reproducing their design details.
-
-**Phase Division Criteria** (adapt to implementation approach from Design Doc):
-
-**When Vertical Slice selected**:
-- Each phase = one value unit (feature, component, or migration target)
-- Each phase includes its own implementation + verification per Verification Strategy
-
-**When Horizontal Slice selected**:
-1. **Phase 1: Foundation Implementation** - Contract definitions, interfaces/signatures, test preparation
-2. **Phase 2: Core Feature Implementation** - Business logic, unit tests
-3. **Phase 3: Integration Implementation** - External connections, presentation layer
-
-**When Hybrid selected**:
-- Combine vertical and horizontal as defined in Design Doc implementation approach
-
-**All approaches**: Each phase ends at a repository-observable verification point. Whole-repository quality assurance remains a separate execution responsibility.
-
-## Creation Process
-
-1. **Problem Analysis**: Confirm scope, determine Structural Scale, and identify candidate technical decision points
-   - Identify explicit and implicit project standards before investigation
-2. **ADR Choice Check** (when candidates exist): Apply the Choice filter, then the Durability filter
-3. **Creation**: Complete and review the qualifying ADR batch, then create the Design Doc with accepted ADRs as constraints
-4. **Approval**: One approval covers the reviewed ADR batch; Design Doc approval enables planning or implementation
 
 ## Storage Locations
 
@@ -206,27 +79,6 @@ An acceptance criterion describes observable behavior rather than implementation
 
 *Note: Work plans are excluded by `.gitignore`
 
-## ADR Status
-`Proposed` → `Accepted` → `Deprecated`/`Superseded`/`Rejected`
+## References
 
-## AI Automation Rules
-- Apply the Choice filter before the Durability filter and independently from Structural Scale
-- Check existing ADRs before implementation
-- Create one ADR per qualifying decision point and review the complete batch together
-
-## Diagram Requirements
-
-Select a Mermaid diagram only when it clarifies a material relationship more effectively than prose or a compact table:
-
-| Document | Required Diagrams | Purpose |
-|----------|------------------|---------|
-| PRD | User journey or scope boundary when prose does not make a material relationship clear | Clarify user experience and scope |
-| ADR | Option comparison when the relationship between options is unclear in a table | Visualize trade-offs |
-| UI Spec | Screen transition or component tree when material interaction or hierarchy remains unclear | Clarify screen flow and component structure |
-| Design Doc | Architecture or data flow when changed relationships are not clear in prose or tables | Understand technical structure |
-
-## Common ADR Relationships
-1. **At creation**: Identify accepted common ADRs that govern the changed responsibility
-2. **When missing**: Apply the same Choice and Durability filters; a generic concern alone does not justify a common ADR
-3. **Design Doc**: Specify applicable common ADRs in "Prerequisite ADRs"
-4. **Compliance check**: Verify the design aligns with accepted decisions
+Each template defines the content, structural elements, and diagram criteria for its document: [prd-template.md](references/prd-template.md), [adr-template.md](references/adr-template.md), [ui-spec-template.md](references/ui-spec-template.md), [design-template.md](references/design-template.md), [plan-template.md](references/plan-template.md), [task-template.md](references/task-template.md)

--- a/dev-workflows-fullstack/skills/documentation-criteria/references/adr-template.md
+++ b/dev-workflows-fullstack/skills/documentation-criteria/references/adr-template.md
@@ -4,6 +4,8 @@
 
 [Proposed | Accepted | Deprecated | Superseded | Rejected]
 
+A created ADR starts at `Proposed` and advances `Proposed` → `Accepted` → `Deprecated`/`Superseded`/`Rejected`.
+
 ## Context
 
 [Describe the background and reasons why this decision is needed. Include the essence of the problem, current challenges, and constraints]
@@ -33,7 +35,7 @@
 
 ### Options Considered
 
-Compare credible, materially distinct options supported by current requirements and repository evidence. The evidence determines how many options exist, and relative evidence-backed cost is sufficient.
+Compare credible, materially distinct options supported by current requirements and repository evidence. The evidence determines how many options exist, and relative evidence-backed cost is sufficient. Add a Mermaid option-comparison diagram only when the relationship between options stays unclear in the table below.
 
 | Option | Requirement and repository fit | Current-scope benefit | Lifecycle cost | Maintainability | Material trade-offs |
 |--------|--------------------------------|-----------------------|----------------|-----------------|---------------------|

--- a/dev-workflows-fullstack/skills/documentation-criteria/references/design-template.md
+++ b/dev-workflows-fullstack/skills/documentation-criteria/references/design-template.md
@@ -8,27 +8,11 @@
 - UI Spec path: [docs/ui-spec/xxx-ui-spec.md]
 - Component structure and state design are inherited from UI Spec
 
-## Design Summary (Meta)
-
-```yaml
-design_type: "new_feature|extension|refactoring"
-risk_level: "low|medium|high"
-complexity_level: "low|medium|high"
-complexity_rationale: "[Required if medium/high: (1) which requirements/ACs necessitate this complexity, (2) which constraints/risks it addresses]"
-main_constraints:
-  - "[constraint 1]"
-  - "[constraint 2]"
-biggest_risks:
-  - "[risk 1]"
-  - "[risk 2]"
-unknowns:
-  - "[uncertainty 1]"
-  - "[uncertainty 2]"
-```
-
 ## Background and Context
 
 ### Prerequisite ADRs
+
+List the accepted ADRs that govern the changed responsibility, including accepted common (cross-cutting) ADRs, and verify this design aligns with each recorded decision.
 
 - [docs/adr/ADR-XXXX.md]: [Related decision items]
 - Reference common technical ADRs when applicable
@@ -50,20 +34,7 @@ Records exclusions **the user decided** at requirement time. Exclusions this des
 - **Speculative**: [idea the user raised without deciding on -> deferral reason | None]
 - **Open questions**: [field the user left as weak-but-explicit | None]
 
-### Agreement Checklist
-
-#### Scope
-- [ ] [Features/components to change]
-- [ ] [Features to add]
-
-#### Non-Scope (Explicitly not changing)
-- [ ] [Features/components not to change]
-- [ ] [Existing logic to preserve]
-
-#### Constraints
-- [ ] Parallel operation: [Yes/No]
-- [ ] Backward compatibility: [Required/Not required]
-- [ ] Performance measurement: [Required/Not required]
+### Standards and Assumptions
 
 #### Applicable Standards
 - [ ] [Standard/convention] `[explicit]` - Source: [config / rule file / documentation path]
@@ -178,6 +149,8 @@ No Ripple Effect:
 ### Architecture Overview
 
 [How this feature is positioned within the overall system]
+
+Add an architecture or data-flow Mermaid diagram only when the changed relationships stay unclear in prose or a compact table; otherwise keep the prose form.
 
 ### Data Flow
 

--- a/dev-workflows-fullstack/skills/documentation-criteria/references/plan-template.md
+++ b/dev-workflows-fullstack/skills/documentation-criteria/references/plan-template.md
@@ -5,12 +5,6 @@ Type: feature|fix|refactor
 Related Issue/PR: #XXX (if any)
 Review Scope: [repository responsibilities or expected files derived from the Design Doc]
 
-## WorkPlan Review
-
-Plan creation and material updates set this to `pending`. Record `approved` after the user approves the reviewed implementation scope.
-
-- **Status**: pending|approved
-
 ## Governing Documents
 
 - Design Doc: [docs/design/XXX.md]
@@ -26,6 +20,14 @@ Plan creation and material updates set this to `pending`. Record `approved` afte
 ## Implementation Phases
 
 Use the implementation approach and dependency order from the Design Doc. Each phase groups work that reaches a shared observable verification point. Keep implementation, tests, configuration, wiring, and documentation together when they become complete at that point.
+
+Shape the phases from the approach the Design Doc selected:
+
+- **Vertical Slice**: each phase is one value unit (feature, component, or migration target) carrying its own implementation and verification per the Verification Strategy.
+- **Horizontal Slice**: foundation (contract definitions, interfaces/signatures, test preparation) → core feature (business logic, unit tests) → integration (external connections, presentation layer).
+- **Hybrid**: combine the two as the Design Doc's implementation approach defines.
+
+Whole-repository quality assurance stays outside the plan as a separate execution responsibility.
 
 ### Phase 1: [First implementation outcome]
 
@@ -63,7 +65,3 @@ Use the implementation approach and dependency order from the Design Doc. Each p
 - [ ] Dependencies permit execution in the listed order
 - [ ] Verification is executable from repository artifacts or the task's own output
 - [ ] Task verification passes and cited acceptance criteria are satisfied
-
-## Progress Notes
-
-[Record execution-relevant discoveries only when they change task order, scope, or verification.]

--- a/dev-workflows-fullstack/skills/documentation-criteria/references/ui-spec-template.md
+++ b/dev-workflows-fullstack/skills/documentation-criteria/references/ui-spec-template.md
@@ -42,6 +42,8 @@ Map confirmed acceptance criteria to prototype references, preserving existing A
 
 ## Screen List and Transitions
 
+Add a screen-transition or component-tree Mermaid diagram only when the material interaction or hierarchy stays unclear in the tables below; otherwise keep the table form.
+
 ### Screen List
 
 | Screen ID | Screen Name | Description | Entry Condition |

--- a/dev-workflows-fullstack/skills/external-resource-context/SKILL.md
+++ b/dev-workflows-fullstack/skills/external-resource-context/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: external-resource-context
-description: Captures and persists access methods for resources outside the repository (design source, design system, API schema, IaC source, secret store) so downstream work can reach them deterministically. Use when work depends on external resources, or when the user mentions design source, design system, API schema, IaC source, secret store, or canonical source.
+description: Captures access methods for resources outside the repository (design source, design system, API schema, IaC source, secret store) into a deterministic location so downstream work can reach them. Use when capturing or updating those access methods, or when the user mentions design source, design system, API schema, IaC source, secret store, or canonical source.
 ---
 
 # External Resource Context
@@ -30,58 +30,19 @@ The project tier owns environment facts. Feature-tier sections list only feature
 
 Example feature-tier entry uses the table format defined in `references/template.md`: a row with the project-tier label in the first column and the feature-specific identifier in the second column.
 
-## Hearing Protocol
-
-### When to Hear
-
-| Condition | Action |
-|-----------|--------|
-| `docs/project-context/external-resources.md` does not exist | Run full hearing for the relevant domain(s) |
-| File exists and covers the current decision | Use it without an update question |
-| User or caller identifies changed environment facts | Run diff-only hearing for the named axes |
-| A relevant axis is absent | Hear only the missing axis |
-| Access failure or contradictory current evidence indicates possible staleness | Ask via AskUserQuestion: "Update external-resources.md? (no / yes-full / yes-diff-only)". On `yes-full` run full hearing; on `yes-diff-only` hear the named stale axes; on `no` preserve the file and report the limitation |
-
-### Domain Routing
-
-Load the domain reference matching the current task:
-
-| Task type | References to load |
-|-----------|--------------------|
-| Frontend (UI work) | [references/frontend.md](references/frontend.md) |
-| Backend (server / data work) | [references/backend.md](references/backend.md) |
-| API contract work | [references/api.md](references/api.md) |
-| Infrastructure / deployment | [references/infra.md](references/infra.md) |
-| Fullstack | Load only the references whose frontend, backend/data, API-contract, or infrastructure responsibilities are affected by the confirmed scope; a fullstack label alone does not activate infrastructure |
-
-Each domain reference defines the axes and the question template.
-
-### Two-Phase Hearing
-
-1. **Structured hearing** — for each axis selected by the When to Hear and Domain Routing rules, present the user with AskUserQuestion using the choices listed in its domain reference (always include "Not applicable" as an option). For each non-N/A axis, follow up with an access-method question (URL / MCP name / file path / command).
-
-2. **Self-declaration for a full hearing** — after the structured axes for all selected domains are complete, present one integrated AskUserQuestion: "Are there any other external resources for this work that the structured questions did not cover? If yes, describe them in your next message." If the user describes additional resources, append them to the storage file under an "Additional resources" subsection. A diff-only or missing-axis hearing ends after its named axes because the existing project record already completed self-declaration.
-
-For a full hearing, the two phases are sequential and self-declaration runs even if the user answered "Not applicable" to every structured axis.
-
-## Storage Protocol
-
-After hearing completes:
-
-1. Build the project-tier content from the answers. Use [references/template.md](references/template.md) as the structure.
-2. Write to `docs/project-context/external-resources.md`. Create the directory if absent.
-3. When the calling workflow has a target UI Spec or Design Doc, also append or update the document's `## External Resources Used` section with the feature-tier subset (label references + feature-specific identifiers only).
-4. Report the file paths back to the calling workflow.
-
 ## Reference Protocol (For Downstream Consumers)
 
-Agents that load this skill consult resources in this order:
+Consuming a recorded resource takes three reads and needs no part of this skill:
 
-1. Read `docs/project-context/external-resources.md` first (if present) to learn what is available and how to access it.
+1. Read `docs/project-context/external-resources.md` (if present) to learn what is available and how to access it.
 2. Read the target UI Spec or Design Doc's `## External Resources Used` section for feature-specific identifiers.
 3. Use the access method declared in the project tier (e.g., the named MCP, the URL, the file path) to fetch the actual resource content.
 
-Agents that only need to *consult* the saved file as input data (not actively hear) can read it directly without loading this skill — frontmatter declaration is reserved for agents that may need to trigger hearing or interpret the protocol semantics.
+A consumer that only reads these records executes the three steps directly. Load this skill when capturing or updating the records, which requires AskUserQuestion and therefore the session that can ask the user.
+
+## Capturing and Updating Records
+
+Follow [references/hearing.md](references/hearing.md) for the hearing conditions, domain routing, two-phase hearing, storage protocol, and quality checklist.
 
 ## Output Format
 
@@ -89,16 +50,9 @@ The project-tier file follows the structure in [references/template.md](referenc
 
 For feature-tier sections inside UI Spec or Design Doc, the heading text "External Resources Used" is fixed; the heading level matches the parent document's natural structure (h2 in UI Spec where it is a sibling of other top-level sections, h3 in Design Doc where it sits under Background and Context).
 
-## Quality Checklist
-
-- [ ] Each axis answered has both a presence indicator and an access method, or is marked "Not applicable"
-- [ ] A full hearing ran self-declaration even when all structured axes were "Not applicable"; a diff-only or missing-axis hearing stayed within its named axes
-- [ ] Project-tier file does not contain feature-specific identifiers
-- [ ] Feature-tier sections reference project-tier entries by label, not by duplicating URLs / MCP names
-- [ ] When the project file already existed, each write traces to an explicit changed fact, a missing relevant axis, or a confirmed stale-evidence update decision
-
 ## References
 
+- [references/hearing.md](references/hearing.md) — Hearing conditions, domain routing, storage protocol, quality checklist
 - [references/frontend.md](references/frontend.md) — Frontend domain axes
 - [references/backend.md](references/backend.md) — Backend domain axes
 - [references/api.md](references/api.md) — API contract domain axes

--- a/dev-workflows-fullstack/skills/external-resource-context/SKILL.md
+++ b/dev-workflows-fullstack/skills/external-resource-context/SKILL.md
@@ -11,12 +11,6 @@ AI agents understand the codebase but not the external resources surrounding it.
 
 Resources covered: design origin (where the canonical visual specification lives), design system (component library and tokens), guidelines (usage docs, accessibility rules), visual verification environment (how to confirm rendering), database schema source, migration history, secret store location, API schema source (OpenAPI / proto / GraphQL SDL), mock environment, IaC source, environment configuration.
 
-## Scope Boundaries
-
-**In scope**: hearing protocol, storage location, single-source-of-truth ownership rule, reference protocol for downstream consumers.
-
-**Out of scope**: enforcing that captured resources are correct or current — verification belongs to the agent that consumes the resource. Generating the resources themselves (e.g., creating a DESIGN.md from scratch).
-
 ## Storage Locations (Two-Tier)
 
 | Tier | Location | Holds | Update Frequency |

--- a/dev-workflows-fullstack/skills/external-resource-context/SKILL.md
+++ b/dev-workflows-fullstack/skills/external-resource-context/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: external-resource-context
-description: Captures access methods for resources outside the repository (design source, design system, API schema, IaC source, secret store) into a deterministic location so downstream work can reach them. Use when capturing or updating those access methods, or when the user mentions design source, design system, API schema, IaC source, secret store, or canonical source.
+description: Records where resources outside the repository live (design source, design system, API schema, IaC source, secret store) and how design, implementation, and verification reach them. Use when work depends on an external resource, or when the user mentions design source, design system, API schema, IaC source, secret store, or canonical source.
 ---
 
 # External Resource Context
@@ -32,17 +32,17 @@ Example feature-tier entry uses the table format defined in `references/template
 
 ## Reference Protocol (For Downstream Consumers)
 
-Consuming a recorded resource takes three reads and needs no part of this skill:
+Before investigating the repository for an external fact, check whether it is already recorded:
 
 1. Read `docs/project-context/external-resources.md` (if present) to learn what is available and how to access it.
 2. Read the target UI Spec or Design Doc's `## External Resources Used` section for feature-specific identifiers.
 3. Use the access method declared in the project tier (e.g., the named MCP, the URL, the file path) to fetch the actual resource content.
 
-A consumer that only reads these records executes the three steps directly. Load this skill when capturing or updating the records, which requires AskUserQuestion and therefore the session that can ask the user.
+When the file is absent or the resource is unreachable, continue from governing and repository evidence. Each consuming agent reports that limitation through its own output contract.
 
 ## Capturing and Updating Records
 
-Follow [references/hearing.md](references/hearing.md) for the hearing conditions, domain routing, two-phase hearing, storage protocol, and quality checklist.
+Capturing a record requires AskUserQuestion, so it belongs to the session that can ask the user. Follow [references/hearing.md](references/hearing.md) for the hearing conditions, domain routing, two-phase hearing, storage protocol, and quality checklist.
 
 ## Output Format
 

--- a/dev-workflows-fullstack/skills/external-resource-context/references/hearing.md
+++ b/dev-workflows-fullstack/skills/external-resource-context/references/hearing.md
@@ -47,6 +47,6 @@ After hearing completes:
 
 - [ ] Each axis answered has both a presence indicator and an access method, or is marked "Not applicable"
 - [ ] A full hearing ran self-declaration even when all structured axes were "Not applicable"; a diff-only or missing-axis hearing stayed within its named axes
-- [ ] Project-tier file does not contain feature-specific identifiers
-- [ ] Feature-tier sections reference project-tier entries by label, not by duplicating URLs / MCP names
+- [ ] Project-tier entries hold the environment facts (URL, MCP name, file path, command)
+- [ ] Feature-tier rows hold a project-tier label and the feature-specific identifier
 - [ ] When the project file already existed, each write traces to an explicit changed fact, a missing relevant axis, or a confirmed stale-evidence update decision

--- a/dev-workflows-fullstack/skills/external-resource-context/references/hearing.md
+++ b/dev-workflows-fullstack/skills/external-resource-context/references/hearing.md
@@ -1,0 +1,52 @@
+# External Resource Hearing and Storage
+
+Producer-side protocol. Load this when capturing or updating external-resource records. Running it requires AskUserQuestion, so it belongs to the session that can ask the user directly.
+
+## When to Hear
+
+| Condition | Action |
+|-----------|--------|
+| `docs/project-context/external-resources.md` does not exist | Run full hearing for the relevant domain(s) |
+| File exists and covers the current decision | Use it without an update question |
+| User or caller identifies changed environment facts | Run diff-only hearing for the named axes |
+| A relevant axis is absent | Hear only the missing axis |
+| Access failure or contradictory current evidence indicates possible staleness | Ask via AskUserQuestion: "Update external-resources.md? (no / yes-full / yes-diff-only)". On `yes-full` run full hearing; on `yes-diff-only` hear the named stale axes; on `no` preserve the file and report the limitation |
+
+## Domain Routing
+
+Load the domain reference matching the current task:
+
+| Task type | References to load |
+|-----------|--------------------|
+| Frontend (UI work) | [frontend.md](frontend.md) |
+| Backend (server / data work) | [backend.md](backend.md) |
+| API contract work | [api.md](api.md) |
+| Infrastructure / deployment | [infra.md](infra.md) |
+| Fullstack | Load only the references whose frontend, backend/data, API-contract, or infrastructure responsibilities are affected by the confirmed scope; a fullstack label alone does not activate infrastructure |
+
+Each domain reference defines the axes and the question template.
+
+## Two-Phase Hearing
+
+1. **Structured hearing** — for each axis selected by the When to Hear and Domain Routing rules, present the user with AskUserQuestion using the choices listed in its domain reference (always include "Not applicable" as an option). For each non-N/A axis, follow up with an access-method question (URL / MCP name / file path / command).
+
+2. **Self-declaration for a full hearing** — after the structured axes for all selected domains are complete, present one integrated AskUserQuestion: "Are there any other external resources for this work that the structured questions did not cover? If yes, describe them in your next message." If the user describes additional resources, append them to the storage file under an "Additional resources" subsection. A diff-only or missing-axis hearing ends after its named axes because the existing project record already completed self-declaration.
+
+For a full hearing, the two phases are sequential and self-declaration runs even if the user answered "Not applicable" to every structured axis.
+
+## Storage Protocol
+
+After hearing completes:
+
+1. Build the project-tier content from the answers. Use [template.md](template.md) as the structure.
+2. Write to `docs/project-context/external-resources.md`. Create the directory if absent.
+3. When the calling workflow has a target UI Spec or Design Doc, also append or update the document's `## External Resources Used` section with the feature-tier subset (label references + feature-specific identifiers only).
+4. Report the file paths back to the calling workflow.
+
+## Quality Checklist
+
+- [ ] Each axis answered has both a presence indicator and an access method, or is marked "Not applicable"
+- [ ] A full hearing ran self-declaration even when all structured axes were "Not applicable"; a diff-only or missing-axis hearing stayed within its named axes
+- [ ] Project-tier file does not contain feature-specific identifiers
+- [ ] Feature-tier sections reference project-tier entries by label, not by duplicating URLs / MCP names
+- [ ] When the project file already existed, each write traces to an explicit changed fact, a missing relevant axis, or a confirmed stale-evidence update decision

--- a/dev-workflows-fullstack/skills/frontend-ai-guide/SKILL.md
+++ b/dev-workflows-fullstack/skills/frontend-ai-guide/SKILL.md
@@ -123,7 +123,7 @@ function EmailInput({ context }: { context: 'user' | 'contact' | 'admin' }) { /*
 - Similar functionality found → Verify that its props, lifecycle, design-system role, and repository usage are representative; reuse or extend it when compatible, otherwise record why it is not a valid model
 - Similar functionality is technical debt → Repair it when it blocks the current outcome, was caused by the current change, or lies in confirmed scope; otherwise report it separately. Create an ADR when the repair requires an architectural decision
 - No similar functionality exists → Implement new functionality following existing design philosophy
-- Record all decisions and rationale in "Existing Codebase Analysis" section of Design Doc
+- Record each reuse, extend, separate, or repair decision with its evidence in the artifact this agent owns
 
 ## Quality Check Workflow
 
@@ -165,11 +165,7 @@ Read `package.json` scripts, map the project's actual commands to the phases bel
 **Completion Criteria**: Complete all 3 stages. Concise search/inspection notes are sufficient for an isolated component change with no shared contract, routing, state-ownership, or build/config impact; use the structured report for cross-component or high-risk changes.
 
 #### 1. Discovery
-```bash
-Grep -n "ComponentName\|hookName" -o content
-Grep -n "importedFunction" -o content
-Grep -n "propsType\|StateType" -o content
-```
+Search the repository for every reference to the changed component or hook, its imported functions, and its Props/State types.
 
 #### 2. Understanding
 Read the discovered files needed to establish:

--- a/dev-workflows-fullstack/skills/implementation-approach/SKILL.md
+++ b/dev-workflows-fullstack/skills/implementation-approach/SKILL.md
@@ -35,7 +35,7 @@ Complete these steps in order before selecting an implementation strategy:
 
 Classify supporting claims as observed, inferred, or unknown. When an unknown blocks the next step, stop at the current step and name the evidence or user decision required.
 
-**Design Doc output**: Direct MVP, Failed Items, Adopted Additions, and Rejected Additions.
+**Phase 2 outputs**: Direct MVP, Failed Items, Adopted Additions, and Rejected Additions. A Design Doc author records all four; an implementer uses them as the convergence check without producing a document.
 
 ### Phase 3: Strategy Exploration and Creation
 
@@ -117,7 +117,7 @@ Select the implementation approach that directly fits the verified dependency an
 
 ### Phase 7: Decision Rationale Documentation
 
-**Design Doc Documentation**: Record in the Design Doc's implementation approach section:
+**Record in the artifact this agent owns**, and in the Design Doc's implementation approach section when this agent owns that document:
 1. Selected strategy name and characteristics
 2. A materially different alternative and reason for rejection, when one was compared
 3. Risk mitigation plan (from Phase 4)

--- a/dev-workflows-fullstack/skills/integration-e2e-testing/SKILL.md
+++ b/dev-workflows-fullstack/skills/integration-e2e-testing/SKILL.md
@@ -76,7 +76,7 @@ The two E2E lanes have different ownership costs and use independent standard th
 | fixture-e2e | ROI ≥ 20 (beyond reserved slot) | Cost is comparable to integration tests once the harness exists; the floor avoids filling MAX 3 with low-signal tests when fewer would suffice |
 | service-integration-e2e | ROI > 50 (beyond reserved slot) | Live-service setup, state cleanup, and failure diagnosis add material ownership cost; reserve for journeys whose value cannot be proven any other way |
 
-Reserved slot rules (see Multi-Step User Journey Definition below) apply per lane and override the threshold (the reserved candidate is emitted regardless of its ROI score). Below-floor candidates beyond the reserved slot are not emitted unless an accepted requirement or distinct uncovered failure mode justifies an exception. Leave budget intentionally unfilled rather than padding with low-value tests; record any threshold or budget exception in the skeleton and generation report.
+Reserved slot rules (see Multi-Step User Journey Definition below) apply per lane and override the threshold (the reserved candidate is emitted regardless of its ROI score). Below-floor candidates beyond the reserved slot are not emitted unless an accepted requirement or distinct uncovered failure mode justifies an exception. Leave budget intentionally unfilled rather than padding with low-value tests; record any threshold or budget exception in the skeleton that carries the exception.
 
 ### ROI Calculation Examples
 

--- a/dev-workflows-fullstack/skills/integration-e2e-testing/SKILL.md
+++ b/dev-workflows-fullstack/skills/integration-e2e-testing/SKILL.md
@@ -76,7 +76,7 @@ The two E2E lanes have different ownership costs and use independent standard th
 | fixture-e2e | ROI ≥ 20 (beyond reserved slot) | Cost is comparable to integration tests once the harness exists; the floor avoids filling MAX 3 with low-signal tests when fewer would suffice |
 | service-integration-e2e | ROI > 50 (beyond reserved slot) | Live-service setup, state cleanup, and failure diagnosis add material ownership cost; reserve for journeys whose value cannot be proven any other way |
 
-Reserved slot rules (see Multi-Step User Journey Definition below) apply per lane and override the threshold (the reserved candidate is emitted regardless of its ROI score). Below-floor candidates beyond the reserved slot are not emitted unless an accepted requirement or distinct uncovered failure mode justifies an exception. Leave budget intentionally unfilled rather than padding with low-value tests; record any threshold or budget exception in the skeleton that carries the exception.
+Reserved slot rules (see Multi-Step User Journey Definition below) apply per lane and override the threshold (the reserved candidate is emitted regardless of its ROI score). Emit a below-floor candidate beyond the reserved slot only when an accepted requirement or a distinct uncovered failure mode justifies the exception. Leave budget intentionally unfilled rather than padding with low-value tests; record any threshold or budget exception in the skeleton that carries the exception.
 
 ### ROI Calculation Examples
 

--- a/dev-workflows-fullstack/skills/recipe-add-integration-tests/SKILL.md
+++ b/dev-workflows-fullstack/skills/recipe-add-integration-tests/SKILL.md
@@ -41,18 +41,7 @@ Document paths: $ARGUMENTS
 
 ### Step 1: Discover and Validate Documents
 
-```bash
-# Verify at least one document path was provided
-test -n "$ARGUMENTS" || { echo "ERROR: No document paths provided"; exit 1; }
-
-# Verify provided paths exist
-ls $ARGUMENTS
-
-# Discover additional documents
-ls docs/design/*.md 2>/dev/null | grep -v template
-ls docs/ui-spec/*.md 2>/dev/null
-ls docs/prd/*.md 2>/dev/null
-```
+Confirm `$ARGUMENTS` names at least one existing document path; report and end when it is empty or every path is unresolvable. Then discover the remaining Design Docs, UI Specs, and PRDs under `docs/design/`, `docs/ui-spec/`, and `docs/prd/`.
 
 Classify discovered documents by filename:
 - Filename contains `backend` → **Design Doc (backend)**

--- a/dev-workflows-fullstack/skills/recipe-build/SKILL.md
+++ b/dev-workflows-fullstack/skills/recipe-build/SKILL.md
@@ -34,7 +34,7 @@ Before any task processing, locate the work plan. Resolution rule:
 1. List task files in `docs/plans/tasks/` matching the single-layer pattern `{plan-name}-task-*.md`. Layer-aware fullstack tasks (`{plan-name}-backend-task-*.md` / `{plan-name}-frontend-task-*.md`) are excluded here so a stale fullstack run does not redirect this recipe to the wrong work plan
 2. For each matched file, extract the `{plan-name}` prefix as the segment that appears before `-task-`
 3. When at least one task file matches, the work plan is `docs/plans/{plan-name}.md` for the prefix that has the most recent task-file mtime; ties broken by the lexicographically last `{plan-name}`
-4. When no task file matches the restricted pattern, the work plan is the most-recent-mtime non-template `.md` in `docs/plans/`
+4. When no task file matches the restricted pattern, the work plan is the most recently modified `.md` in `docs/plans/`
 
 ### Consumed Task Set
 

--- a/dev-workflows-fullstack/skills/recipe-front-build/SKILL.md
+++ b/dev-workflows-fullstack/skills/recipe-front-build/SKILL.md
@@ -34,7 +34,7 @@ Before any task processing, locate the work plan. Resolution rule:
 1. List task files in `docs/plans/tasks/` matching the single-layer pattern `{plan-name}-task-*.md`. Layer-aware fullstack tasks (`{plan-name}-backend-task-*.md` / `{plan-name}-frontend-task-*.md`) are excluded here so a stale fullstack run does not redirect this recipe to the wrong work plan
 2. For each matched file, extract the `{plan-name}` prefix as the segment that appears before `-task-`
 3. When at least one task file matches, the work plan is `docs/plans/{plan-name}.md` for the prefix that has the most recent task-file mtime; ties broken by the lexicographically last `{plan-name}`
-4. When no task file matches the restricted pattern, the work plan is the most-recent-mtime non-template `.md` in `docs/plans/`
+4. When no task file matches the restricted pattern, the work plan is the most recently modified `.md` in `docs/plans/`
 
 ### Consumed Task Set
 

--- a/dev-workflows-fullstack/skills/recipe-front-review/SKILL.md
+++ b/dev-workflows-fullstack/skills/recipe-front-review/SKILL.md
@@ -36,13 +36,7 @@ Design Doc (uses most recent if omitted): $ARGUMENTS
 ## Execution Flow
 
 ### Step 1: Prerequisite Check
-```bash
-# Identify Design Doc
-ls docs/design/*.md | grep -v template | tail -1
-
-# Check implementation files
-git diff --name-only main...HEAD
-```
+Identify the review inputs: the most recently updated Design Doc under `docs/design/`, and the files changed on the current branch relative to its base.
 
 ### Step 2: Execute code-reviewer
 Invoke code-reviewer using Agent tool:
@@ -116,7 +110,7 @@ Run this step only when the user routed at least one finding to `d`. When no `d`
    - `prompt`: "Review updated Design Doc at [path] for consistency and completeness. doc_type: DesignDoc. review_context: update."
    - Run the Review Resolution Gate through its correction re-review, escalation, and convergence transitions, using technical-designer-frontend for rerouted corrections. Proceed only at its convergence condition.
 
-3. When multiple Design Docs exist (`ls docs/design/*.md | grep -v template | wc -l > 1`), invoke design-sync:
+3. When more than one Design Doc exists under `docs/design/`, invoke design-sync:
    - `subagent_type`: "dev-workflows-fullstack:design-sync"
    - `description`: "Cross-DD consistency check"
    - `prompt`: "source_design: [updated DD path]"

--- a/dev-workflows-fullstack/skills/recipe-fullstack-build/SKILL.md
+++ b/dev-workflows-fullstack/skills/recipe-fullstack-build/SKILL.md
@@ -42,7 +42,7 @@ Before any task processing, locate the work plan. Resolution rule:
 1. List task files in `docs/plans/tasks/` matching the layer-aware patterns `{plan-name}-backend-task-*.md` and `{plan-name}-frontend-task-*.md` only. Single-layer tasks (`{plan-name}-task-*.md`) are excluded here so a stale single-layer run does not redirect this recipe to the wrong work plan
 2. For each matched file, extract the `{plan-name}` prefix as the segment that appears before `-backend-task-` or `-frontend-task-`
 3. When at least one task file matches, the work plan is `docs/plans/{plan-name}.md` for the prefix that has the most recent task-file mtime; ties broken by the lexicographically last `{plan-name}`
-4. When no task file matches the restricted pattern, the work plan is the most-recent-mtime non-template `.md` in `docs/plans/`
+4. When no task file matches the restricted pattern, the work plan is the most recently modified `.md` in `docs/plans/`
 
 ### Consumed Task Set
 

--- a/dev-workflows-fullstack/skills/recipe-review/SKILL.md
+++ b/dev-workflows-fullstack/skills/recipe-review/SKILL.md
@@ -36,13 +36,7 @@ Design Doc (uses most recent if omitted): $ARGUMENTS
 ## Execution Flow
 
 ### Step 1: Prerequisite Check
-```bash
-# Identify Design Doc
-ls docs/design/*.md | grep -v template | tail -1
-
-# Check implementation files
-git diff --name-only main...HEAD
-```
+Identify the review inputs: the most recently updated Design Doc under `docs/design/`, and the files changed on the current branch relative to its base.
 
 ### Step 2: Execute code-reviewer
 Invoke code-reviewer using Agent tool:
@@ -116,7 +110,7 @@ Run this step only when the user routed at least one finding to `d`. When no `d`
    - `prompt`: "Review updated Design Doc at [path] for consistency and completeness. doc_type: DesignDoc. review_context: update."
    - Run the Review Resolution Gate through its correction re-review, escalation, and convergence transitions, using technical-designer for rerouted corrections. Proceed only at its convergence condition.
 
-3. When multiple Design Docs exist (`ls docs/design/*.md | grep -v template | wc -l > 1`), invoke design-sync:
+3. When more than one Design Doc exists under `docs/design/`, invoke design-sync:
    - `subagent_type`: "dev-workflows-fullstack:design-sync"
    - `description`: "Cross-DD consistency check"
    - `prompt`: "source_design: [updated DD path]"

--- a/dev-workflows-fullstack/skills/recipe-update-doc/SKILL.md
+++ b/dev-workflows-fullstack/skills/recipe-update-doc/SKILL.md
@@ -24,21 +24,21 @@ Before the first finding disposition, read `references/review-resolution.md` fro
 1. **Invoke named specialists for deliverable production** — pass deliverable paths between them and validate their results (see subagents-orchestration-guide "Orchestrator Execution Boundary")
 2. **Execute update flow**:
    - Identify target → Clarify changes → Update document → Review → Consistency check
-   - **Stop at every `[Stop: ...]` marker** → Wait for user approval before proceeding
+   - **Stop at the `[Stop: Final approval]` marker** → Wait for user approval before completing
 3. **Scope**: Complete when updated document receives approval
 
 At each Agent invocation below, build the prompt as a mechanical extraction: copy the named source values into the exact fields, apply only the declared serialization, then invoke immediately.
 
-**CRITICAL**: Execute document-reviewer and all stopping points — each serves as a quality gate for document accuracy.
+**CRITICAL**: Execute document-reviewer — it is the quality gate for document accuracy.
 
 ## Workflow Overview
 
 ```
-Target document → [Stop: Confirm changes]
+Target document → change clarification
                         ↓
               technical-designer / technical-designer-frontend / prd-creator (update mode)
                         ↓ (Design Doc only)
-              code-verifier → document-reviewer → [Stop: Review approval]
+              code-verifier → document-reviewer
                         ↓ (Design Doc only)
               design-sync → [Stop: Final approval]
 ```
@@ -47,7 +47,7 @@ Target document → [Stop: Confirm changes]
 
 **Included in this skill**:
 - Existing document identification and selection
-- Change content clarification with user
+- Change content clarification
 - Document update with appropriate agent (update mode)
 - Document review with document-reviewer
 - Consistency verification with design-sync (Design Doc only)
@@ -64,10 +64,7 @@ Target document: $ARGUMENTS
 
 ### Step 1: Target Document Identification
 
-```bash
-# Check existing documents
-ls docs/design/*.md docs/prd/*.md docs/adr/*.md 2>/dev/null | grep -v template
-```
+Discover the existing documents under `docs/design/`, `docs/prd/`, and `docs/adr/`.
 
 **Decision flow**:
 
@@ -97,16 +94,11 @@ Read the document and determine its layer from content signals:
 - **Minor changes** (clarification, typo fix, small scope adjustment): Update the existing ADR file
 - **Major changes** (decision reversal, significant scope change): Create a new ADR that supersedes the original
 
-### Step 3: Change Content Clarification [Stop]
+### Step 3: Change Content Clarification
 
-Use AskUserQuestion to clarify what changes are needed:
-- What sections need updating
-- Reason for the change (bug fix findings, spec change, review feedback, etc.)
-- Expected outcome after the update
+Determine which sections need updating, the reason for the change, and the expected outcome after the update. Derive them from the request and the target document. Use AskUserQuestion only for an item the request and document leave undetermined, and only when a different answer would change which sections are updated or what the update must achieve.
 
-Confirm understanding of changes with user before proceeding.
-
-Pass approved items, covered sections, and any stated total size budget to update or revision agents. Before the next approval gate, map every diff hunk to an approved item or required consistency update; request a scope decision for unmapped or over-budget changes.
+Pass the resulting items, covered sections, and any stated total size budget to update or revision agents. Before the next approval gate, map every diff hunk to an approved item or required consistency update; request a scope decision for unmapped or over-budget changes.
 
 ### Step 4: Document Update
 
@@ -119,13 +111,13 @@ prompt: |
   Existing Document: [path from Step 1]
 
   ## Changes Required
-  [user-approved Step 3 statements for the sections to update, reason, and expected outcome, copied verbatim]
+  [Step 3 statements for the sections to update, reason, and expected outcome, copied verbatim]
 
   Update the document to reflect the specified changes.
   Add change history entry.
 ```
 
-### Step 5: Document Review [Stop]
+### Step 5: Document Review
 
 **For Design Doc updates only**: Before document-reviewer, invoke code-verifier:
 ```
@@ -170,22 +162,18 @@ For each type, review consistency of the changed sections and their dependent st
 - On re-review pass `prior_feedback` as `[{id, disposition, reason?, evidence}]`
 - All actionable findings are `decline` and every `user_decision_required` item is resolved → Proceed to Step 6
 
-Present review result to user for approval.
+### Step 6: Consistency Verification and Final Approval `[Stop: Final approval]`
 
-### Step 6: Consistency Verification (Design Doc only) [Stop]
-
-**Skip condition**: Document type is PRD or ADR → Proceed to completion.
-
-For Design Doc, invoke design-sync:
+**For Design Doc only**, invoke design-sync first:
 ```
 subagent_type: design-sync
 description: "Verify consistency"
 prompt: "source_design: [path from Step 1]"
 ```
 
-**On consistency result**:
-- No conflicts → Present result to user for final approval
-- Conflicts detected → Apply the Review Resolution Gate using design-sync as a fresh verifier. Return `apply` conflicts to Step 4 for the owning document, rerun design-sync after correction, retain evidenced declines as complete, and request user input for `user_decision_required` or the Gate's escalation conditions. Present final approval at convergence.
+When conflicts are detected, apply the Review Resolution Gate using design-sync as a fresh verifier. Return `apply` conflicts to Step 4 for the owning document, rerun design-sync after correction, retain evidenced declines as complete, and request user input for `user_decision_required` or the Gate's escalation conditions.
+
+**For every document type**, present the updated document, the review outcome, any resolved declines, and the sync result when one ran. This is the only approval gate in the flow: wait for the user's decision before completing.
 
 ## Error Handling
 
@@ -197,7 +185,7 @@ prompt: "source_design: [path from Step 1]"
 ## Completion Criteria
 
 - [ ] Identified target document
-- [ ] Clarified change content with user
+- [ ] Change content determined from the request, the document, or a question whose answer changed the update
 - [ ] Updated document with appropriate agent (update mode)
 - [ ] Executed code-verifier before document-reviewer (Design Doc only)
 - [ ] Executed document-reviewer and addressed feedback

--- a/dev-workflows-fullstack/skills/subagents-orchestration-guide/SKILL.md
+++ b/dev-workflows-fullstack/skills/subagents-orchestration-guide/SKILL.md
@@ -284,8 +284,8 @@ Pass the Design Doc path. Work-planner maps governing sections and ACs to implem
 
 - Invoke acceptance-test-generator with `design_docs` as the applicable Design Doc path list, optional `ui_spec`, and the same `confirmed_requirement_context` used for design.
 - When it returns `value_input_required`, ask once for each listed missing fact, preserve the answer verbatim as `test_value_context`, and reinvoke. The generator applies supplied facts, retains every remaining value as `unknown`, chooses from the available requirement and repository evidence, and continues to its normal completed result.
-- Verify each non-null `generatedFiles.<lane>` path exists. For each null E2E lane, accept its `e2eAbsenceReason.<lane>` only when it names the selection rule, source evidence, and selected or governing proof covering the accepted boundary. Return an uncovered accepted proof obligation to the generator for completion.
-- Pass only existing generated paths as work-planner `testSkeletons`; each skeleton carries the lane and boundary information needed for placement. Consume valid null-lane reasons at this gate.
+- Verify each non-null `generatedFiles.<lane>` path exists. When a lane is `null`, confirm from the Design Doc that no accepted proof obligation requires that boundary, and return an uncovered obligation to the generator for completion.
+- Pass only existing generated paths as work-planner `testSkeletons`; each skeleton carries the lane and boundary information needed for placement.
 - Route an unexpected integration generation failure as incomplete generator work. A validated null E2E lane is complete.
 
 ## References

--- a/dev-workflows-fullstack/skills/subagents-orchestration-guide/references/monorepo-flow.md
+++ b/dev-workflows-fullstack/skills/subagents-orchestration-guide/references/monorepo-flow.md
@@ -27,7 +27,7 @@ This reference defines the orchestration flow for one feature spanning backend a
 | 11 | technical-designer-frontend | Frontend Design Doc with backend contracts, applicable UI Spec, and accepted ADR constraints | Frontend Design Doc |
 | 12 | code-verifier ×2 + orchestrator | Verify each Design Doc and apply Review Resolution | Resolved verification evidence |
 | 13 | document-reviewer ×2 | Review each Design Doc with resolved verification evidence | Reviews |
-| 14 | design-sync | Cross-layer consistency verification **[Stop]** | Sync status |
+| 14 | design-sync | Cross-layer consistency verification **[Stop when conflicts remain after Review Resolution]** | Sync status |
 | 15 | acceptance-test-generator | Integration/E2E skeletons selected from cross-layer contracts | Test skeletons |
 | 16 | work-planner | Work plan from both Design Docs | Work Plan |
 | 17 | document-reviewer | Work Plan review **[Stop: Batch approval]** | Approval |

--- a/dev-workflows-fullstack/skills/task-analyzer/references/skills-index.yaml
+++ b/dev-workflows-fullstack/skills/task-analyzer/references/skills-index.yaml
@@ -206,7 +206,6 @@ skills:
       - "references/template.md"
     sections:
       - "Purpose"
-      - "Scope Boundaries"
       - "Storage Locations (Two-Tier)"
       - "Reference Protocol (For Downstream Consumers)"
       - "Capturing and Updating Records"

--- a/dev-workflows-fullstack/skills/task-analyzer/references/skills-index.yaml
+++ b/dev-workflows-fullstack/skills/task-analyzer/references/skills-index.yaml
@@ -71,17 +71,12 @@ skills:
       - "Design Doc Culture - Google Engineering Practices"
       - "Single Source of Truth"
     sections:
-      - "Templates"
+      - "What Each Document Fixes"
       - "Creation Decision Matrix"
       - "Structural Scale"
       - "ADR Decision Filters"
-      - "Detailed Document Definitions"
-      - "Creation Process"
       - "Storage Locations"
-      - "ADR Status"
-      - "AI Automation Rules"
-      - "Diagram Requirements"
-      - "Common ADR Relationships"
+      - "References"
 
   implementation-approach:
     skill: "implementation-approach"
@@ -203,6 +198,7 @@ skills:
     tags: [cross-cutting, hearing-protocol, design-source, design-system, api-schema, iac-source, secrets, environment, two-tier-storage]
     typical-use: "Captures access methods for resources outside the repository (design origin, design system, API schema, IaC source, secrets, etc.) and persists them in a deterministic location for downstream agents"
     key-references:
+      - "references/hearing.md"
       - "references/frontend.md"
       - "references/backend.md"
       - "references/api.md"
@@ -212,11 +208,9 @@ skills:
       - "Purpose"
       - "Scope Boundaries"
       - "Storage Locations (Two-Tier)"
-      - "Hearing Protocol"
-      - "Storage Protocol"
       - "Reference Protocol (For Downstream Consumers)"
+      - "Capturing and Updating Records"
       - "Output Format"
-      - "Quality Checklist"
       - "References"
 
   requirement-convergence:

--- a/dev-workflows/.claude-plugin/plugin.json
+++ b/dev-workflows/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflows",
   "description": "Skills + Subagents for backend development - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
-  "version": "0.24.3",
+  "version": "0.24.4",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows/agents/acceptance-test-generator.md
+++ b/dev-workflows/agents/acceptance-test-generator.md
@@ -198,22 +198,6 @@ A skeleton is committed before its implementation exists, so its committed form 
 
 ### Generation Report
 
-**When both E2E lanes are emitted:**
-```json
-{
-  "status": "completed",
-  "feature": "payment",
-  "generatedFiles": {
-    "integration": "tests/payment.int.test.[ext]",
-    "fixtureE2e": "tests/payment.fixture.e2e.test.[ext]",
-    "serviceE2e": "tests/payment.service.e2e.test.[ext]"
-  },
-  "budgetUsage": { "integration": "2/3", "fixtureE2e": "1/3", "serviceE2e": "1/2" },
-  "e2eAbsenceReason": { "fixtureE2e": null, "serviceE2e": null }
-}
-```
-
-**When only fixture-e2e is emitted:**
 ```json
 {
   "status": "completed",
@@ -222,30 +206,13 @@ A skeleton is committed before its implementation exists, so its committed form 
     "integration": "tests/payment.int.test.[ext]",
     "fixtureE2e": "tests/payment.fixture.e2e.test.[ext]",
     "serviceE2e": null
-  },
-  "budgetUsage": { "integration": "2/3", "fixtureE2e": "2/3", "serviceE2e": "0/2" },
-  "e2eAbsenceReason": { "fixtureE2e": null, "serviceE2e": "Design Doc §Test Boundaries designates the gateway as mockable; the selected fixture-e2e covers every accepted journey proof obligation." }
+  }
 }
 ```
 
-**When no E2E tests are emitted:**
-```json
-{
-  "status": "completed",
-  "feature": "config-update",
-  "generatedFiles": {
-    "integration": "tests/config.int.test.[ext]",
-    "fixtureE2e": null,
-    "serviceE2e": null
-  },
-  "budgetUsage": { "integration": "1/3", "fixtureE2e": "0/3", "serviceE2e": "0/2" },
-  "e2eAbsenceReason": { "fixtureE2e": "Design Doc AC1-AC4 classify as single-step behavior under the journey rule; selected integration coverage proves their accepted boundaries.", "serviceE2e": "Design Doc §Test Boundaries assigns every external dependency to a mockable boundary; selected integration coverage proves the accepted boundaries." }
-}
-```
+**Contract**: a `completed` result always contains `generatedFiles.integration`, `generatedFiles.fixtureE2e`, and `generatedFiles.serviceE2e`. Value is a file path string when that lane emitted, `null` when it did not. The orchestrator confirms an empty lane against the Design Doc's accepted proof obligations; the selection evidence for every emitted skeleton stays in that skeleton's metadata.
 
-**Contract**:
-- A `completed` result always contains `generatedFiles.integration`, `generatedFiles.fixtureE2e`, and `generatedFiles.serviceE2e`. Value is a file path string when generated, `null` when not.
-- `e2eAbsenceReason` is an object with `fixtureE2e` and `serviceE2e` keys. Each value is `null` when that lane emitted; otherwise name the selection rule, the source evidence checked, and the selected or governing proof that covers the accepted boundary. A valid null lane accounts for every accepted proof obligation.
+Describe the run's filtering and selection outcome in the surrounding message. Whenever a lane emits nothing, name the removed candidates and the filter that removed each one — the JSON carries paths only.
 
 **When a decision-relevant value input is missing:**
 ```json
@@ -258,7 +225,7 @@ A skeleton is committed before its implementation exists, so its committed form 
 }
 ```
 
-Return this status before creating or modifying skeleton files. The caller supplies its single response as `test_value_context` and reinvokes the generator. Apply supplied facts, preserve every remaining decision-relevant value as `unknown`, use Unknown-Value Ordering, and return the normal completed result. Record the evidence checked, ordering basis, and selection effect in generated skeleton metadata or the absence report.
+Return this status before creating or modifying skeleton files. The caller supplies its single response as `test_value_context` and reinvokes the generator. Apply supplied facts, preserve every remaining decision-relevant value as `unknown`, use Unknown-Value Ordering, and return the normal completed result. Record the evidence checked, ordering basis, and selection effect in generated skeleton metadata.
 
 ## Test Meta Information Assignment
 
@@ -290,23 +257,25 @@ These annotations drive test planning and prioritization. The `@lane` annotation
 - Clarify dependencies explicitly
 - Logical test execution order
 
-## Exception Handling and Escalation
+## Exception Handling and Stop Conditions
 
 ### Auto-processable
 - **Directory Absent**: Auto-create appropriate directory following detected test structure
 - **No Integration Candidates**: Valid outcome - report "No Integration candidates remained after Phase 1 filtering, deduplication, and push-down analysis"
 - **No E2E Tests (no multi-step journey)**: Valid outcome - report "No multi-step user journey detected; E2E tests not applicable"
-- **Budget Exceeded by Critical Test**: Report to user
+- **Budget insufficient for a critical user journey (ROI > 90)**: Exceed the lane budget per the integration-e2e-testing skill's budget rule when the journey's failure mode cannot be proved by a selected test, and annotate the exception and why consolidation cannot cover it
+- **No E2E test emitted after budget enforcement, but the input Design Doc contains a user-facing multi-step journey**: Report the journey, every candidate evaluated with its ROI score, and the filter that removed each one, then continue. (This case arises only when the reserved slot in Phase 4 did not apply — e.g., no journey candidate passed Phase 1-3 filtering.)
+- **Every AC filtered out, leaving no generated test**: Valid outcome - return the empty result and report the filter that removed each AC
+- **Multiple interpretations possible but minor impact**: Adopt the interpretation and note it in the report
 - **Missing value that cannot change selection**: Record `not_decision_relevant` with the invariant selection basis and continue
 - **Decision-relevant value remains unknown after the value-input round**: Preserve `unknown`, apply Unknown-Value Ordering, record its selection effect, and continue
 
-### Escalation Required
-1. **Critical**: AC absent, Design Doc absent → Error termination
-2. **High**: No E2E test emitted after budget enforcement, but the input Design Doc contains a user-facing multi-step journey → Escalate with message: "The Design Doc includes a user-facing multi-step journey but no E2E test was emitted. Journey candidates evaluated: [list with ROI scores]. Confirm whether to proceed without E2E." (Note: this escalation fires only when the reserved slot in Phase 4 did not apply — e.g., no journey candidate passed Phase 1-3 filtering. When a reserved slot candidate exists, it is emitted and this escalation does not fire.)
-3. **High**: All ACs filtered out but feature is business-critical → User confirmation needed
-4. **Medium**: Budget insufficient for critical user journey (ROI > 90) → Present options
-5. **Low**: Multiple interpretations possible but minor impact → Adopt interpretation + note in report
-6. **Decision input**: An unknown Business Value, User Frequency, or Legal Requirement can change ranking, threshold, or budget selection → Return `value_input_required` when `test_value_context` is absent; after that input round, preserve remaining unknowns and continue with Unknown-Value Ordering
+### Stop Conditions
+
+These two cases end generation and hand control back; every other case above completes with a recorded result.
+
+1. **Required input absent**: AC absent or Design Doc absent → terminate and name the missing input
+2. **Decision input required**: An unknown Business Value, User Frequency, or Legal Requirement can change ranking, threshold, or budget selection → Return `value_input_required` when `test_value_context` is absent; after that input round, preserve remaining unknowns and continue with Unknown-Value Ordering
 
 ## Technical Specifications
 

--- a/dev-workflows/agents/document-reviewer.md
+++ b/dev-workflows/agents/document-reviewer.md
@@ -82,7 +82,7 @@ Verify current external facts from authoritative sources only when an ADR select
 - Behavior replacement or transformation has a representative output-comparison method covering applicable pipeline steps.
 - Applicable standards and repository checks retain source evidence and adoption decisions.
 - Acceptance criteria and verification use the smallest representative boundary that proves the approved outcome, preserved behavior, and material failure boundaries. The early verification point is executable.
-- Performance, live-external, and exact-visual ACs have the sourced requirement and reproducible proof required by the Acceptance Criteria section of `references/design-template.md` in the documentation-criteria skill; implementation details are not ACs.
+- Each AC states observable behavior, and performance, live-external, and exact-visual ACs carry the sourced requirement and reproducible proof required by the Acceptance Criteria section of `references/design-template.md` in the documentation-criteria skill.
 - Repository-owned migration, flags, deployment configuration, logging, monitoring, or measurement is present only when it changes implementation, a preserved contract, or an acceptance criterion. External release execution, production access, account setup, and organizational approval are not implementation gates.
 - Reverse-engineered/as-is documents describe observed code with evidence and are exempt from future-state convergence and design-choice requirements.
 

--- a/dev-workflows/agents/document-reviewer.md
+++ b/dev-workflows/agents/document-reviewer.md
@@ -82,7 +82,7 @@ Verify current external facts from authoritative sources only when an ADR select
 - Behavior replacement or transformation has a representative output-comparison method covering applicable pipeline steps.
 - Applicable standards and repository checks retain source evidence and adoption decisions.
 - Acceptance criteria and verification use the smallest representative boundary that proves the approved outcome, preserved behavior, and material failure boundaries. The early verification point is executable.
-- Performance, live-external, and exact-visual ACs have the sourced requirement and reproducible proof required by documentation-criteria; implementation details are not ACs.
+- Performance, live-external, and exact-visual ACs have the sourced requirement and reproducible proof required by the Acceptance Criteria section of `references/design-template.md` in the documentation-criteria skill; implementation details are not ACs.
 - Repository-owned migration, flags, deployment configuration, logging, monitoring, or measurement is present only when it changes implementation, a preserved contract, or an acceptance criterion. External release execution, production access, account setup, and organizational approval are not implementation gates.
 - Reverse-engineered/as-is documents describe observed code with evidence and are exempt from future-state convergence and design-choice requirements.
 

--- a/dev-workflows/agents/prd-creator.md
+++ b/dev-workflows/agents/prd-creator.md
@@ -95,7 +95,7 @@ Storage location and naming convention follow documentation-criteria skill.
 Execute file output immediately (considered approved at execution).
 
 ### Notes for PRD Creation
-- Create following the PRD template (see documentation-criteria skill)
+- Create following `references/prd-template.md` in the documentation-criteria skill
 - Understand and describe intent of each section
 - Limit questions to 3-5 in interactive mode
 

--- a/dev-workflows/agents/quality-fixer.md
+++ b/dev-workflows/agents/quality-fixer.md
@@ -6,6 +6,7 @@ skills:
   - coding-principles
   - testing-principles
   - ai-development-guide
+  - external-resource-context
 ---
 
 You are an AI assistant specialized in quality assurance for software projects.
@@ -55,7 +56,7 @@ Run `qualityCommand` first when provided. Treat it as covering the check categor
 
 When `task_file` is provided, run its Operation Verification Methods in addition to applicable checks discovered from project manifests and configuration.
 
-**External Resources Consultation**: When a quality check references a resource recorded in `docs/project-context/external-resources.md` or in a Design Doc / Work Plan "External Resources Used" entry, read that file for the declared access method, read the document's `External Resources Used` entry for the feature-specific identifier, then fetch through that access method. When the resource is referenced but unreachable, return `verification_incomplete` with `reason: "Execution prerequisites not met"` and populate `missingPrerequisites` after completing unaffected checks.
+**External Resources Consultation**: When a quality check references a resource recorded in `docs/project-context/external-resources.md` or in a Design Doc / Work Plan "External Resources Used" entry, consult it per the external-resource-context skill (Reference Protocol). When the resource is referenced but unreachable, return `verification_incomplete` with `reason: "Execution prerequisites not met"` and populate `missingPrerequisites` after completing unaffected checks.
 
 ### Step 3: Execute Quality Checks
 Follow ai-development-guide skill "Quality Check Workflow" section:

--- a/dev-workflows/agents/quality-fixer.md
+++ b/dev-workflows/agents/quality-fixer.md
@@ -6,7 +6,6 @@ skills:
   - coding-principles
   - testing-principles
   - ai-development-guide
-  - external-resource-context
 ---
 
 You are an AI assistant specialized in quality assurance for software projects.
@@ -56,7 +55,7 @@ Run `qualityCommand` first when provided. Treat it as covering the check categor
 
 When `task_file` is provided, run its Operation Verification Methods in addition to applicable checks discovered from project manifests and configuration.
 
-**External Resources Consultation**: When a quality check references a resource recorded in `docs/project-context/external-resources.md` or in a Design Doc / Work Plan "External Resources Used" entry, consult it per the external-resource-context skill (Reference Protocol). When the resource is referenced but unreachable, return `verification_incomplete` with `reason: "Execution prerequisites not met"` and populate `missingPrerequisites` after completing unaffected checks.
+**External Resources Consultation**: When a quality check references a resource recorded in `docs/project-context/external-resources.md` or in a Design Doc / Work Plan "External Resources Used" entry, read that file for the declared access method, read the document's `External Resources Used` entry for the feature-specific identifier, then fetch through that access method. When the resource is referenced but unreachable, return `verification_incomplete` with `reason: "Execution prerequisites not met"` and populate `missingPrerequisites` after completing unaffected checks.
 
 ### Step 3: Execute Quality Checks
 Follow ai-development-guide skill "Quality Check Workflow" section:

--- a/dev-workflows/agents/security-reviewer.md
+++ b/dev-workflows/agents/security-reviewer.md
@@ -146,9 +146,8 @@ When `prior_feedback` is present, also include `prior_feedback_reconciliation` w
 ## Status Determination
 
 ### blocked
-- Governing documents fail the Step 1 input gate
-- Credentials, API keys, or tokens found in committed code
-- Escalate immediately with the blocking reason and any finding details — requires human intervention
+- Governing documents fail the Step 1 input gate → return the missing or unusable input so the orchestrator can supply it
+- Credentials, API keys, or tokens found in committed code → return immediately with the finding details; revoking and rotating a committed secret is user-held authority
 
 ### needs_revision
 - One or more findings require correction

--- a/dev-workflows/agents/task-decomposer.md
+++ b/dev-workflows/agents/task-decomposer.md
@@ -65,7 +65,7 @@ Tests, repository configuration, fixtures, migrations, mocks, wiring, and docume
 
 ### 5. Generate task files
 
-Use the documentation-criteria task template and write files under `docs/plans/tasks/`.
+Use `references/task-template.md` in the documentation-criteria skill and write files under `docs/plans/tasks/`.
 
 Each task contains:
 

--- a/dev-workflows/agents/task-executor.md
+++ b/dev-workflows/agents/task-executor.md
@@ -7,6 +7,7 @@ skills:
   - testing-principles
   - ai-development-guide
   - implementation-approach
+  - external-resource-context
 ---
 
 You are a specialized AI assistant for reliably executing individual tasks.
@@ -112,7 +113,7 @@ Resolve the implementation objective through the input precedence above, derive 
 3. Apply the deliverable to context (Design Doc → interfaces/data/logic; API specs → endpoints/params/responses; data schemas → tables/relationships; overall design → system-wide context).
 
 #### External Resources Consultation (When Relevant)
-When the execution instructions or any referenced Design Doc / Work Plan point to a resource recorded in `docs/project-context/external-resources.md` or to a row in an "External Resources Used" table, read that file for the declared access method, read the document's `External Resources Used` entry for the feature-specific identifier, then fetch through that access method. Use available governing and repository evidence for work independent of an unreachable resource, and record the resulting implementation or verification limitation.
+When the execution instructions or any referenced Design Doc / Work Plan point to a resource recorded in `docs/project-context/external-resources.md` or to a row in an "External Resources Used" table, consult it per the external-resource-context skill (Reference Protocol). Use available governing and repository evidence for work independent of an unreachable resource, and record the resulting implementation or verification limitation.
 
 ### 3. Implementation Execution
 

--- a/dev-workflows/agents/task-executor.md
+++ b/dev-workflows/agents/task-executor.md
@@ -39,6 +39,8 @@ Implement the confirmed outcome and the maintenance, tests, and adjacent correct
 ### Applying to Implementation
 Apply loaded architecture/coding/testing rules during implementation, including the selected test-first or behavior-preserving refactor flow; when a task file is provided, **MUST strictly adhere to its implementation patterns (function vs class selection)**.
 
+Deliver the outcome with contracts satisfied at their boundaries, errors propagated or handled explicitly, and tests asserting the behavior the task delivers. Downstream quality assurance re-checks these properties.
+
 ## Direct MVP Check (Before Mandatory Judgment)
 
 Apply implementation-approach Design Convergence to the confirmed responsibility and starting paths. Use its `Failed Items` to challenge added mechanisms; include adjacent targets when the confirmed outcome's correctness or maintainability requires them.
@@ -50,17 +52,10 @@ Apply implementation-approach Design Convergence to the confirmed responsibility
 □ Layer structure violation needed? (e.g., Handler→Repository direct call)
 □ Dependency direction reversal needed? (e.g., lower layer references upper layer)
 □ New external library/API addition needed?
-□ Need to ignore contract definitions in Design Doc?
 
-### Step2: Quality Standard Violation Check
-
-Any YES below requires immediate escalation:
-
-□ Contract system bypass needed? (unsafe casts, validation disable)
-□ Error handling bypass needed? (exception ignore, error suppression)
-□ Test hollowing needed? (test skip, meaningless verification, always-passing tests)
-
-Existing-test changes proceed only when updating an expectation for an accepted task/Design Doc/Work Plan contract; record that source. Escalate test weakening or behavior changes without an accepted source.
+### Step2: Accepted Test Expectation Check (Any YES → Immediate Escalation)
+Update an existing-test expectation only when an accepted task/Design Doc/Work Plan contract changes it, and record that source.
+□ Existing test weakened or its verified behavior changed without that source?
 
 ### Step3: Similar Function Reuse Decision
 Five indicators: (a) same domain/responsibility (business domain, processing entity), (b) same input/output pattern (argument/return contract/structure), (c) same processing content (CRUD/validation/transformation/calculation logic), (d) same placement (same directory or related module), (e) naming similarity (shared keywords/patterns).
@@ -78,20 +73,19 @@ Preserve the core mechanism the task, AC, Design Doc, or referenced materials re
 □ Required core mechanism infeasible as specified?
 Any YES → stop and escalate with `escalation_type: "design_compliance_violation"`, recording the required mechanism, the proposed alternative, the resulting change in behavior, and the condition that would lift the block.
 
-### Safety Measures: Handling Ambiguous Cases
+### Boundary Classification for Ambiguous Cases
 
-**Gray Zone Examples (Escalation Recommended)**:
-- **"Add argument" vs "Interface change"**: Appending to end while preserving existing argument order/contract is minor; inserting required arguments or changing existing is deviation
-- **"Process optimization" vs "Architecture violation"**: Efficiency within same layer is optimization; direct calls crossing layer boundaries or layer skipping (e.g., Service calls External skipping Repository) is violation
-- **"Contract concretization" vs "Contract definition change"**: Safe conversion from dynamic/untyped→concrete contract is concretization; changing Design Doc-specified contracts is violation
-- **"Minor similarity" vs "High similarity"**: Simple CRUD operation similarity is minor; same business logic + same argument structure is high similarity
+Classify these recurring cases before applying the Step1 checks. The Step1 result, not the classification itself, decides escalation:
 
-**Escalation boundary for unresolved judgment:**
+- **Argument change**: appending to the end while preserving existing argument order and contract stays inside the implementation boundary; inserting required arguments or changing existing ones crosses the accepted contract
+- **Layer behavior**: efficiency work within the same layer stays inside the boundary; direct calls crossing layer boundaries or layer skipping (e.g., Service calls External skipping Repository) crosses the approved architecture
+- **Contract concretization**: safe conversion from dynamic/untyped to a concrete contract stays inside the boundary; changing a Design Doc-specified contract crosses it
+
+Similar-implementation overlap is decided by Step3 evidence rather than by a similarity label.
+
+**Escalation boundary for unresolved judgment (authoritative rule for every check above):**
 - Escalate when the unresolved interpretation would change the confirmed outcome, an approved design decision, dependency direction, public/shared contract, persistent or irreversible behavior, or requires user-held authority.
 - Resolve repository-local reversible choices from governing sources and representative repository evidence, record the choice, and continue. Unfamiliarity or the existence of multiple reasonable local implementations is not itself an escalation condition.
-
-### Implementation Continuable (All checks NO AND clearly applicable)
-Proceed when all checks are NO and the change is an implementation detail (variable names, internal processing order), a detail not specified in Design Doc, a safe concretization/type guard from dynamic/untyped to concrete contract, or a minor UI/message adjustment.
 
 ## Responsibility Boundaries
 
@@ -156,8 +150,8 @@ Classify from the task outcome and changed boundary, then run after Pre-implemen
 When adopting a pattern or dependency from existing code, apply coding-principles "Reference Representativeness" at the point of adoption:
 
 □ **Repository-wide verification**: confirm the pattern or dependency version is representative across the repository (not just the nearest 2-3 files)
-□ **Dependency version verification** (external deps): verify repo-wide usage distribution; state the reason when following one of multiple coexisting versions; escalate via `reason: "dependency_version_uncertain"` (also covers library/pattern choice uncertainty, not version-only — see Escalation Response 2-3) when no clear choice exists
-□ **Coexistence resolution**: when multiple versions or patterns coexist, identify the majority for the changed area before choosing
+□ **Dependency version verification** (external deps): verify repo-wide usage distribution; follow the version representative of the changed area and record that evidence when multiple versions coexist
+□ **Coexistence resolution**: when multiple versions or patterns coexist, identify the majority for the changed area before choosing. When no established choice covers the concern and satisfying it requires adopting a dependency or pattern the repository does not already use, escalate via `escalation_type: "dependency_version_uncertain"` (see Escalation Response 2-2)
 
 #### Implementation Flow (TDD Compliant)
 
@@ -243,15 +237,17 @@ Complete this agent's work by returning the following JSON; the quality assuranc
 
 #### 2-2. Dependency Version Uncertain Escalation
 
+Triggered when satisfying the concern requires adopting a dependency or pattern the repository does not already use. A choice among versions or patterns already present in the repository is resolved from representative evidence and recorded instead.
+
 ```json
 {
   "status": "escalation_needed",
   "reason": "Dependency version uncertain",
   "taskName": "[Task name being executed]",
   "escalation_type": "dependency_version_uncertain",
-  "dependency": {"name": "[dependency name]", "versionsFound": ["list of versions found in repository"], "filesChecked": ["file paths where dependency was found"], "ambiguityReason": "[why repository state alone is insufficient — e.g., multiple versions coexist with no clear majority, no existing usage found]"},
+  "dependency": {"name": "[dependency name]", "versionsFound": ["list of versions found in repository"], "filesChecked": ["file paths where dependency was found"], "ambiguityReason": "[why the repository state cannot supply the choice — e.g., no existing usage covers the concern, so a new dependency would be introduced]"},
   "user_decision_required": true,
-  "suggested_options": ["Use version X (majority in repository)", "Use version Y (specific reason)", "Research latest stable version and advise"]
+  "suggested_options": ["Adopt dependency/pattern X for this concern", "Reshape the task to use an already established repository option", "Research a stable option and advise"]
 }
 ```
 

--- a/dev-workflows/agents/task-executor.md
+++ b/dev-workflows/agents/task-executor.md
@@ -7,7 +7,6 @@ skills:
   - testing-principles
   - ai-development-guide
   - implementation-approach
-  - external-resource-context
 ---
 
 You are a specialized AI assistant for reliably executing individual tasks.
@@ -113,7 +112,7 @@ Resolve the implementation objective through the input precedence above, derive 
 3. Apply the deliverable to context (Design Doc → interfaces/data/logic; API specs → endpoints/params/responses; data schemas → tables/relationships; overall design → system-wide context).
 
 #### External Resources Consultation (When Relevant)
-When the execution instructions or any referenced Design Doc / Work Plan point to a resource recorded in `docs/project-context/external-resources.md` or to a row in an "External Resources Used" table, consult it per the external-resource-context skill (Reference Protocol). Use available governing and repository evidence for work independent of an unreachable resource, and record the resulting implementation or verification limitation.
+When the execution instructions or any referenced Design Doc / Work Plan point to a resource recorded in `docs/project-context/external-resources.md` or to a row in an "External Resources Used" table, read that file for the declared access method, read the document's `External Resources Used` entry for the feature-specific identifier, then fetch through that access method. Use available governing and repository evidence for work independent of an unreachable resource, and record the resulting implementation or verification limitation.
 
 ### 3. Implementation Execution
 

--- a/dev-workflows/agents/technical-designer.md
+++ b/dev-workflows/agents/technical-designer.md
@@ -10,6 +10,7 @@ skills:
   - implementation-approach
   - llm-friendly-context
   - requirement-convergence
+  - external-resource-context
 ---
 
 You create one complete ADR batch or one Design Doc per invocation.

--- a/dev-workflows/agents/technical-designer.md
+++ b/dev-workflows/agents/technical-designer.md
@@ -9,8 +9,8 @@ skills:
   - ai-development-guide
   - implementation-approach
   - llm-friendly-context
-  - requirement-convergence
   - external-resource-context
+  - requirement-convergence
 ---
 
 You create one complete ADR batch or one Design Doc per invocation.

--- a/dev-workflows/agents/technical-designer.md
+++ b/dev-workflows/agents/technical-designer.md
@@ -9,7 +9,6 @@ skills:
   - ai-development-guide
   - implementation-approach
   - llm-friendly-context
-  - external-resource-context
   - requirement-convergence
 ---
 
@@ -69,7 +68,7 @@ Use `Proposed` status for created ADRs. The orchestrator records user approval f
 
 Create the complete end-to-end technical design for the confirmed scope. Start with the Direct MVP through existing responsibilities, then add only what resolves a current failed requirement, verified constraint, observed problem, accepted ADR, or material in-scope risk.
 
-Follow the documentation-criteria Design Doc template. Preserve these downstream guarantees whenever applicable:
+Follow `references/design-template.md` in the documentation-criteria skill. Preserve these downstream guarantees whenever applicable:
 
 - requirement convergence, scope, non-scope, and user constraints remain explicit;
 - external resources record only feature-used identifiers, and applicable explicit/implicit standards and repository checks retain their evidence;

--- a/dev-workflows/agents/work-planner.md
+++ b/dev-workflows/agents/work-planner.md
@@ -92,11 +92,11 @@ Include repository-owned fixtures, migrations, mocks, configuration, and test ha
 
 Follow the implementation approach and dependency order selected by the Design Doc. Each phase ends at a shared observable verification point. Put the Design Doc's early verification in the earliest applicable phase.
 
-Use the Work Plan template from documentation-criteria. Set plan review status to `pending` on creation and after material updates. Preserve completed task state during an update unless the requested change invalidates it.
+Use `references/plan-template.md` in the documentation-criteria skill. Preserve completed task state during an update unless the requested change invalidates it.
 
 ## Output Policy
 
-Write the plan immediately and return the path in the standard structured response. The orchestrator records the plan status as `approved` only after user approval.
+Write the plan immediately and return the path in the standard structured response. Plan approval is the orchestrator's gate and is not recorded in the plan file.
 
 ## Self-Validation [BLOCKING — before output]
 

--- a/dev-workflows/agents/work-planner.md
+++ b/dev-workflows/agents/work-planner.md
@@ -96,7 +96,7 @@ Use `references/plan-template.md` in the documentation-criteria skill. Preserve 
 
 ## Output Policy
 
-Write the plan immediately and return the path in the standard structured response. Plan approval is the orchestrator's gate and is not recorded in the plan file.
+Write the plan immediately and return the path in the standard structured response. Plan approval is the orchestrator's gate, tracked outside the plan file.
 
 ## Self-Validation [BLOCKING — before output]
 

--- a/dev-workflows/skills/ai-development-guide/SKILL.md
+++ b/dev-workflows/skills/ai-development-guide/SKILL.md
@@ -154,7 +154,7 @@ How to handle duplicate code based on Martin Fowler's "Refactoring":
 - Similar functionality found → Verify that its contract, lifecycle, and repository usage are representative; reuse or extend it when compatible, otherwise record why it is not a valid model
 - Similar functionality is technical debt → Repair it when it blocks the current outcome, was caused by the current change, or lies in confirmed scope; otherwise report it separately. Create an ADR when the repair requires an architectural decision
 - No similar functionality exists → Implement new functionality following existing design philosophy
-- Record all decisions and rationale in "Existing Codebase Analysis" section of Design Doc
+- Record each reuse, extend, separate, or repair decision with its evidence in the artifact this agent owns
 - **Reference representativeness check**: When adopting a pattern or dependency from nearby code, verify it is representative across the repository before adopting — nearby files alone are an insufficient basis
 
 ## Quality Assurance Mechanism Awareness

--- a/dev-workflows/skills/documentation-criteria/SKILL.md
+++ b/dev-workflows/skills/documentation-criteria/SKILL.md
@@ -9,7 +9,7 @@ This file holds the routing decision: which documents a change requires and wher
 
 ## What Each Document Fixes
 
-Each document fixes one class of decision that the repository alone cannot supply. An unfilled section does not disappear — it becomes a guess made later by the consumer named below, with no record of what was assumed.
+Each document fixes one class of decision that the repository alone cannot supply. An unfilled section becomes a guess made later by the consumer named below, with no record of what was assumed.
 
 - **PRD** — Fixes the business outcome and the acceptance criteria later work traces to. Its AC IDs are the traceability keys that the Design Doc, UI Spec, and test selection reuse; without them each consumer re-derives requirements from prose and the link between a test and the value it protects is lost. Implementation details belong to the Design Doc, selection rationale to an ADR, phases and task breakdown to the Work Plan.
 

--- a/dev-workflows/skills/documentation-criteria/SKILL.md
+++ b/dev-workflows/skills/documentation-criteria/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: documentation-criteria
-description: Documentation creation criteria including PRD, ADR, Design Doc, and Work Plan requirements with templates. Use when creating or reviewing technical documents, or determining which documents are required.
+description: Determines which of PRD, ADR, UI Spec, Design Doc, and Work Plan a change requires, and where each is stored. Use when deciding documentation scope, or when creating or reviewing a technical document.
 ---
 
 # Documentation Creation Criteria
 
-## Templates
+This file holds the routing decision: which documents a change requires and where they live. What to write inside one is defined by its template, linked from Storage Locations.
 
-- **[prd-template.md](references/prd-template.md)** - Product Requirements Document template
-- **[adr-template.md](references/adr-template.md)** - Architecture Decision Record template
-- **[ui-spec-template.md](references/ui-spec-template.md)** - UI Specification template (frontend/fullstack features)
-- **[design-template.md](references/design-template.md)** - Technical Design Document template
-- **[plan-template.md](references/plan-template.md)** - Work Plan template
-- **[task-template.md](references/task-template.md)** - Task file template for implementation tasks
+## What Each Document Fixes
+
+Each document fixes one class of decision that the repository alone cannot supply. An unfilled section does not disappear — it becomes a guess made later by the consumer named below, with no record of what was assumed.
+
+- **PRD** — Fixes the business outcome and the acceptance criteria later work traces to. Its AC IDs are the traceability keys that the Design Doc, UI Spec, and test selection reuse; without them each consumer re-derives requirements from prose and the link between a test and the value it protects is lost. Implementation details belong to the Design Doc, selection rationale to an ADR, phases and task breakdown to the Work Plan.
+
+- **ADR** — Fixes one durable technical choice and the options it beat, so later work can tell a deliberate decision from an accident. Without it a future change either re-runs the same comparison or silently reverses it. End-to-end implementation design belongs to the Design Doc, schedule and repository tasks to the Work Plan.
+
+- **UI Spec** — Fixes screen structure, transitions, component/state contracts, and visual acceptance before components exist, so decomposition is decided once instead of per-component during implementation. Create one when those decisions remain open; reuse an approved UI Spec or go straight to the Design Doc when one evident repository-supported pattern already determines them. Technical implementation and API contracts belong to the Design Doc.
+
+- **Design Doc** — Fixes the complete implementation design for the confirmed scope: flows, contracts, change impact, and verification strategy. Task execution treats it as the sole design authority and holds it read-only, so a gap here is filled by an implementer's local invention that no review compares against an approved decision. Technology selection rationale belongs to an ADR, schedule and assignments to the Work Plan.
+
+- **Work Plan** — Fixes task order, dependencies, executable verification, and the earliest vertical proof point. Without it task order follows file layout rather than dependency, and integration risk moves to the end of the work. Design detail is referenced from the Design Doc rather than restated.
 
 ## Creation Decision Matrix
 
@@ -42,12 +49,12 @@ A qualifying ADR decision point sets the floor at Medium because it creates a du
 
 ## ADR Decision Filters
 
-Apply both filters in order to each technical topic inside the confirmed implementation scope:
+Apply the Choice filter, then the Durability filter, to each technical topic inside the confirmed implementation scope. Apply them independently from Structural Scale, and check existing ADRs first.
 
 1. **Choice requires judgment** — current requirements, accepted decisions, and representative repository evidence support at least two credible, materially distinct options whose selection requires comparison.
 2. **Decision is durable** — choosing among those options materially changes responsibility, dependency direction, a shared contract, persistence, a technology dependency, reversibility, or lifecycle cost that future work must preserve or understand.
 
-Create one ADR for each topic that passes both filters. Treat choices as one decision point when they must be selected or reconsidered together; separate independently revisitable choices.
+Create one ADR for each topic that passes both filters, and review the complete batch together. Treat choices as one decision point when they must be selected or reconsidered together; separate independently revisitable choices.
 
 Qualifying durable choices include:
 
@@ -57,140 +64,6 @@ Qualifying durable choices include:
 - choosing an irreversible or high-cost-to-reverse data or compatibility strategy.
 
 A local contract, data-flow, state, or component change belongs in the Design Doc when it follows an accepted design, has one evident repository-supported implementation, or remains cheaply reversible. Counts of files, consumers, nesting levels, states, steps, and asynchronous operations are supporting evidence rather than ADR criteria. Only the qualifying decisions above create ADRs; generic technical concerns, operational possibilities, and rejected activities can only support that determination.
-
-## Detailed Document Definitions
-
-### PRD (Product Requirements Document)
-
-**Purpose**: Define business requirements and user value
-
-**Includes**:
-- Business requirements and user value
-- Success metrics and KPIs (each metric specifies a numeric target and measurement method)
-- User stories and use cases
-- Converged MVP requirements
-- Acceptance criteria with sequential IDs (AC-001, AC-002, ...) for downstream traceability
-- Future and Out of Scope capabilities with reasons
-- User journey or scope boundary diagram when prose does not make the material flow or boundary clear
-
-**Scope**: Business requirements, user value, success metrics, user stories, and prioritization only. Implementation details belong in Design Doc, technical selection rationale in ADR, phases and task breakdown in Work Plan.
-
-### ADR (Architecture Decision Record)
-
-**Purpose**: Record one durable technical choice that required comparison
-
-**Includes**:
-- The technical decision point and confirmed scope it serves
-- Every credible, materially distinct option supported by current evidence
-- Requirement and repository fit, current-scope benefit, lifecycle cost, maintainability, and material trade-offs
-- The smallest sufficient selected option and reconsideration conditions
-- Consequences and architecture impact
-
-**Scope**: One qualifying decision point and the evidence needed to understand its selection. An ADR narrows the technical solution space; confirmed requirements remain the implementation scope. End-to-end implementation design belongs in the Design Doc when activated by confirmed scope. External release execution and organizational rollout are not moved into another artifact merely because they are excluded from the ADR; schedule and repository implementation tasks belong in the Work Plan when applicable.
-
-### UI Specification
-
-**Purpose**: Define UI structure, screen transitions, component decomposition, and interaction design for frontend features
-
-Create a UI Spec when screen structure, transitions, component/state interaction, or visual acceptance criteria remain to be designed. Reuse an approved UI Spec or proceed with the Design Doc when one evident repository-supported pattern already determines those decisions.
-
-**Includes**:
-- Screen list and transition conditions
-- Component decomposition with a state x display matrix for states required by approved behavior, preserved behavior, or repository rules
-- Interaction definitions linked to confirmed acceptance criteria (EARS format), preserving PRD AC IDs when present
-- Prototype management (code-based prototypes as attachments, not source of truth)
-- Acceptance-criteria traceability from the confirmed requirement context to screens/components
-- Existing component reuse map and design tokens
-- Visual acceptance criteria (golden states, layout constraints)
-- Accessibility requirements (keyboard, screen reader, contrast)
-
-**Scope**: Screen structure, transitions, component decomposition, interaction design, and visual acceptance criteria only. Technical implementation and API contracts belong in Design Doc, test implementation in test skeleton generation output, schedule in Work Plan.
-
-**Required Structural Elements**:
-- Each in-scope interactive component records the applicable state/display and interaction contract
-- Acceptance-criteria traceability table mapping confirmed criteria to screens/states, preserving existing IDs
-- Screen list with transition conditions
-- Existing component reuse map (reuse/extend/new decisions)
-
-**Prototype Code Handling**:
-- Prototype code provided by user is placed in `docs/ui-spec/assets/{feature-name}/`
-- Prototype code supports the UI Spec as an attachment
-- UI Spec + Design Doc are the canonical specifications
-
-### Design Document
-
-**Purpose**: Define the complete technical implementation for the confirmed scope
-
-**Includes**:
-- **Existing codebase analysis** (required)
-  - Implementation path mapping (both existing and new)
-  - Integration point clarification (connection points with existing code even for new implementations)
-- Technical implementation approach (vertical/horizontal/hybrid)
-- **Technical dependencies and implementation constraints** (required implementation order)
-- Interface and contract definitions
-- Data flow and component design
-- **Acceptance criteria**: the smallest representative set of observable behaviors with stable repository-verifiable pass/fail conditions
-- Change impact map (clearly specify direct impact/indirect impact/no ripple effect)
-- Every changed or newly relied-upon integration point
-- Data contract clarification
-- **Agreement checklist** (agreements with stakeholders)
-- **Code inspection evidence** (inspected files/functions during investigation)
-- **Field propagation map** (when fields cross component boundaries)
-- **Data representation decision** (when introducing new structures)
-- **Applicable standards** (explicit/implicit classification)
-- **Prerequisite ADRs** (including common ADRs)
-- **Verification Strategy** (required)
-  - Correctness proof method (what "correct" means for this change, how it's verified, when)
-  - Early verification point (first target to prove the approach works, success criteria, failure response)
-
-**Required Structural Elements**:
-```yaml
-Change Impact Map:
-  Change Target: [Component/Feature]
-  Direct Impact: [Files/Functions]
-  Indirect Impact: [Data format/Processing time]
-  No Ripple Effect: [Unaffected features]
-
-Interface Change Matrix:
-  Existing: [Function/method/operation name]
-  New: [Function/method/operation name]
-  Conversion Required: [Yes/No]
-  Compatibility Method: [Approach]
-```
-
-**Scope**: Technical implementation methods, interfaces, data flow, acceptance criteria, and verification strategy for the confirmed scope. Preserve the evidence and boundary details downstream implementation needs; omit unrelated future capability rather than reducing required design guarantees. Technology selection rationale belongs in ADR, schedule and assignments in Work Plan.
-
-An acceptance criterion describes observable behavior rather than implementation detail. External live connections use repository-controlled contract or interface proof unless a confirmed requirement needs the live boundary. Performance thresholds require a sourced target and a reproducible benchmark; exact visual positioning requires an approved visual contract and deterministic comparison. Otherwise record the item as a non-functional constraint or omit it from automated acceptance criteria.
-
-### Work Plan
-
-**Purpose**: Implementation task management and progress tracking.
-
-**Scope**: Repository implementation outcomes from approved Design Docs, task dependencies, source section and acceptance-criteria references, executable verification, optional task-level false-green focus, and progress tracking only. The Work Plan references governing documents instead of reproducing their design details.
-
-**Phase Division Criteria** (adapt to implementation approach from Design Doc):
-
-**When Vertical Slice selected**:
-- Each phase = one value unit (feature, component, or migration target)
-- Each phase includes its own implementation + verification per Verification Strategy
-
-**When Horizontal Slice selected**:
-1. **Phase 1: Foundation Implementation** - Contract definitions, interfaces/signatures, test preparation
-2. **Phase 2: Core Feature Implementation** - Business logic, unit tests
-3. **Phase 3: Integration Implementation** - External connections, presentation layer
-
-**When Hybrid selected**:
-- Combine vertical and horizontal as defined in Design Doc implementation approach
-
-**All approaches**: Each phase ends at a repository-observable verification point. Whole-repository quality assurance remains a separate execution responsibility.
-
-## Creation Process
-
-1. **Problem Analysis**: Confirm scope, determine Structural Scale, and identify candidate technical decision points
-   - Identify explicit and implicit project standards before investigation
-2. **ADR Choice Check** (when candidates exist): Apply the Choice filter, then the Durability filter
-3. **Creation**: Complete and review the qualifying ADR batch, then create the Design Doc with accepted ADRs as constraints
-4. **Approval**: One approval covers the reviewed ADR batch; Design Doc approval enables planning or implementation
 
 ## Storage Locations
 
@@ -206,27 +79,6 @@ An acceptance criterion describes observable behavior rather than implementation
 
 *Note: Work plans are excluded by `.gitignore`
 
-## ADR Status
-`Proposed` → `Accepted` → `Deprecated`/`Superseded`/`Rejected`
+## References
 
-## AI Automation Rules
-- Apply the Choice filter before the Durability filter and independently from Structural Scale
-- Check existing ADRs before implementation
-- Create one ADR per qualifying decision point and review the complete batch together
-
-## Diagram Requirements
-
-Select a Mermaid diagram only when it clarifies a material relationship more effectively than prose or a compact table:
-
-| Document | Required Diagrams | Purpose |
-|----------|------------------|---------|
-| PRD | User journey or scope boundary when prose does not make a material relationship clear | Clarify user experience and scope |
-| ADR | Option comparison when the relationship between options is unclear in a table | Visualize trade-offs |
-| UI Spec | Screen transition or component tree when material interaction or hierarchy remains unclear | Clarify screen flow and component structure |
-| Design Doc | Architecture or data flow when changed relationships are not clear in prose or tables | Understand technical structure |
-
-## Common ADR Relationships
-1. **At creation**: Identify accepted common ADRs that govern the changed responsibility
-2. **When missing**: Apply the same Choice and Durability filters; a generic concern alone does not justify a common ADR
-3. **Design Doc**: Specify applicable common ADRs in "Prerequisite ADRs"
-4. **Compliance check**: Verify the design aligns with accepted decisions
+Each template defines the content, structural elements, and diagram criteria for its document: [prd-template.md](references/prd-template.md), [adr-template.md](references/adr-template.md), [ui-spec-template.md](references/ui-spec-template.md), [design-template.md](references/design-template.md), [plan-template.md](references/plan-template.md), [task-template.md](references/task-template.md)

--- a/dev-workflows/skills/documentation-criteria/references/adr-template.md
+++ b/dev-workflows/skills/documentation-criteria/references/adr-template.md
@@ -4,6 +4,8 @@
 
 [Proposed | Accepted | Deprecated | Superseded | Rejected]
 
+A created ADR starts at `Proposed` and advances `Proposed` → `Accepted` → `Deprecated`/`Superseded`/`Rejected`.
+
 ## Context
 
 [Describe the background and reasons why this decision is needed. Include the essence of the problem, current challenges, and constraints]
@@ -33,7 +35,7 @@
 
 ### Options Considered
 
-Compare credible, materially distinct options supported by current requirements and repository evidence. The evidence determines how many options exist, and relative evidence-backed cost is sufficient.
+Compare credible, materially distinct options supported by current requirements and repository evidence. The evidence determines how many options exist, and relative evidence-backed cost is sufficient. Add a Mermaid option-comparison diagram only when the relationship between options stays unclear in the table below.
 
 | Option | Requirement and repository fit | Current-scope benefit | Lifecycle cost | Maintainability | Material trade-offs |
 |--------|--------------------------------|-----------------------|----------------|-----------------|---------------------|

--- a/dev-workflows/skills/documentation-criteria/references/design-template.md
+++ b/dev-workflows/skills/documentation-criteria/references/design-template.md
@@ -8,27 +8,11 @@
 - UI Spec path: [docs/ui-spec/xxx-ui-spec.md]
 - Component structure and state design are inherited from UI Spec
 
-## Design Summary (Meta)
-
-```yaml
-design_type: "new_feature|extension|refactoring"
-risk_level: "low|medium|high"
-complexity_level: "low|medium|high"
-complexity_rationale: "[Required if medium/high: (1) which requirements/ACs necessitate this complexity, (2) which constraints/risks it addresses]"
-main_constraints:
-  - "[constraint 1]"
-  - "[constraint 2]"
-biggest_risks:
-  - "[risk 1]"
-  - "[risk 2]"
-unknowns:
-  - "[uncertainty 1]"
-  - "[uncertainty 2]"
-```
-
 ## Background and Context
 
 ### Prerequisite ADRs
+
+List the accepted ADRs that govern the changed responsibility, including accepted common (cross-cutting) ADRs, and verify this design aligns with each recorded decision.
 
 - [docs/adr/ADR-XXXX.md]: [Related decision items]
 - Reference common technical ADRs when applicable
@@ -50,20 +34,7 @@ Records exclusions **the user decided** at requirement time. Exclusions this des
 - **Speculative**: [idea the user raised without deciding on -> deferral reason | None]
 - **Open questions**: [field the user left as weak-but-explicit | None]
 
-### Agreement Checklist
-
-#### Scope
-- [ ] [Features/components to change]
-- [ ] [Features to add]
-
-#### Non-Scope (Explicitly not changing)
-- [ ] [Features/components not to change]
-- [ ] [Existing logic to preserve]
-
-#### Constraints
-- [ ] Parallel operation: [Yes/No]
-- [ ] Backward compatibility: [Required/Not required]
-- [ ] Performance measurement: [Required/Not required]
+### Standards and Assumptions
 
 #### Applicable Standards
 - [ ] [Standard/convention] `[explicit]` - Source: [config / rule file / documentation path]
@@ -178,6 +149,8 @@ No Ripple Effect:
 ### Architecture Overview
 
 [How this feature is positioned within the overall system]
+
+Add an architecture or data-flow Mermaid diagram only when the changed relationships stay unclear in prose or a compact table; otherwise keep the prose form.
 
 ### Data Flow
 

--- a/dev-workflows/skills/documentation-criteria/references/plan-template.md
+++ b/dev-workflows/skills/documentation-criteria/references/plan-template.md
@@ -5,12 +5,6 @@ Type: feature|fix|refactor
 Related Issue/PR: #XXX (if any)
 Review Scope: [repository responsibilities or expected files derived from the Design Doc]
 
-## WorkPlan Review
-
-Plan creation and material updates set this to `pending`. Record `approved` after the user approves the reviewed implementation scope.
-
-- **Status**: pending|approved
-
 ## Governing Documents
 
 - Design Doc: [docs/design/XXX.md]
@@ -26,6 +20,14 @@ Plan creation and material updates set this to `pending`. Record `approved` afte
 ## Implementation Phases
 
 Use the implementation approach and dependency order from the Design Doc. Each phase groups work that reaches a shared observable verification point. Keep implementation, tests, configuration, wiring, and documentation together when they become complete at that point.
+
+Shape the phases from the approach the Design Doc selected:
+
+- **Vertical Slice**: each phase is one value unit (feature, component, or migration target) carrying its own implementation and verification per the Verification Strategy.
+- **Horizontal Slice**: foundation (contract definitions, interfaces/signatures, test preparation) → core feature (business logic, unit tests) → integration (external connections, presentation layer).
+- **Hybrid**: combine the two as the Design Doc's implementation approach defines.
+
+Whole-repository quality assurance stays outside the plan as a separate execution responsibility.
 
 ### Phase 1: [First implementation outcome]
 
@@ -63,7 +65,3 @@ Use the implementation approach and dependency order from the Design Doc. Each p
 - [ ] Dependencies permit execution in the listed order
 - [ ] Verification is executable from repository artifacts or the task's own output
 - [ ] Task verification passes and cited acceptance criteria are satisfied
-
-## Progress Notes
-
-[Record execution-relevant discoveries only when they change task order, scope, or verification.]

--- a/dev-workflows/skills/documentation-criteria/references/ui-spec-template.md
+++ b/dev-workflows/skills/documentation-criteria/references/ui-spec-template.md
@@ -42,6 +42,8 @@ Map confirmed acceptance criteria to prototype references, preserving existing A
 
 ## Screen List and Transitions
 
+Add a screen-transition or component-tree Mermaid diagram only when the material interaction or hierarchy stays unclear in the tables below; otherwise keep the table form.
+
 ### Screen List
 
 | Screen ID | Screen Name | Description | Entry Condition |

--- a/dev-workflows/skills/external-resource-context/SKILL.md
+++ b/dev-workflows/skills/external-resource-context/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: external-resource-context
-description: Captures and persists access methods for resources outside the repository (design source, design system, API schema, IaC source, secret store) so downstream work can reach them deterministically. Use when work depends on external resources, or when the user mentions design source, design system, API schema, IaC source, secret store, or canonical source.
+description: Captures access methods for resources outside the repository (design source, design system, API schema, IaC source, secret store) into a deterministic location so downstream work can reach them. Use when capturing or updating those access methods, or when the user mentions design source, design system, API schema, IaC source, secret store, or canonical source.
 ---
 
 # External Resource Context
@@ -30,58 +30,19 @@ The project tier owns environment facts. Feature-tier sections list only feature
 
 Example feature-tier entry uses the table format defined in `references/template.md`: a row with the project-tier label in the first column and the feature-specific identifier in the second column.
 
-## Hearing Protocol
-
-### When to Hear
-
-| Condition | Action |
-|-----------|--------|
-| `docs/project-context/external-resources.md` does not exist | Run full hearing for the relevant domain(s) |
-| File exists and covers the current decision | Use it without an update question |
-| User or caller identifies changed environment facts | Run diff-only hearing for the named axes |
-| A relevant axis is absent | Hear only the missing axis |
-| Access failure or contradictory current evidence indicates possible staleness | Ask via AskUserQuestion: "Update external-resources.md? (no / yes-full / yes-diff-only)". On `yes-full` run full hearing; on `yes-diff-only` hear the named stale axes; on `no` preserve the file and report the limitation |
-
-### Domain Routing
-
-Load the domain reference matching the current task:
-
-| Task type | References to load |
-|-----------|--------------------|
-| Frontend (UI work) | [references/frontend.md](references/frontend.md) |
-| Backend (server / data work) | [references/backend.md](references/backend.md) |
-| API contract work | [references/api.md](references/api.md) |
-| Infrastructure / deployment | [references/infra.md](references/infra.md) |
-| Fullstack | Load only the references whose frontend, backend/data, API-contract, or infrastructure responsibilities are affected by the confirmed scope; a fullstack label alone does not activate infrastructure |
-
-Each domain reference defines the axes and the question template.
-
-### Two-Phase Hearing
-
-1. **Structured hearing** — for each axis selected by the When to Hear and Domain Routing rules, present the user with AskUserQuestion using the choices listed in its domain reference (always include "Not applicable" as an option). For each non-N/A axis, follow up with an access-method question (URL / MCP name / file path / command).
-
-2. **Self-declaration for a full hearing** — after the structured axes for all selected domains are complete, present one integrated AskUserQuestion: "Are there any other external resources for this work that the structured questions did not cover? If yes, describe them in your next message." If the user describes additional resources, append them to the storage file under an "Additional resources" subsection. A diff-only or missing-axis hearing ends after its named axes because the existing project record already completed self-declaration.
-
-For a full hearing, the two phases are sequential and self-declaration runs even if the user answered "Not applicable" to every structured axis.
-
-## Storage Protocol
-
-After hearing completes:
-
-1. Build the project-tier content from the answers. Use [references/template.md](references/template.md) as the structure.
-2. Write to `docs/project-context/external-resources.md`. Create the directory if absent.
-3. When the calling workflow has a target UI Spec or Design Doc, also append or update the document's `## External Resources Used` section with the feature-tier subset (label references + feature-specific identifiers only).
-4. Report the file paths back to the calling workflow.
-
 ## Reference Protocol (For Downstream Consumers)
 
-Agents that load this skill consult resources in this order:
+Consuming a recorded resource takes three reads and needs no part of this skill:
 
-1. Read `docs/project-context/external-resources.md` first (if present) to learn what is available and how to access it.
+1. Read `docs/project-context/external-resources.md` (if present) to learn what is available and how to access it.
 2. Read the target UI Spec or Design Doc's `## External Resources Used` section for feature-specific identifiers.
 3. Use the access method declared in the project tier (e.g., the named MCP, the URL, the file path) to fetch the actual resource content.
 
-Agents that only need to *consult* the saved file as input data (not actively hear) can read it directly without loading this skill — frontmatter declaration is reserved for agents that may need to trigger hearing or interpret the protocol semantics.
+A consumer that only reads these records executes the three steps directly. Load this skill when capturing or updating the records, which requires AskUserQuestion and therefore the session that can ask the user.
+
+## Capturing and Updating Records
+
+Follow [references/hearing.md](references/hearing.md) for the hearing conditions, domain routing, two-phase hearing, storage protocol, and quality checklist.
 
 ## Output Format
 
@@ -89,16 +50,9 @@ The project-tier file follows the structure in [references/template.md](referenc
 
 For feature-tier sections inside UI Spec or Design Doc, the heading text "External Resources Used" is fixed; the heading level matches the parent document's natural structure (h2 in UI Spec where it is a sibling of other top-level sections, h3 in Design Doc where it sits under Background and Context).
 
-## Quality Checklist
-
-- [ ] Each axis answered has both a presence indicator and an access method, or is marked "Not applicable"
-- [ ] A full hearing ran self-declaration even when all structured axes were "Not applicable"; a diff-only or missing-axis hearing stayed within its named axes
-- [ ] Project-tier file does not contain feature-specific identifiers
-- [ ] Feature-tier sections reference project-tier entries by label, not by duplicating URLs / MCP names
-- [ ] When the project file already existed, each write traces to an explicit changed fact, a missing relevant axis, or a confirmed stale-evidence update decision
-
 ## References
 
+- [references/hearing.md](references/hearing.md) — Hearing conditions, domain routing, storage protocol, quality checklist
 - [references/frontend.md](references/frontend.md) — Frontend domain axes
 - [references/backend.md](references/backend.md) — Backend domain axes
 - [references/api.md](references/api.md) — API contract domain axes

--- a/dev-workflows/skills/external-resource-context/SKILL.md
+++ b/dev-workflows/skills/external-resource-context/SKILL.md
@@ -11,12 +11,6 @@ AI agents understand the codebase but not the external resources surrounding it.
 
 Resources covered: design origin (where the canonical visual specification lives), design system (component library and tokens), guidelines (usage docs, accessibility rules), visual verification environment (how to confirm rendering), database schema source, migration history, secret store location, API schema source (OpenAPI / proto / GraphQL SDL), mock environment, IaC source, environment configuration.
 
-## Scope Boundaries
-
-**In scope**: hearing protocol, storage location, single-source-of-truth ownership rule, reference protocol for downstream consumers.
-
-**Out of scope**: enforcing that captured resources are correct or current — verification belongs to the agent that consumes the resource. Generating the resources themselves (e.g., creating a DESIGN.md from scratch).
-
 ## Storage Locations (Two-Tier)
 
 | Tier | Location | Holds | Update Frequency |

--- a/dev-workflows/skills/external-resource-context/SKILL.md
+++ b/dev-workflows/skills/external-resource-context/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: external-resource-context
-description: Captures access methods for resources outside the repository (design source, design system, API schema, IaC source, secret store) into a deterministic location so downstream work can reach them. Use when capturing or updating those access methods, or when the user mentions design source, design system, API schema, IaC source, secret store, or canonical source.
+description: Records where resources outside the repository live (design source, design system, API schema, IaC source, secret store) and how design, implementation, and verification reach them. Use when work depends on an external resource, or when the user mentions design source, design system, API schema, IaC source, secret store, or canonical source.
 ---
 
 # External Resource Context
@@ -32,17 +32,17 @@ Example feature-tier entry uses the table format defined in `references/template
 
 ## Reference Protocol (For Downstream Consumers)
 
-Consuming a recorded resource takes three reads and needs no part of this skill:
+Before investigating the repository for an external fact, check whether it is already recorded:
 
 1. Read `docs/project-context/external-resources.md` (if present) to learn what is available and how to access it.
 2. Read the target UI Spec or Design Doc's `## External Resources Used` section for feature-specific identifiers.
 3. Use the access method declared in the project tier (e.g., the named MCP, the URL, the file path) to fetch the actual resource content.
 
-A consumer that only reads these records executes the three steps directly. Load this skill when capturing or updating the records, which requires AskUserQuestion and therefore the session that can ask the user.
+When the file is absent or the resource is unreachable, continue from governing and repository evidence. Each consuming agent reports that limitation through its own output contract.
 
 ## Capturing and Updating Records
 
-Follow [references/hearing.md](references/hearing.md) for the hearing conditions, domain routing, two-phase hearing, storage protocol, and quality checklist.
+Capturing a record requires AskUserQuestion, so it belongs to the session that can ask the user. Follow [references/hearing.md](references/hearing.md) for the hearing conditions, domain routing, two-phase hearing, storage protocol, and quality checklist.
 
 ## Output Format
 

--- a/dev-workflows/skills/external-resource-context/references/hearing.md
+++ b/dev-workflows/skills/external-resource-context/references/hearing.md
@@ -47,6 +47,6 @@ After hearing completes:
 
 - [ ] Each axis answered has both a presence indicator and an access method, or is marked "Not applicable"
 - [ ] A full hearing ran self-declaration even when all structured axes were "Not applicable"; a diff-only or missing-axis hearing stayed within its named axes
-- [ ] Project-tier file does not contain feature-specific identifiers
-- [ ] Feature-tier sections reference project-tier entries by label, not by duplicating URLs / MCP names
+- [ ] Project-tier entries hold the environment facts (URL, MCP name, file path, command)
+- [ ] Feature-tier rows hold a project-tier label and the feature-specific identifier
 - [ ] When the project file already existed, each write traces to an explicit changed fact, a missing relevant axis, or a confirmed stale-evidence update decision

--- a/dev-workflows/skills/external-resource-context/references/hearing.md
+++ b/dev-workflows/skills/external-resource-context/references/hearing.md
@@ -1,0 +1,52 @@
+# External Resource Hearing and Storage
+
+Producer-side protocol. Load this when capturing or updating external-resource records. Running it requires AskUserQuestion, so it belongs to the session that can ask the user directly.
+
+## When to Hear
+
+| Condition | Action |
+|-----------|--------|
+| `docs/project-context/external-resources.md` does not exist | Run full hearing for the relevant domain(s) |
+| File exists and covers the current decision | Use it without an update question |
+| User or caller identifies changed environment facts | Run diff-only hearing for the named axes |
+| A relevant axis is absent | Hear only the missing axis |
+| Access failure or contradictory current evidence indicates possible staleness | Ask via AskUserQuestion: "Update external-resources.md? (no / yes-full / yes-diff-only)". On `yes-full` run full hearing; on `yes-diff-only` hear the named stale axes; on `no` preserve the file and report the limitation |
+
+## Domain Routing
+
+Load the domain reference matching the current task:
+
+| Task type | References to load |
+|-----------|--------------------|
+| Frontend (UI work) | [frontend.md](frontend.md) |
+| Backend (server / data work) | [backend.md](backend.md) |
+| API contract work | [api.md](api.md) |
+| Infrastructure / deployment | [infra.md](infra.md) |
+| Fullstack | Load only the references whose frontend, backend/data, API-contract, or infrastructure responsibilities are affected by the confirmed scope; a fullstack label alone does not activate infrastructure |
+
+Each domain reference defines the axes and the question template.
+
+## Two-Phase Hearing
+
+1. **Structured hearing** — for each axis selected by the When to Hear and Domain Routing rules, present the user with AskUserQuestion using the choices listed in its domain reference (always include "Not applicable" as an option). For each non-N/A axis, follow up with an access-method question (URL / MCP name / file path / command).
+
+2. **Self-declaration for a full hearing** — after the structured axes for all selected domains are complete, present one integrated AskUserQuestion: "Are there any other external resources for this work that the structured questions did not cover? If yes, describe them in your next message." If the user describes additional resources, append them to the storage file under an "Additional resources" subsection. A diff-only or missing-axis hearing ends after its named axes because the existing project record already completed self-declaration.
+
+For a full hearing, the two phases are sequential and self-declaration runs even if the user answered "Not applicable" to every structured axis.
+
+## Storage Protocol
+
+After hearing completes:
+
+1. Build the project-tier content from the answers. Use [template.md](template.md) as the structure.
+2. Write to `docs/project-context/external-resources.md`. Create the directory if absent.
+3. When the calling workflow has a target UI Spec or Design Doc, also append or update the document's `## External Resources Used` section with the feature-tier subset (label references + feature-specific identifiers only).
+4. Report the file paths back to the calling workflow.
+
+## Quality Checklist
+
+- [ ] Each axis answered has both a presence indicator and an access method, or is marked "Not applicable"
+- [ ] A full hearing ran self-declaration even when all structured axes were "Not applicable"; a diff-only or missing-axis hearing stayed within its named axes
+- [ ] Project-tier file does not contain feature-specific identifiers
+- [ ] Feature-tier sections reference project-tier entries by label, not by duplicating URLs / MCP names
+- [ ] When the project file already existed, each write traces to an explicit changed fact, a missing relevant axis, or a confirmed stale-evidence update decision

--- a/dev-workflows/skills/implementation-approach/SKILL.md
+++ b/dev-workflows/skills/implementation-approach/SKILL.md
@@ -35,7 +35,7 @@ Complete these steps in order before selecting an implementation strategy:
 
 Classify supporting claims as observed, inferred, or unknown. When an unknown blocks the next step, stop at the current step and name the evidence or user decision required.
 
-**Design Doc output**: Direct MVP, Failed Items, Adopted Additions, and Rejected Additions.
+**Phase 2 outputs**: Direct MVP, Failed Items, Adopted Additions, and Rejected Additions. A Design Doc author records all four; an implementer uses them as the convergence check without producing a document.
 
 ### Phase 3: Strategy Exploration and Creation
 
@@ -117,7 +117,7 @@ Select the implementation approach that directly fits the verified dependency an
 
 ### Phase 7: Decision Rationale Documentation
 
-**Design Doc Documentation**: Record in the Design Doc's implementation approach section:
+**Record in the artifact this agent owns**, and in the Design Doc's implementation approach section when this agent owns that document:
 1. Selected strategy name and characteristics
 2. A materially different alternative and reason for rejection, when one was compared
 3. Risk mitigation plan (from Phase 4)

--- a/dev-workflows/skills/integration-e2e-testing/SKILL.md
+++ b/dev-workflows/skills/integration-e2e-testing/SKILL.md
@@ -76,7 +76,7 @@ The two E2E lanes have different ownership costs and use independent standard th
 | fixture-e2e | ROI ≥ 20 (beyond reserved slot) | Cost is comparable to integration tests once the harness exists; the floor avoids filling MAX 3 with low-signal tests when fewer would suffice |
 | service-integration-e2e | ROI > 50 (beyond reserved slot) | Live-service setup, state cleanup, and failure diagnosis add material ownership cost; reserve for journeys whose value cannot be proven any other way |
 
-Reserved slot rules (see Multi-Step User Journey Definition below) apply per lane and override the threshold (the reserved candidate is emitted regardless of its ROI score). Below-floor candidates beyond the reserved slot are not emitted unless an accepted requirement or distinct uncovered failure mode justifies an exception. Leave budget intentionally unfilled rather than padding with low-value tests; record any threshold or budget exception in the skeleton and generation report.
+Reserved slot rules (see Multi-Step User Journey Definition below) apply per lane and override the threshold (the reserved candidate is emitted regardless of its ROI score). Below-floor candidates beyond the reserved slot are not emitted unless an accepted requirement or distinct uncovered failure mode justifies an exception. Leave budget intentionally unfilled rather than padding with low-value tests; record any threshold or budget exception in the skeleton that carries the exception.
 
 ### ROI Calculation Examples
 

--- a/dev-workflows/skills/integration-e2e-testing/SKILL.md
+++ b/dev-workflows/skills/integration-e2e-testing/SKILL.md
@@ -76,7 +76,7 @@ The two E2E lanes have different ownership costs and use independent standard th
 | fixture-e2e | ROI ≥ 20 (beyond reserved slot) | Cost is comparable to integration tests once the harness exists; the floor avoids filling MAX 3 with low-signal tests when fewer would suffice |
 | service-integration-e2e | ROI > 50 (beyond reserved slot) | Live-service setup, state cleanup, and failure diagnosis add material ownership cost; reserve for journeys whose value cannot be proven any other way |
 
-Reserved slot rules (see Multi-Step User Journey Definition below) apply per lane and override the threshold (the reserved candidate is emitted regardless of its ROI score). Below-floor candidates beyond the reserved slot are not emitted unless an accepted requirement or distinct uncovered failure mode justifies an exception. Leave budget intentionally unfilled rather than padding with low-value tests; record any threshold or budget exception in the skeleton that carries the exception.
+Reserved slot rules (see Multi-Step User Journey Definition below) apply per lane and override the threshold (the reserved candidate is emitted regardless of its ROI score). Emit a below-floor candidate beyond the reserved slot only when an accepted requirement or a distinct uncovered failure mode justifies the exception. Leave budget intentionally unfilled rather than padding with low-value tests; record any threshold or budget exception in the skeleton that carries the exception.
 
 ### ROI Calculation Examples
 

--- a/dev-workflows/skills/recipe-add-integration-tests/SKILL.md
+++ b/dev-workflows/skills/recipe-add-integration-tests/SKILL.md
@@ -41,18 +41,7 @@ Document paths: $ARGUMENTS
 
 ### Step 1: Discover and Validate Documents
 
-```bash
-# Verify at least one document path was provided
-test -n "$ARGUMENTS" || { echo "ERROR: No document paths provided"; exit 1; }
-
-# Verify provided paths exist
-ls $ARGUMENTS
-
-# Discover additional documents
-ls docs/design/*.md 2>/dev/null | grep -v template
-ls docs/ui-spec/*.md 2>/dev/null
-ls docs/prd/*.md 2>/dev/null
-```
+Confirm `$ARGUMENTS` names at least one existing document path; report and end when it is empty or every path is unresolvable. Then discover the remaining Design Docs, UI Specs, and PRDs under `docs/design/`, `docs/ui-spec/`, and `docs/prd/`.
 
 Classify discovered documents by filename:
 - Filename contains `backend` → **Design Doc (backend)**

--- a/dev-workflows/skills/recipe-build/SKILL.md
+++ b/dev-workflows/skills/recipe-build/SKILL.md
@@ -34,7 +34,7 @@ Before any task processing, locate the work plan. Resolution rule:
 1. List task files in `docs/plans/tasks/` matching the single-layer pattern `{plan-name}-task-*.md`. Layer-aware fullstack tasks (`{plan-name}-backend-task-*.md` / `{plan-name}-frontend-task-*.md`) are excluded here so a stale fullstack run does not redirect this recipe to the wrong work plan
 2. For each matched file, extract the `{plan-name}` prefix as the segment that appears before `-task-`
 3. When at least one task file matches, the work plan is `docs/plans/{plan-name}.md` for the prefix that has the most recent task-file mtime; ties broken by the lexicographically last `{plan-name}`
-4. When no task file matches the restricted pattern, the work plan is the most-recent-mtime non-template `.md` in `docs/plans/`
+4. When no task file matches the restricted pattern, the work plan is the most recently modified `.md` in `docs/plans/`
 
 ### Consumed Task Set
 

--- a/dev-workflows/skills/recipe-review/SKILL.md
+++ b/dev-workflows/skills/recipe-review/SKILL.md
@@ -36,13 +36,7 @@ Design Doc (uses most recent if omitted): $ARGUMENTS
 ## Execution Flow
 
 ### Step 1: Prerequisite Check
-```bash
-# Identify Design Doc
-ls docs/design/*.md | grep -v template | tail -1
-
-# Check implementation files
-git diff --name-only main...HEAD
-```
+Identify the review inputs: the most recently updated Design Doc under `docs/design/`, and the files changed on the current branch relative to its base.
 
 ### Step 2: Execute code-reviewer
 Invoke code-reviewer using Agent tool:
@@ -116,7 +110,7 @@ Run this step only when the user routed at least one finding to `d`. When no `d`
    - `prompt`: "Review updated Design Doc at [path] for consistency and completeness. doc_type: DesignDoc. review_context: update."
    - Run the Review Resolution Gate through its correction re-review, escalation, and convergence transitions, using technical-designer for rerouted corrections. Proceed only at its convergence condition.
 
-3. When multiple Design Docs exist (`ls docs/design/*.md | grep -v template | wc -l > 1`), invoke design-sync:
+3. When more than one Design Doc exists under `docs/design/`, invoke design-sync:
    - `subagent_type`: "dev-workflows:design-sync"
    - `description`: "Cross-DD consistency check"
    - `prompt`: "source_design: [updated DD path]"

--- a/dev-workflows/skills/recipe-update-doc/SKILL.md
+++ b/dev-workflows/skills/recipe-update-doc/SKILL.md
@@ -24,21 +24,21 @@ Before the first finding disposition, read `references/review-resolution.md` fro
 1. **Invoke named specialists for deliverable production** — pass deliverable paths between them and validate their results (see subagents-orchestration-guide "Orchestrator Execution Boundary")
 2. **Execute update flow**:
    - Identify target → Clarify changes → Update document → Review → Consistency check
-   - **Stop at every `[Stop: ...]` marker** → Wait for user approval before proceeding
+   - **Stop at the `[Stop: Final approval]` marker** → Wait for user approval before completing
 3. **Scope**: Complete when updated document receives approval
 
 At each Agent invocation below, build the prompt as a mechanical extraction: copy the named source values into the exact fields, apply only the declared serialization, then invoke immediately.
 
-**CRITICAL**: Execute document-reviewer and all stopping points — each serves as a quality gate for document accuracy.
+**CRITICAL**: Execute document-reviewer — it is the quality gate for document accuracy.
 
 ## Workflow Overview
 
 ```
-Target document → [Stop: Confirm changes]
+Target document → change clarification
                         ↓
               technical-designer / technical-designer-frontend / prd-creator (update mode)
                         ↓ (Design Doc only)
-              code-verifier → document-reviewer → [Stop: Review approval]
+              code-verifier → document-reviewer
                         ↓ (Design Doc only)
               design-sync → [Stop: Final approval]
 ```
@@ -47,7 +47,7 @@ Target document → [Stop: Confirm changes]
 
 **Included in this skill**:
 - Existing document identification and selection
-- Change content clarification with user
+- Change content clarification
 - Document update with appropriate agent (update mode)
 - Document review with document-reviewer
 - Consistency verification with design-sync (Design Doc only)
@@ -64,10 +64,7 @@ Target document: $ARGUMENTS
 
 ### Step 1: Target Document Identification
 
-```bash
-# Check existing documents
-ls docs/design/*.md docs/prd/*.md docs/adr/*.md 2>/dev/null | grep -v template
-```
+Discover the existing documents under `docs/design/`, `docs/prd/`, and `docs/adr/`.
 
 **Decision flow**:
 
@@ -97,16 +94,11 @@ Read the document and determine its layer from content signals:
 - **Minor changes** (clarification, typo fix, small scope adjustment): Update the existing ADR file
 - **Major changes** (decision reversal, significant scope change): Create a new ADR that supersedes the original
 
-### Step 3: Change Content Clarification [Stop]
+### Step 3: Change Content Clarification
 
-Use AskUserQuestion to clarify what changes are needed:
-- What sections need updating
-- Reason for the change (bug fix findings, spec change, review feedback, etc.)
-- Expected outcome after the update
+Determine which sections need updating, the reason for the change, and the expected outcome after the update. Derive them from the request and the target document. Use AskUserQuestion only for an item the request and document leave undetermined, and only when a different answer would change which sections are updated or what the update must achieve.
 
-Confirm understanding of changes with user before proceeding.
-
-Pass approved items, covered sections, and any stated total size budget to update or revision agents. Before the next approval gate, map every diff hunk to an approved item or required consistency update; request a scope decision for unmapped or over-budget changes.
+Pass the resulting items, covered sections, and any stated total size budget to update or revision agents. Before the next approval gate, map every diff hunk to an approved item or required consistency update; request a scope decision for unmapped or over-budget changes.
 
 ### Step 4: Document Update
 
@@ -119,13 +111,13 @@ prompt: |
   Existing Document: [path from Step 1]
 
   ## Changes Required
-  [user-approved Step 3 statements for the sections to update, reason, and expected outcome, copied verbatim]
+  [Step 3 statements for the sections to update, reason, and expected outcome, copied verbatim]
 
   Update the document to reflect the specified changes.
   Add change history entry.
 ```
 
-### Step 5: Document Review [Stop]
+### Step 5: Document Review
 
 **For Design Doc updates only**: Before document-reviewer, invoke code-verifier:
 ```
@@ -170,22 +162,18 @@ For each type, review consistency of the changed sections and their dependent st
 - On re-review pass `prior_feedback` as `[{id, disposition, reason?, evidence}]`
 - All actionable findings are `decline` and every `user_decision_required` item is resolved → Proceed to Step 6
 
-Present review result to user for approval.
+### Step 6: Consistency Verification and Final Approval `[Stop: Final approval]`
 
-### Step 6: Consistency Verification (Design Doc only) [Stop]
-
-**Skip condition**: Document type is PRD or ADR → Proceed to completion.
-
-For Design Doc, invoke design-sync:
+**For Design Doc only**, invoke design-sync first:
 ```
 subagent_type: design-sync
 description: "Verify consistency"
 prompt: "source_design: [path from Step 1]"
 ```
 
-**On consistency result**:
-- No conflicts → Present result to user for final approval
-- Conflicts detected → Apply the Review Resolution Gate using design-sync as a fresh verifier. Return `apply` conflicts to Step 4 for the owning document, rerun design-sync after correction, retain evidenced declines as complete, and request user input for `user_decision_required` or the Gate's escalation conditions. Present final approval at convergence.
+When conflicts are detected, apply the Review Resolution Gate using design-sync as a fresh verifier. Return `apply` conflicts to Step 4 for the owning document, rerun design-sync after correction, retain evidenced declines as complete, and request user input for `user_decision_required` or the Gate's escalation conditions.
+
+**For every document type**, present the updated document, the review outcome, any resolved declines, and the sync result when one ran. This is the only approval gate in the flow: wait for the user's decision before completing.
 
 ## Error Handling
 
@@ -197,7 +185,7 @@ prompt: "source_design: [path from Step 1]"
 ## Completion Criteria
 
 - [ ] Identified target document
-- [ ] Clarified change content with user
+- [ ] Change content determined from the request, the document, or a question whose answer changed the update
 - [ ] Updated document with appropriate agent (update mode)
 - [ ] Executed code-verifier before document-reviewer (Design Doc only)
 - [ ] Executed document-reviewer and addressed feedback

--- a/dev-workflows/skills/subagents-orchestration-guide/SKILL.md
+++ b/dev-workflows/skills/subagents-orchestration-guide/SKILL.md
@@ -284,8 +284,8 @@ Pass the Design Doc path. Work-planner maps governing sections and ACs to implem
 
 - Invoke acceptance-test-generator with `design_docs` as the applicable Design Doc path list, optional `ui_spec`, and the same `confirmed_requirement_context` used for design.
 - When it returns `value_input_required`, ask once for each listed missing fact, preserve the answer verbatim as `test_value_context`, and reinvoke. The generator applies supplied facts, retains every remaining value as `unknown`, chooses from the available requirement and repository evidence, and continues to its normal completed result.
-- Verify each non-null `generatedFiles.<lane>` path exists. For each null E2E lane, accept its `e2eAbsenceReason.<lane>` only when it names the selection rule, source evidence, and selected or governing proof covering the accepted boundary. Return an uncovered accepted proof obligation to the generator for completion.
-- Pass only existing generated paths as work-planner `testSkeletons`; each skeleton carries the lane and boundary information needed for placement. Consume valid null-lane reasons at this gate.
+- Verify each non-null `generatedFiles.<lane>` path exists. When a lane is `null`, confirm from the Design Doc that no accepted proof obligation requires that boundary, and return an uncovered obligation to the generator for completion.
+- Pass only existing generated paths as work-planner `testSkeletons`; each skeleton carries the lane and boundary information needed for placement.
 - Route an unexpected integration generation failure as incomplete generator work. A validated null E2E lane is complete.
 
 ## References

--- a/dev-workflows/skills/subagents-orchestration-guide/references/monorepo-flow.md
+++ b/dev-workflows/skills/subagents-orchestration-guide/references/monorepo-flow.md
@@ -27,7 +27,7 @@ This reference defines the orchestration flow for one feature spanning backend a
 | 11 | technical-designer-frontend | Frontend Design Doc with backend contracts, applicable UI Spec, and accepted ADR constraints | Frontend Design Doc |
 | 12 | code-verifier ×2 + orchestrator | Verify each Design Doc and apply Review Resolution | Resolved verification evidence |
 | 13 | document-reviewer ×2 | Review each Design Doc with resolved verification evidence | Reviews |
-| 14 | design-sync | Cross-layer consistency verification **[Stop]** | Sync status |
+| 14 | design-sync | Cross-layer consistency verification **[Stop when conflicts remain after Review Resolution]** | Sync status |
 | 15 | acceptance-test-generator | Integration/E2E skeletons selected from cross-layer contracts | Test skeletons |
 | 16 | work-planner | Work plan from both Design Docs | Work Plan |
 | 17 | document-reviewer | Work Plan review **[Stop: Batch approval]** | Approval |

--- a/dev-workflows/skills/task-analyzer/references/skills-index.yaml
+++ b/dev-workflows/skills/task-analyzer/references/skills-index.yaml
@@ -206,7 +206,6 @@ skills:
       - "references/template.md"
     sections:
       - "Purpose"
-      - "Scope Boundaries"
       - "Storage Locations (Two-Tier)"
       - "Reference Protocol (For Downstream Consumers)"
       - "Capturing and Updating Records"

--- a/dev-workflows/skills/task-analyzer/references/skills-index.yaml
+++ b/dev-workflows/skills/task-analyzer/references/skills-index.yaml
@@ -71,17 +71,12 @@ skills:
       - "Design Doc Culture - Google Engineering Practices"
       - "Single Source of Truth"
     sections:
-      - "Templates"
+      - "What Each Document Fixes"
       - "Creation Decision Matrix"
       - "Structural Scale"
       - "ADR Decision Filters"
-      - "Detailed Document Definitions"
-      - "Creation Process"
       - "Storage Locations"
-      - "ADR Status"
-      - "AI Automation Rules"
-      - "Diagram Requirements"
-      - "Common ADR Relationships"
+      - "References"
 
   implementation-approach:
     skill: "implementation-approach"
@@ -203,6 +198,7 @@ skills:
     tags: [cross-cutting, hearing-protocol, design-source, design-system, api-schema, iac-source, secrets, environment, two-tier-storage]
     typical-use: "Captures access methods for resources outside the repository (design origin, design system, API schema, IaC source, secrets, etc.) and persists them in a deterministic location for downstream agents"
     key-references:
+      - "references/hearing.md"
       - "references/frontend.md"
       - "references/backend.md"
       - "references/api.md"
@@ -212,11 +208,9 @@ skills:
       - "Purpose"
       - "Scope Boundaries"
       - "Storage Locations (Two-Tier)"
-      - "Hearing Protocol"
-      - "Storage Protocol"
       - "Reference Protocol (For Downstream Consumers)"
+      - "Capturing and Updating Records"
       - "Output Format"
-      - "Quality Checklist"
       - "References"
 
   requirement-convergence:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-workflows",
-  "version": "0.24.3",
+  "version": "0.24.4",
   "private": true,
   "type": "module",
   "engines": {

--- a/skills/ai-development-guide/SKILL.md
+++ b/skills/ai-development-guide/SKILL.md
@@ -154,7 +154,7 @@ How to handle duplicate code based on Martin Fowler's "Refactoring":
 - Similar functionality found → Verify that its contract, lifecycle, and repository usage are representative; reuse or extend it when compatible, otherwise record why it is not a valid model
 - Similar functionality is technical debt → Repair it when it blocks the current outcome, was caused by the current change, or lies in confirmed scope; otherwise report it separately. Create an ADR when the repair requires an architectural decision
 - No similar functionality exists → Implement new functionality following existing design philosophy
-- Record all decisions and rationale in "Existing Codebase Analysis" section of Design Doc
+- Record each reuse, extend, separate, or repair decision with its evidence in the artifact this agent owns
 - **Reference representativeness check**: When adopting a pattern or dependency from nearby code, verify it is representative across the repository before adopting — nearby files alone are an insufficient basis
 
 ## Quality Assurance Mechanism Awareness

--- a/skills/documentation-criteria/SKILL.md
+++ b/skills/documentation-criteria/SKILL.md
@@ -9,7 +9,7 @@ This file holds the routing decision: which documents a change requires and wher
 
 ## What Each Document Fixes
 
-Each document fixes one class of decision that the repository alone cannot supply. An unfilled section does not disappear — it becomes a guess made later by the consumer named below, with no record of what was assumed.
+Each document fixes one class of decision that the repository alone cannot supply. An unfilled section becomes a guess made later by the consumer named below, with no record of what was assumed.
 
 - **PRD** — Fixes the business outcome and the acceptance criteria later work traces to. Its AC IDs are the traceability keys that the Design Doc, UI Spec, and test selection reuse; without them each consumer re-derives requirements from prose and the link between a test and the value it protects is lost. Implementation details belong to the Design Doc, selection rationale to an ADR, phases and task breakdown to the Work Plan.
 

--- a/skills/documentation-criteria/SKILL.md
+++ b/skills/documentation-criteria/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: documentation-criteria
-description: Documentation creation criteria including PRD, ADR, Design Doc, and Work Plan requirements with templates. Use when creating or reviewing technical documents, or determining which documents are required.
+description: Determines which of PRD, ADR, UI Spec, Design Doc, and Work Plan a change requires, and where each is stored. Use when deciding documentation scope, or when creating or reviewing a technical document.
 ---
 
 # Documentation Creation Criteria
 
-## Templates
+This file holds the routing decision: which documents a change requires and where they live. What to write inside one is defined by its template, linked from Storage Locations.
 
-- **[prd-template.md](references/prd-template.md)** - Product Requirements Document template
-- **[adr-template.md](references/adr-template.md)** - Architecture Decision Record template
-- **[ui-spec-template.md](references/ui-spec-template.md)** - UI Specification template (frontend/fullstack features)
-- **[design-template.md](references/design-template.md)** - Technical Design Document template
-- **[plan-template.md](references/plan-template.md)** - Work Plan template
-- **[task-template.md](references/task-template.md)** - Task file template for implementation tasks
+## What Each Document Fixes
+
+Each document fixes one class of decision that the repository alone cannot supply. An unfilled section does not disappear — it becomes a guess made later by the consumer named below, with no record of what was assumed.
+
+- **PRD** — Fixes the business outcome and the acceptance criteria later work traces to. Its AC IDs are the traceability keys that the Design Doc, UI Spec, and test selection reuse; without them each consumer re-derives requirements from prose and the link between a test and the value it protects is lost. Implementation details belong to the Design Doc, selection rationale to an ADR, phases and task breakdown to the Work Plan.
+
+- **ADR** — Fixes one durable technical choice and the options it beat, so later work can tell a deliberate decision from an accident. Without it a future change either re-runs the same comparison or silently reverses it. End-to-end implementation design belongs to the Design Doc, schedule and repository tasks to the Work Plan.
+
+- **UI Spec** — Fixes screen structure, transitions, component/state contracts, and visual acceptance before components exist, so decomposition is decided once instead of per-component during implementation. Create one when those decisions remain open; reuse an approved UI Spec or go straight to the Design Doc when one evident repository-supported pattern already determines them. Technical implementation and API contracts belong to the Design Doc.
+
+- **Design Doc** — Fixes the complete implementation design for the confirmed scope: flows, contracts, change impact, and verification strategy. Task execution treats it as the sole design authority and holds it read-only, so a gap here is filled by an implementer's local invention that no review compares against an approved decision. Technology selection rationale belongs to an ADR, schedule and assignments to the Work Plan.
+
+- **Work Plan** — Fixes task order, dependencies, executable verification, and the earliest vertical proof point. Without it task order follows file layout rather than dependency, and integration risk moves to the end of the work. Design detail is referenced from the Design Doc rather than restated.
 
 ## Creation Decision Matrix
 
@@ -42,12 +49,12 @@ A qualifying ADR decision point sets the floor at Medium because it creates a du
 
 ## ADR Decision Filters
 
-Apply both filters in order to each technical topic inside the confirmed implementation scope:
+Apply the Choice filter, then the Durability filter, to each technical topic inside the confirmed implementation scope. Apply them independently from Structural Scale, and check existing ADRs first.
 
 1. **Choice requires judgment** — current requirements, accepted decisions, and representative repository evidence support at least two credible, materially distinct options whose selection requires comparison.
 2. **Decision is durable** — choosing among those options materially changes responsibility, dependency direction, a shared contract, persistence, a technology dependency, reversibility, or lifecycle cost that future work must preserve or understand.
 
-Create one ADR for each topic that passes both filters. Treat choices as one decision point when they must be selected or reconsidered together; separate independently revisitable choices.
+Create one ADR for each topic that passes both filters, and review the complete batch together. Treat choices as one decision point when they must be selected or reconsidered together; separate independently revisitable choices.
 
 Qualifying durable choices include:
 
@@ -57,140 +64,6 @@ Qualifying durable choices include:
 - choosing an irreversible or high-cost-to-reverse data or compatibility strategy.
 
 A local contract, data-flow, state, or component change belongs in the Design Doc when it follows an accepted design, has one evident repository-supported implementation, or remains cheaply reversible. Counts of files, consumers, nesting levels, states, steps, and asynchronous operations are supporting evidence rather than ADR criteria. Only the qualifying decisions above create ADRs; generic technical concerns, operational possibilities, and rejected activities can only support that determination.
-
-## Detailed Document Definitions
-
-### PRD (Product Requirements Document)
-
-**Purpose**: Define business requirements and user value
-
-**Includes**:
-- Business requirements and user value
-- Success metrics and KPIs (each metric specifies a numeric target and measurement method)
-- User stories and use cases
-- Converged MVP requirements
-- Acceptance criteria with sequential IDs (AC-001, AC-002, ...) for downstream traceability
-- Future and Out of Scope capabilities with reasons
-- User journey or scope boundary diagram when prose does not make the material flow or boundary clear
-
-**Scope**: Business requirements, user value, success metrics, user stories, and prioritization only. Implementation details belong in Design Doc, technical selection rationale in ADR, phases and task breakdown in Work Plan.
-
-### ADR (Architecture Decision Record)
-
-**Purpose**: Record one durable technical choice that required comparison
-
-**Includes**:
-- The technical decision point and confirmed scope it serves
-- Every credible, materially distinct option supported by current evidence
-- Requirement and repository fit, current-scope benefit, lifecycle cost, maintainability, and material trade-offs
-- The smallest sufficient selected option and reconsideration conditions
-- Consequences and architecture impact
-
-**Scope**: One qualifying decision point and the evidence needed to understand its selection. An ADR narrows the technical solution space; confirmed requirements remain the implementation scope. End-to-end implementation design belongs in the Design Doc when activated by confirmed scope. External release execution and organizational rollout are not moved into another artifact merely because they are excluded from the ADR; schedule and repository implementation tasks belong in the Work Plan when applicable.
-
-### UI Specification
-
-**Purpose**: Define UI structure, screen transitions, component decomposition, and interaction design for frontend features
-
-Create a UI Spec when screen structure, transitions, component/state interaction, or visual acceptance criteria remain to be designed. Reuse an approved UI Spec or proceed with the Design Doc when one evident repository-supported pattern already determines those decisions.
-
-**Includes**:
-- Screen list and transition conditions
-- Component decomposition with a state x display matrix for states required by approved behavior, preserved behavior, or repository rules
-- Interaction definitions linked to confirmed acceptance criteria (EARS format), preserving PRD AC IDs when present
-- Prototype management (code-based prototypes as attachments, not source of truth)
-- Acceptance-criteria traceability from the confirmed requirement context to screens/components
-- Existing component reuse map and design tokens
-- Visual acceptance criteria (golden states, layout constraints)
-- Accessibility requirements (keyboard, screen reader, contrast)
-
-**Scope**: Screen structure, transitions, component decomposition, interaction design, and visual acceptance criteria only. Technical implementation and API contracts belong in Design Doc, test implementation in test skeleton generation output, schedule in Work Plan.
-
-**Required Structural Elements**:
-- Each in-scope interactive component records the applicable state/display and interaction contract
-- Acceptance-criteria traceability table mapping confirmed criteria to screens/states, preserving existing IDs
-- Screen list with transition conditions
-- Existing component reuse map (reuse/extend/new decisions)
-
-**Prototype Code Handling**:
-- Prototype code provided by user is placed in `docs/ui-spec/assets/{feature-name}/`
-- Prototype code supports the UI Spec as an attachment
-- UI Spec + Design Doc are the canonical specifications
-
-### Design Document
-
-**Purpose**: Define the complete technical implementation for the confirmed scope
-
-**Includes**:
-- **Existing codebase analysis** (required)
-  - Implementation path mapping (both existing and new)
-  - Integration point clarification (connection points with existing code even for new implementations)
-- Technical implementation approach (vertical/horizontal/hybrid)
-- **Technical dependencies and implementation constraints** (required implementation order)
-- Interface and contract definitions
-- Data flow and component design
-- **Acceptance criteria**: the smallest representative set of observable behaviors with stable repository-verifiable pass/fail conditions
-- Change impact map (clearly specify direct impact/indirect impact/no ripple effect)
-- Every changed or newly relied-upon integration point
-- Data contract clarification
-- **Agreement checklist** (agreements with stakeholders)
-- **Code inspection evidence** (inspected files/functions during investigation)
-- **Field propagation map** (when fields cross component boundaries)
-- **Data representation decision** (when introducing new structures)
-- **Applicable standards** (explicit/implicit classification)
-- **Prerequisite ADRs** (including common ADRs)
-- **Verification Strategy** (required)
-  - Correctness proof method (what "correct" means for this change, how it's verified, when)
-  - Early verification point (first target to prove the approach works, success criteria, failure response)
-
-**Required Structural Elements**:
-```yaml
-Change Impact Map:
-  Change Target: [Component/Feature]
-  Direct Impact: [Files/Functions]
-  Indirect Impact: [Data format/Processing time]
-  No Ripple Effect: [Unaffected features]
-
-Interface Change Matrix:
-  Existing: [Function/method/operation name]
-  New: [Function/method/operation name]
-  Conversion Required: [Yes/No]
-  Compatibility Method: [Approach]
-```
-
-**Scope**: Technical implementation methods, interfaces, data flow, acceptance criteria, and verification strategy for the confirmed scope. Preserve the evidence and boundary details downstream implementation needs; omit unrelated future capability rather than reducing required design guarantees. Technology selection rationale belongs in ADR, schedule and assignments in Work Plan.
-
-An acceptance criterion describes observable behavior rather than implementation detail. External live connections use repository-controlled contract or interface proof unless a confirmed requirement needs the live boundary. Performance thresholds require a sourced target and a reproducible benchmark; exact visual positioning requires an approved visual contract and deterministic comparison. Otherwise record the item as a non-functional constraint or omit it from automated acceptance criteria.
-
-### Work Plan
-
-**Purpose**: Implementation task management and progress tracking.
-
-**Scope**: Repository implementation outcomes from approved Design Docs, task dependencies, source section and acceptance-criteria references, executable verification, optional task-level false-green focus, and progress tracking only. The Work Plan references governing documents instead of reproducing their design details.
-
-**Phase Division Criteria** (adapt to implementation approach from Design Doc):
-
-**When Vertical Slice selected**:
-- Each phase = one value unit (feature, component, or migration target)
-- Each phase includes its own implementation + verification per Verification Strategy
-
-**When Horizontal Slice selected**:
-1. **Phase 1: Foundation Implementation** - Contract definitions, interfaces/signatures, test preparation
-2. **Phase 2: Core Feature Implementation** - Business logic, unit tests
-3. **Phase 3: Integration Implementation** - External connections, presentation layer
-
-**When Hybrid selected**:
-- Combine vertical and horizontal as defined in Design Doc implementation approach
-
-**All approaches**: Each phase ends at a repository-observable verification point. Whole-repository quality assurance remains a separate execution responsibility.
-
-## Creation Process
-
-1. **Problem Analysis**: Confirm scope, determine Structural Scale, and identify candidate technical decision points
-   - Identify explicit and implicit project standards before investigation
-2. **ADR Choice Check** (when candidates exist): Apply the Choice filter, then the Durability filter
-3. **Creation**: Complete and review the qualifying ADR batch, then create the Design Doc with accepted ADRs as constraints
-4. **Approval**: One approval covers the reviewed ADR batch; Design Doc approval enables planning or implementation
 
 ## Storage Locations
 
@@ -206,27 +79,6 @@ An acceptance criterion describes observable behavior rather than implementation
 
 *Note: Work plans are excluded by `.gitignore`
 
-## ADR Status
-`Proposed` → `Accepted` → `Deprecated`/`Superseded`/`Rejected`
+## References
 
-## AI Automation Rules
-- Apply the Choice filter before the Durability filter and independently from Structural Scale
-- Check existing ADRs before implementation
-- Create one ADR per qualifying decision point and review the complete batch together
-
-## Diagram Requirements
-
-Select a Mermaid diagram only when it clarifies a material relationship more effectively than prose or a compact table:
-
-| Document | Required Diagrams | Purpose |
-|----------|------------------|---------|
-| PRD | User journey or scope boundary when prose does not make a material relationship clear | Clarify user experience and scope |
-| ADR | Option comparison when the relationship between options is unclear in a table | Visualize trade-offs |
-| UI Spec | Screen transition or component tree when material interaction or hierarchy remains unclear | Clarify screen flow and component structure |
-| Design Doc | Architecture or data flow when changed relationships are not clear in prose or tables | Understand technical structure |
-
-## Common ADR Relationships
-1. **At creation**: Identify accepted common ADRs that govern the changed responsibility
-2. **When missing**: Apply the same Choice and Durability filters; a generic concern alone does not justify a common ADR
-3. **Design Doc**: Specify applicable common ADRs in "Prerequisite ADRs"
-4. **Compliance check**: Verify the design aligns with accepted decisions
+Each template defines the content, structural elements, and diagram criteria for its document: [prd-template.md](references/prd-template.md), [adr-template.md](references/adr-template.md), [ui-spec-template.md](references/ui-spec-template.md), [design-template.md](references/design-template.md), [plan-template.md](references/plan-template.md), [task-template.md](references/task-template.md)

--- a/skills/documentation-criteria/references/adr-template.md
+++ b/skills/documentation-criteria/references/adr-template.md
@@ -4,6 +4,8 @@
 
 [Proposed | Accepted | Deprecated | Superseded | Rejected]
 
+A created ADR starts at `Proposed` and advances `Proposed` → `Accepted` → `Deprecated`/`Superseded`/`Rejected`.
+
 ## Context
 
 [Describe the background and reasons why this decision is needed. Include the essence of the problem, current challenges, and constraints]
@@ -33,7 +35,7 @@
 
 ### Options Considered
 
-Compare credible, materially distinct options supported by current requirements and repository evidence. The evidence determines how many options exist, and relative evidence-backed cost is sufficient.
+Compare credible, materially distinct options supported by current requirements and repository evidence. The evidence determines how many options exist, and relative evidence-backed cost is sufficient. Add a Mermaid option-comparison diagram only when the relationship between options stays unclear in the table below.
 
 | Option | Requirement and repository fit | Current-scope benefit | Lifecycle cost | Maintainability | Material trade-offs |
 |--------|--------------------------------|-----------------------|----------------|-----------------|---------------------|

--- a/skills/documentation-criteria/references/design-template.md
+++ b/skills/documentation-criteria/references/design-template.md
@@ -8,27 +8,11 @@
 - UI Spec path: [docs/ui-spec/xxx-ui-spec.md]
 - Component structure and state design are inherited from UI Spec
 
-## Design Summary (Meta)
-
-```yaml
-design_type: "new_feature|extension|refactoring"
-risk_level: "low|medium|high"
-complexity_level: "low|medium|high"
-complexity_rationale: "[Required if medium/high: (1) which requirements/ACs necessitate this complexity, (2) which constraints/risks it addresses]"
-main_constraints:
-  - "[constraint 1]"
-  - "[constraint 2]"
-biggest_risks:
-  - "[risk 1]"
-  - "[risk 2]"
-unknowns:
-  - "[uncertainty 1]"
-  - "[uncertainty 2]"
-```
-
 ## Background and Context
 
 ### Prerequisite ADRs
+
+List the accepted ADRs that govern the changed responsibility, including accepted common (cross-cutting) ADRs, and verify this design aligns with each recorded decision.
 
 - [docs/adr/ADR-XXXX.md]: [Related decision items]
 - Reference common technical ADRs when applicable
@@ -50,20 +34,7 @@ Records exclusions **the user decided** at requirement time. Exclusions this des
 - **Speculative**: [idea the user raised without deciding on -> deferral reason | None]
 - **Open questions**: [field the user left as weak-but-explicit | None]
 
-### Agreement Checklist
-
-#### Scope
-- [ ] [Features/components to change]
-- [ ] [Features to add]
-
-#### Non-Scope (Explicitly not changing)
-- [ ] [Features/components not to change]
-- [ ] [Existing logic to preserve]
-
-#### Constraints
-- [ ] Parallel operation: [Yes/No]
-- [ ] Backward compatibility: [Required/Not required]
-- [ ] Performance measurement: [Required/Not required]
+### Standards and Assumptions
 
 #### Applicable Standards
 - [ ] [Standard/convention] `[explicit]` - Source: [config / rule file / documentation path]
@@ -178,6 +149,8 @@ No Ripple Effect:
 ### Architecture Overview
 
 [How this feature is positioned within the overall system]
+
+Add an architecture or data-flow Mermaid diagram only when the changed relationships stay unclear in prose or a compact table; otherwise keep the prose form.
 
 ### Data Flow
 

--- a/skills/documentation-criteria/references/plan-template.md
+++ b/skills/documentation-criteria/references/plan-template.md
@@ -5,12 +5,6 @@ Type: feature|fix|refactor
 Related Issue/PR: #XXX (if any)
 Review Scope: [repository responsibilities or expected files derived from the Design Doc]
 
-## WorkPlan Review
-
-Plan creation and material updates set this to `pending`. Record `approved` after the user approves the reviewed implementation scope.
-
-- **Status**: pending|approved
-
 ## Governing Documents
 
 - Design Doc: [docs/design/XXX.md]
@@ -26,6 +20,14 @@ Plan creation and material updates set this to `pending`. Record `approved` afte
 ## Implementation Phases
 
 Use the implementation approach and dependency order from the Design Doc. Each phase groups work that reaches a shared observable verification point. Keep implementation, tests, configuration, wiring, and documentation together when they become complete at that point.
+
+Shape the phases from the approach the Design Doc selected:
+
+- **Vertical Slice**: each phase is one value unit (feature, component, or migration target) carrying its own implementation and verification per the Verification Strategy.
+- **Horizontal Slice**: foundation (contract definitions, interfaces/signatures, test preparation) → core feature (business logic, unit tests) → integration (external connections, presentation layer).
+- **Hybrid**: combine the two as the Design Doc's implementation approach defines.
+
+Whole-repository quality assurance stays outside the plan as a separate execution responsibility.
 
 ### Phase 1: [First implementation outcome]
 
@@ -63,7 +65,3 @@ Use the implementation approach and dependency order from the Design Doc. Each p
 - [ ] Dependencies permit execution in the listed order
 - [ ] Verification is executable from repository artifacts or the task's own output
 - [ ] Task verification passes and cited acceptance criteria are satisfied
-
-## Progress Notes
-
-[Record execution-relevant discoveries only when they change task order, scope, or verification.]

--- a/skills/documentation-criteria/references/ui-spec-template.md
+++ b/skills/documentation-criteria/references/ui-spec-template.md
@@ -42,6 +42,8 @@ Map confirmed acceptance criteria to prototype references, preserving existing A
 
 ## Screen List and Transitions
 
+Add a screen-transition or component-tree Mermaid diagram only when the material interaction or hierarchy stays unclear in the tables below; otherwise keep the table form.
+
 ### Screen List
 
 | Screen ID | Screen Name | Description | Entry Condition |

--- a/skills/external-resource-context/SKILL.md
+++ b/skills/external-resource-context/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: external-resource-context
-description: Captures and persists access methods for resources outside the repository (design source, design system, API schema, IaC source, secret store) so downstream work can reach them deterministically. Use when work depends on external resources, or when the user mentions design source, design system, API schema, IaC source, secret store, or canonical source.
+description: Captures access methods for resources outside the repository (design source, design system, API schema, IaC source, secret store) into a deterministic location so downstream work can reach them. Use when capturing or updating those access methods, or when the user mentions design source, design system, API schema, IaC source, secret store, or canonical source.
 ---
 
 # External Resource Context
@@ -30,58 +30,19 @@ The project tier owns environment facts. Feature-tier sections list only feature
 
 Example feature-tier entry uses the table format defined in `references/template.md`: a row with the project-tier label in the first column and the feature-specific identifier in the second column.
 
-## Hearing Protocol
-
-### When to Hear
-
-| Condition | Action |
-|-----------|--------|
-| `docs/project-context/external-resources.md` does not exist | Run full hearing for the relevant domain(s) |
-| File exists and covers the current decision | Use it without an update question |
-| User or caller identifies changed environment facts | Run diff-only hearing for the named axes |
-| A relevant axis is absent | Hear only the missing axis |
-| Access failure or contradictory current evidence indicates possible staleness | Ask via AskUserQuestion: "Update external-resources.md? (no / yes-full / yes-diff-only)". On `yes-full` run full hearing; on `yes-diff-only` hear the named stale axes; on `no` preserve the file and report the limitation |
-
-### Domain Routing
-
-Load the domain reference matching the current task:
-
-| Task type | References to load |
-|-----------|--------------------|
-| Frontend (UI work) | [references/frontend.md](references/frontend.md) |
-| Backend (server / data work) | [references/backend.md](references/backend.md) |
-| API contract work | [references/api.md](references/api.md) |
-| Infrastructure / deployment | [references/infra.md](references/infra.md) |
-| Fullstack | Load only the references whose frontend, backend/data, API-contract, or infrastructure responsibilities are affected by the confirmed scope; a fullstack label alone does not activate infrastructure |
-
-Each domain reference defines the axes and the question template.
-
-### Two-Phase Hearing
-
-1. **Structured hearing** — for each axis selected by the When to Hear and Domain Routing rules, present the user with AskUserQuestion using the choices listed in its domain reference (always include "Not applicable" as an option). For each non-N/A axis, follow up with an access-method question (URL / MCP name / file path / command).
-
-2. **Self-declaration for a full hearing** — after the structured axes for all selected domains are complete, present one integrated AskUserQuestion: "Are there any other external resources for this work that the structured questions did not cover? If yes, describe them in your next message." If the user describes additional resources, append them to the storage file under an "Additional resources" subsection. A diff-only or missing-axis hearing ends after its named axes because the existing project record already completed self-declaration.
-
-For a full hearing, the two phases are sequential and self-declaration runs even if the user answered "Not applicable" to every structured axis.
-
-## Storage Protocol
-
-After hearing completes:
-
-1. Build the project-tier content from the answers. Use [references/template.md](references/template.md) as the structure.
-2. Write to `docs/project-context/external-resources.md`. Create the directory if absent.
-3. When the calling workflow has a target UI Spec or Design Doc, also append or update the document's `## External Resources Used` section with the feature-tier subset (label references + feature-specific identifiers only).
-4. Report the file paths back to the calling workflow.
-
 ## Reference Protocol (For Downstream Consumers)
 
-Agents that load this skill consult resources in this order:
+Consuming a recorded resource takes three reads and needs no part of this skill:
 
-1. Read `docs/project-context/external-resources.md` first (if present) to learn what is available and how to access it.
+1. Read `docs/project-context/external-resources.md` (if present) to learn what is available and how to access it.
 2. Read the target UI Spec or Design Doc's `## External Resources Used` section for feature-specific identifiers.
 3. Use the access method declared in the project tier (e.g., the named MCP, the URL, the file path) to fetch the actual resource content.
 
-Agents that only need to *consult* the saved file as input data (not actively hear) can read it directly without loading this skill — frontmatter declaration is reserved for agents that may need to trigger hearing or interpret the protocol semantics.
+A consumer that only reads these records executes the three steps directly. Load this skill when capturing or updating the records, which requires AskUserQuestion and therefore the session that can ask the user.
+
+## Capturing and Updating Records
+
+Follow [references/hearing.md](references/hearing.md) for the hearing conditions, domain routing, two-phase hearing, storage protocol, and quality checklist.
 
 ## Output Format
 
@@ -89,16 +50,9 @@ The project-tier file follows the structure in [references/template.md](referenc
 
 For feature-tier sections inside UI Spec or Design Doc, the heading text "External Resources Used" is fixed; the heading level matches the parent document's natural structure (h2 in UI Spec where it is a sibling of other top-level sections, h3 in Design Doc where it sits under Background and Context).
 
-## Quality Checklist
-
-- [ ] Each axis answered has both a presence indicator and an access method, or is marked "Not applicable"
-- [ ] A full hearing ran self-declaration even when all structured axes were "Not applicable"; a diff-only or missing-axis hearing stayed within its named axes
-- [ ] Project-tier file does not contain feature-specific identifiers
-- [ ] Feature-tier sections reference project-tier entries by label, not by duplicating URLs / MCP names
-- [ ] When the project file already existed, each write traces to an explicit changed fact, a missing relevant axis, or a confirmed stale-evidence update decision
-
 ## References
 
+- [references/hearing.md](references/hearing.md) — Hearing conditions, domain routing, storage protocol, quality checklist
 - [references/frontend.md](references/frontend.md) — Frontend domain axes
 - [references/backend.md](references/backend.md) — Backend domain axes
 - [references/api.md](references/api.md) — API contract domain axes

--- a/skills/external-resource-context/SKILL.md
+++ b/skills/external-resource-context/SKILL.md
@@ -11,12 +11,6 @@ AI agents understand the codebase but not the external resources surrounding it.
 
 Resources covered: design origin (where the canonical visual specification lives), design system (component library and tokens), guidelines (usage docs, accessibility rules), visual verification environment (how to confirm rendering), database schema source, migration history, secret store location, API schema source (OpenAPI / proto / GraphQL SDL), mock environment, IaC source, environment configuration.
 
-## Scope Boundaries
-
-**In scope**: hearing protocol, storage location, single-source-of-truth ownership rule, reference protocol for downstream consumers.
-
-**Out of scope**: enforcing that captured resources are correct or current — verification belongs to the agent that consumes the resource. Generating the resources themselves (e.g., creating a DESIGN.md from scratch).
-
 ## Storage Locations (Two-Tier)
 
 | Tier | Location | Holds | Update Frequency |

--- a/skills/external-resource-context/SKILL.md
+++ b/skills/external-resource-context/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: external-resource-context
-description: Captures access methods for resources outside the repository (design source, design system, API schema, IaC source, secret store) into a deterministic location so downstream work can reach them. Use when capturing or updating those access methods, or when the user mentions design source, design system, API schema, IaC source, secret store, or canonical source.
+description: Records where resources outside the repository live (design source, design system, API schema, IaC source, secret store) and how design, implementation, and verification reach them. Use when work depends on an external resource, or when the user mentions design source, design system, API schema, IaC source, secret store, or canonical source.
 ---
 
 # External Resource Context
@@ -32,17 +32,17 @@ Example feature-tier entry uses the table format defined in `references/template
 
 ## Reference Protocol (For Downstream Consumers)
 
-Consuming a recorded resource takes three reads and needs no part of this skill:
+Before investigating the repository for an external fact, check whether it is already recorded:
 
 1. Read `docs/project-context/external-resources.md` (if present) to learn what is available and how to access it.
 2. Read the target UI Spec or Design Doc's `## External Resources Used` section for feature-specific identifiers.
 3. Use the access method declared in the project tier (e.g., the named MCP, the URL, the file path) to fetch the actual resource content.
 
-A consumer that only reads these records executes the three steps directly. Load this skill when capturing or updating the records, which requires AskUserQuestion and therefore the session that can ask the user.
+When the file is absent or the resource is unreachable, continue from governing and repository evidence. Each consuming agent reports that limitation through its own output contract.
 
 ## Capturing and Updating Records
 
-Follow [references/hearing.md](references/hearing.md) for the hearing conditions, domain routing, two-phase hearing, storage protocol, and quality checklist.
+Capturing a record requires AskUserQuestion, so it belongs to the session that can ask the user. Follow [references/hearing.md](references/hearing.md) for the hearing conditions, domain routing, two-phase hearing, storage protocol, and quality checklist.
 
 ## Output Format
 

--- a/skills/external-resource-context/references/hearing.md
+++ b/skills/external-resource-context/references/hearing.md
@@ -47,6 +47,6 @@ After hearing completes:
 
 - [ ] Each axis answered has both a presence indicator and an access method, or is marked "Not applicable"
 - [ ] A full hearing ran self-declaration even when all structured axes were "Not applicable"; a diff-only or missing-axis hearing stayed within its named axes
-- [ ] Project-tier file does not contain feature-specific identifiers
-- [ ] Feature-tier sections reference project-tier entries by label, not by duplicating URLs / MCP names
+- [ ] Project-tier entries hold the environment facts (URL, MCP name, file path, command)
+- [ ] Feature-tier rows hold a project-tier label and the feature-specific identifier
 - [ ] When the project file already existed, each write traces to an explicit changed fact, a missing relevant axis, or a confirmed stale-evidence update decision

--- a/skills/external-resource-context/references/hearing.md
+++ b/skills/external-resource-context/references/hearing.md
@@ -1,0 +1,52 @@
+# External Resource Hearing and Storage
+
+Producer-side protocol. Load this when capturing or updating external-resource records. Running it requires AskUserQuestion, so it belongs to the session that can ask the user directly.
+
+## When to Hear
+
+| Condition | Action |
+|-----------|--------|
+| `docs/project-context/external-resources.md` does not exist | Run full hearing for the relevant domain(s) |
+| File exists and covers the current decision | Use it without an update question |
+| User or caller identifies changed environment facts | Run diff-only hearing for the named axes |
+| A relevant axis is absent | Hear only the missing axis |
+| Access failure or contradictory current evidence indicates possible staleness | Ask via AskUserQuestion: "Update external-resources.md? (no / yes-full / yes-diff-only)". On `yes-full` run full hearing; on `yes-diff-only` hear the named stale axes; on `no` preserve the file and report the limitation |
+
+## Domain Routing
+
+Load the domain reference matching the current task:
+
+| Task type | References to load |
+|-----------|--------------------|
+| Frontend (UI work) | [frontend.md](frontend.md) |
+| Backend (server / data work) | [backend.md](backend.md) |
+| API contract work | [api.md](api.md) |
+| Infrastructure / deployment | [infra.md](infra.md) |
+| Fullstack | Load only the references whose frontend, backend/data, API-contract, or infrastructure responsibilities are affected by the confirmed scope; a fullstack label alone does not activate infrastructure |
+
+Each domain reference defines the axes and the question template.
+
+## Two-Phase Hearing
+
+1. **Structured hearing** — for each axis selected by the When to Hear and Domain Routing rules, present the user with AskUserQuestion using the choices listed in its domain reference (always include "Not applicable" as an option). For each non-N/A axis, follow up with an access-method question (URL / MCP name / file path / command).
+
+2. **Self-declaration for a full hearing** — after the structured axes for all selected domains are complete, present one integrated AskUserQuestion: "Are there any other external resources for this work that the structured questions did not cover? If yes, describe them in your next message." If the user describes additional resources, append them to the storage file under an "Additional resources" subsection. A diff-only or missing-axis hearing ends after its named axes because the existing project record already completed self-declaration.
+
+For a full hearing, the two phases are sequential and self-declaration runs even if the user answered "Not applicable" to every structured axis.
+
+## Storage Protocol
+
+After hearing completes:
+
+1. Build the project-tier content from the answers. Use [template.md](template.md) as the structure.
+2. Write to `docs/project-context/external-resources.md`. Create the directory if absent.
+3. When the calling workflow has a target UI Spec or Design Doc, also append or update the document's `## External Resources Used` section with the feature-tier subset (label references + feature-specific identifiers only).
+4. Report the file paths back to the calling workflow.
+
+## Quality Checklist
+
+- [ ] Each axis answered has both a presence indicator and an access method, or is marked "Not applicable"
+- [ ] A full hearing ran self-declaration even when all structured axes were "Not applicable"; a diff-only or missing-axis hearing stayed within its named axes
+- [ ] Project-tier file does not contain feature-specific identifiers
+- [ ] Feature-tier sections reference project-tier entries by label, not by duplicating URLs / MCP names
+- [ ] When the project file already existed, each write traces to an explicit changed fact, a missing relevant axis, or a confirmed stale-evidence update decision

--- a/skills/frontend-ai-guide/SKILL.md
+++ b/skills/frontend-ai-guide/SKILL.md
@@ -123,7 +123,7 @@ function EmailInput({ context }: { context: 'user' | 'contact' | 'admin' }) { /*
 - Similar functionality found → Verify that its props, lifecycle, design-system role, and repository usage are representative; reuse or extend it when compatible, otherwise record why it is not a valid model
 - Similar functionality is technical debt → Repair it when it blocks the current outcome, was caused by the current change, or lies in confirmed scope; otherwise report it separately. Create an ADR when the repair requires an architectural decision
 - No similar functionality exists → Implement new functionality following existing design philosophy
-- Record all decisions and rationale in "Existing Codebase Analysis" section of Design Doc
+- Record each reuse, extend, separate, or repair decision with its evidence in the artifact this agent owns
 
 ## Quality Check Workflow
 
@@ -165,11 +165,7 @@ Read `package.json` scripts, map the project's actual commands to the phases bel
 **Completion Criteria**: Complete all 3 stages. Concise search/inspection notes are sufficient for an isolated component change with no shared contract, routing, state-ownership, or build/config impact; use the structured report for cross-component or high-risk changes.
 
 #### 1. Discovery
-```bash
-Grep -n "ComponentName\|hookName" -o content
-Grep -n "importedFunction" -o content
-Grep -n "propsType\|StateType" -o content
-```
+Search the repository for every reference to the changed component or hook, its imported functions, and its Props/State types.
 
 #### 2. Understanding
 Read the discovered files needed to establish:

--- a/skills/implementation-approach/SKILL.md
+++ b/skills/implementation-approach/SKILL.md
@@ -35,7 +35,7 @@ Complete these steps in order before selecting an implementation strategy:
 
 Classify supporting claims as observed, inferred, or unknown. When an unknown blocks the next step, stop at the current step and name the evidence or user decision required.
 
-**Design Doc output**: Direct MVP, Failed Items, Adopted Additions, and Rejected Additions.
+**Phase 2 outputs**: Direct MVP, Failed Items, Adopted Additions, and Rejected Additions. A Design Doc author records all four; an implementer uses them as the convergence check without producing a document.
 
 ### Phase 3: Strategy Exploration and Creation
 
@@ -117,7 +117,7 @@ Select the implementation approach that directly fits the verified dependency an
 
 ### Phase 7: Decision Rationale Documentation
 
-**Design Doc Documentation**: Record in the Design Doc's implementation approach section:
+**Record in the artifact this agent owns**, and in the Design Doc's implementation approach section when this agent owns that document:
 1. Selected strategy name and characteristics
 2. A materially different alternative and reason for rejection, when one was compared
 3. Risk mitigation plan (from Phase 4)

--- a/skills/integration-e2e-testing/SKILL.md
+++ b/skills/integration-e2e-testing/SKILL.md
@@ -76,7 +76,7 @@ The two E2E lanes have different ownership costs and use independent standard th
 | fixture-e2e | ROI ≥ 20 (beyond reserved slot) | Cost is comparable to integration tests once the harness exists; the floor avoids filling MAX 3 with low-signal tests when fewer would suffice |
 | service-integration-e2e | ROI > 50 (beyond reserved slot) | Live-service setup, state cleanup, and failure diagnosis add material ownership cost; reserve for journeys whose value cannot be proven any other way |
 
-Reserved slot rules (see Multi-Step User Journey Definition below) apply per lane and override the threshold (the reserved candidate is emitted regardless of its ROI score). Below-floor candidates beyond the reserved slot are not emitted unless an accepted requirement or distinct uncovered failure mode justifies an exception. Leave budget intentionally unfilled rather than padding with low-value tests; record any threshold or budget exception in the skeleton and generation report.
+Reserved slot rules (see Multi-Step User Journey Definition below) apply per lane and override the threshold (the reserved candidate is emitted regardless of its ROI score). Below-floor candidates beyond the reserved slot are not emitted unless an accepted requirement or distinct uncovered failure mode justifies an exception. Leave budget intentionally unfilled rather than padding with low-value tests; record any threshold or budget exception in the skeleton that carries the exception.
 
 ### ROI Calculation Examples
 

--- a/skills/integration-e2e-testing/SKILL.md
+++ b/skills/integration-e2e-testing/SKILL.md
@@ -76,7 +76,7 @@ The two E2E lanes have different ownership costs and use independent standard th
 | fixture-e2e | ROI ≥ 20 (beyond reserved slot) | Cost is comparable to integration tests once the harness exists; the floor avoids filling MAX 3 with low-signal tests when fewer would suffice |
 | service-integration-e2e | ROI > 50 (beyond reserved slot) | Live-service setup, state cleanup, and failure diagnosis add material ownership cost; reserve for journeys whose value cannot be proven any other way |
 
-Reserved slot rules (see Multi-Step User Journey Definition below) apply per lane and override the threshold (the reserved candidate is emitted regardless of its ROI score). Below-floor candidates beyond the reserved slot are not emitted unless an accepted requirement or distinct uncovered failure mode justifies an exception. Leave budget intentionally unfilled rather than padding with low-value tests; record any threshold or budget exception in the skeleton that carries the exception.
+Reserved slot rules (see Multi-Step User Journey Definition below) apply per lane and override the threshold (the reserved candidate is emitted regardless of its ROI score). Emit a below-floor candidate beyond the reserved slot only when an accepted requirement or a distinct uncovered failure mode justifies the exception. Leave budget intentionally unfilled rather than padding with low-value tests; record any threshold or budget exception in the skeleton that carries the exception.
 
 ### ROI Calculation Examples
 

--- a/skills/recipe-add-integration-tests/SKILL.md
+++ b/skills/recipe-add-integration-tests/SKILL.md
@@ -41,18 +41,7 @@ Document paths: $ARGUMENTS
 
 ### Step 1: Discover and Validate Documents
 
-```bash
-# Verify at least one document path was provided
-test -n "$ARGUMENTS" || { echo "ERROR: No document paths provided"; exit 1; }
-
-# Verify provided paths exist
-ls $ARGUMENTS
-
-# Discover additional documents
-ls docs/design/*.md 2>/dev/null | grep -v template
-ls docs/ui-spec/*.md 2>/dev/null
-ls docs/prd/*.md 2>/dev/null
-```
+Confirm `$ARGUMENTS` names at least one existing document path; report and end when it is empty or every path is unresolvable. Then discover the remaining Design Docs, UI Specs, and PRDs under `docs/design/`, `docs/ui-spec/`, and `docs/prd/`.
 
 Classify discovered documents by filename:
 - Filename contains `backend` → **Design Doc (backend)**

--- a/skills/recipe-build/SKILL.md
+++ b/skills/recipe-build/SKILL.md
@@ -34,7 +34,7 @@ Before any task processing, locate the work plan. Resolution rule:
 1. List task files in `docs/plans/tasks/` matching the single-layer pattern `{plan-name}-task-*.md`. Layer-aware fullstack tasks (`{plan-name}-backend-task-*.md` / `{plan-name}-frontend-task-*.md`) are excluded here so a stale fullstack run does not redirect this recipe to the wrong work plan
 2. For each matched file, extract the `{plan-name}` prefix as the segment that appears before `-task-`
 3. When at least one task file matches, the work plan is `docs/plans/{plan-name}.md` for the prefix that has the most recent task-file mtime; ties broken by the lexicographically last `{plan-name}`
-4. When no task file matches the restricted pattern, the work plan is the most-recent-mtime non-template `.md` in `docs/plans/`
+4. When no task file matches the restricted pattern, the work plan is the most recently modified `.md` in `docs/plans/`
 
 ### Consumed Task Set
 

--- a/skills/recipe-front-build/SKILL.md
+++ b/skills/recipe-front-build/SKILL.md
@@ -34,7 +34,7 @@ Before any task processing, locate the work plan. Resolution rule:
 1. List task files in `docs/plans/tasks/` matching the single-layer pattern `{plan-name}-task-*.md`. Layer-aware fullstack tasks (`{plan-name}-backend-task-*.md` / `{plan-name}-frontend-task-*.md`) are excluded here so a stale fullstack run does not redirect this recipe to the wrong work plan
 2. For each matched file, extract the `{plan-name}` prefix as the segment that appears before `-task-`
 3. When at least one task file matches, the work plan is `docs/plans/{plan-name}.md` for the prefix that has the most recent task-file mtime; ties broken by the lexicographically last `{plan-name}`
-4. When no task file matches the restricted pattern, the work plan is the most-recent-mtime non-template `.md` in `docs/plans/`
+4. When no task file matches the restricted pattern, the work plan is the most recently modified `.md` in `docs/plans/`
 
 ### Consumed Task Set
 

--- a/skills/recipe-front-review/SKILL.md
+++ b/skills/recipe-front-review/SKILL.md
@@ -36,13 +36,7 @@ Design Doc (uses most recent if omitted): $ARGUMENTS
 ## Execution Flow
 
 ### Step 1: Prerequisite Check
-```bash
-# Identify Design Doc
-ls docs/design/*.md | grep -v template | tail -1
-
-# Check implementation files
-git diff --name-only main...HEAD
-```
+Identify the review inputs: the most recently updated Design Doc under `docs/design/`, and the files changed on the current branch relative to its base.
 
 ### Step 2: Execute code-reviewer
 Invoke code-reviewer using Agent tool:
@@ -116,7 +110,7 @@ Run this step only when the user routed at least one finding to `d`. When no `d`
    - `prompt`: "Review updated Design Doc at [path] for consistency and completeness. doc_type: DesignDoc. review_context: update."
    - Run the Review Resolution Gate through its correction re-review, escalation, and convergence transitions, using technical-designer-frontend for rerouted corrections. Proceed only at its convergence condition.
 
-3. When multiple Design Docs exist (`ls docs/design/*.md | grep -v template | wc -l > 1`), invoke design-sync:
+3. When more than one Design Doc exists under `docs/design/`, invoke design-sync:
    - `subagent_type`: "dev-workflows-frontend:design-sync"
    - `description`: "Cross-DD consistency check"
    - `prompt`: "source_design: [updated DD path]"

--- a/skills/recipe-fullstack-build/SKILL.md
+++ b/skills/recipe-fullstack-build/SKILL.md
@@ -42,7 +42,7 @@ Before any task processing, locate the work plan. Resolution rule:
 1. List task files in `docs/plans/tasks/` matching the layer-aware patterns `{plan-name}-backend-task-*.md` and `{plan-name}-frontend-task-*.md` only. Single-layer tasks (`{plan-name}-task-*.md`) are excluded here so a stale single-layer run does not redirect this recipe to the wrong work plan
 2. For each matched file, extract the `{plan-name}` prefix as the segment that appears before `-backend-task-` or `-frontend-task-`
 3. When at least one task file matches, the work plan is `docs/plans/{plan-name}.md` for the prefix that has the most recent task-file mtime; ties broken by the lexicographically last `{plan-name}`
-4. When no task file matches the restricted pattern, the work plan is the most-recent-mtime non-template `.md` in `docs/plans/`
+4. When no task file matches the restricted pattern, the work plan is the most recently modified `.md` in `docs/plans/`
 
 ### Consumed Task Set
 

--- a/skills/recipe-review/SKILL.md
+++ b/skills/recipe-review/SKILL.md
@@ -36,13 +36,7 @@ Design Doc (uses most recent if omitted): $ARGUMENTS
 ## Execution Flow
 
 ### Step 1: Prerequisite Check
-```bash
-# Identify Design Doc
-ls docs/design/*.md | grep -v template | tail -1
-
-# Check implementation files
-git diff --name-only main...HEAD
-```
+Identify the review inputs: the most recently updated Design Doc under `docs/design/`, and the files changed on the current branch relative to its base.
 
 ### Step 2: Execute code-reviewer
 Invoke code-reviewer using Agent tool:
@@ -116,7 +110,7 @@ Run this step only when the user routed at least one finding to `d`. When no `d`
    - `prompt`: "Review updated Design Doc at [path] for consistency and completeness. doc_type: DesignDoc. review_context: update."
    - Run the Review Resolution Gate through its correction re-review, escalation, and convergence transitions, using technical-designer for rerouted corrections. Proceed only at its convergence condition.
 
-3. When multiple Design Docs exist (`ls docs/design/*.md | grep -v template | wc -l > 1`), invoke design-sync:
+3. When more than one Design Doc exists under `docs/design/`, invoke design-sync:
    - `subagent_type`: "dev-workflows:design-sync"
    - `description`: "Cross-DD consistency check"
    - `prompt`: "source_design: [updated DD path]"

--- a/skills/recipe-update-doc/SKILL.md
+++ b/skills/recipe-update-doc/SKILL.md
@@ -24,21 +24,21 @@ Before the first finding disposition, read `references/review-resolution.md` fro
 1. **Invoke named specialists for deliverable production** — pass deliverable paths between them and validate their results (see subagents-orchestration-guide "Orchestrator Execution Boundary")
 2. **Execute update flow**:
    - Identify target → Clarify changes → Update document → Review → Consistency check
-   - **Stop at every `[Stop: ...]` marker** → Wait for user approval before proceeding
+   - **Stop at the `[Stop: Final approval]` marker** → Wait for user approval before completing
 3. **Scope**: Complete when updated document receives approval
 
 At each Agent invocation below, build the prompt as a mechanical extraction: copy the named source values into the exact fields, apply only the declared serialization, then invoke immediately.
 
-**CRITICAL**: Execute document-reviewer and all stopping points — each serves as a quality gate for document accuracy.
+**CRITICAL**: Execute document-reviewer — it is the quality gate for document accuracy.
 
 ## Workflow Overview
 
 ```
-Target document → [Stop: Confirm changes]
+Target document → change clarification
                         ↓
               technical-designer / technical-designer-frontend / prd-creator (update mode)
                         ↓ (Design Doc only)
-              code-verifier → document-reviewer → [Stop: Review approval]
+              code-verifier → document-reviewer
                         ↓ (Design Doc only)
               design-sync → [Stop: Final approval]
 ```
@@ -47,7 +47,7 @@ Target document → [Stop: Confirm changes]
 
 **Included in this skill**:
 - Existing document identification and selection
-- Change content clarification with user
+- Change content clarification
 - Document update with appropriate agent (update mode)
 - Document review with document-reviewer
 - Consistency verification with design-sync (Design Doc only)
@@ -64,10 +64,7 @@ Target document: $ARGUMENTS
 
 ### Step 1: Target Document Identification
 
-```bash
-# Check existing documents
-ls docs/design/*.md docs/prd/*.md docs/adr/*.md 2>/dev/null | grep -v template
-```
+Discover the existing documents under `docs/design/`, `docs/prd/`, and `docs/adr/`.
 
 **Decision flow**:
 
@@ -97,16 +94,11 @@ Read the document and determine its layer from content signals:
 - **Minor changes** (clarification, typo fix, small scope adjustment): Update the existing ADR file
 - **Major changes** (decision reversal, significant scope change): Create a new ADR that supersedes the original
 
-### Step 3: Change Content Clarification [Stop]
+### Step 3: Change Content Clarification
 
-Use AskUserQuestion to clarify what changes are needed:
-- What sections need updating
-- Reason for the change (bug fix findings, spec change, review feedback, etc.)
-- Expected outcome after the update
+Determine which sections need updating, the reason for the change, and the expected outcome after the update. Derive them from the request and the target document. Use AskUserQuestion only for an item the request and document leave undetermined, and only when a different answer would change which sections are updated or what the update must achieve.
 
-Confirm understanding of changes with user before proceeding.
-
-Pass approved items, covered sections, and any stated total size budget to update or revision agents. Before the next approval gate, map every diff hunk to an approved item or required consistency update; request a scope decision for unmapped or over-budget changes.
+Pass the resulting items, covered sections, and any stated total size budget to update or revision agents. Before the next approval gate, map every diff hunk to an approved item or required consistency update; request a scope decision for unmapped or over-budget changes.
 
 ### Step 4: Document Update
 
@@ -119,13 +111,13 @@ prompt: |
   Existing Document: [path from Step 1]
 
   ## Changes Required
-  [user-approved Step 3 statements for the sections to update, reason, and expected outcome, copied verbatim]
+  [Step 3 statements for the sections to update, reason, and expected outcome, copied verbatim]
 
   Update the document to reflect the specified changes.
   Add change history entry.
 ```
 
-### Step 5: Document Review [Stop]
+### Step 5: Document Review
 
 **For Design Doc updates only**: Before document-reviewer, invoke code-verifier:
 ```
@@ -170,22 +162,18 @@ For each type, review consistency of the changed sections and their dependent st
 - On re-review pass `prior_feedback` as `[{id, disposition, reason?, evidence}]`
 - All actionable findings are `decline` and every `user_decision_required` item is resolved → Proceed to Step 6
 
-Present review result to user for approval.
+### Step 6: Consistency Verification and Final Approval `[Stop: Final approval]`
 
-### Step 6: Consistency Verification (Design Doc only) [Stop]
-
-**Skip condition**: Document type is PRD or ADR → Proceed to completion.
-
-For Design Doc, invoke design-sync:
+**For Design Doc only**, invoke design-sync first:
 ```
 subagent_type: design-sync
 description: "Verify consistency"
 prompt: "source_design: [path from Step 1]"
 ```
 
-**On consistency result**:
-- No conflicts → Present result to user for final approval
-- Conflicts detected → Apply the Review Resolution Gate using design-sync as a fresh verifier. Return `apply` conflicts to Step 4 for the owning document, rerun design-sync after correction, retain evidenced declines as complete, and request user input for `user_decision_required` or the Gate's escalation conditions. Present final approval at convergence.
+When conflicts are detected, apply the Review Resolution Gate using design-sync as a fresh verifier. Return `apply` conflicts to Step 4 for the owning document, rerun design-sync after correction, retain evidenced declines as complete, and request user input for `user_decision_required` or the Gate's escalation conditions.
+
+**For every document type**, present the updated document, the review outcome, any resolved declines, and the sync result when one ran. This is the only approval gate in the flow: wait for the user's decision before completing.
 
 ## Error Handling
 
@@ -197,7 +185,7 @@ prompt: "source_design: [path from Step 1]"
 ## Completion Criteria
 
 - [ ] Identified target document
-- [ ] Clarified change content with user
+- [ ] Change content determined from the request, the document, or a question whose answer changed the update
 - [ ] Updated document with appropriate agent (update mode)
 - [ ] Executed code-verifier before document-reviewer (Design Doc only)
 - [ ] Executed document-reviewer and addressed feedback

--- a/skills/subagents-orchestration-guide/SKILL.md
+++ b/skills/subagents-orchestration-guide/SKILL.md
@@ -284,8 +284,8 @@ Pass the Design Doc path. Work-planner maps governing sections and ACs to implem
 
 - Invoke acceptance-test-generator with `design_docs` as the applicable Design Doc path list, optional `ui_spec`, and the same `confirmed_requirement_context` used for design.
 - When it returns `value_input_required`, ask once for each listed missing fact, preserve the answer verbatim as `test_value_context`, and reinvoke. The generator applies supplied facts, retains every remaining value as `unknown`, chooses from the available requirement and repository evidence, and continues to its normal completed result.
-- Verify each non-null `generatedFiles.<lane>` path exists. For each null E2E lane, accept its `e2eAbsenceReason.<lane>` only when it names the selection rule, source evidence, and selected or governing proof covering the accepted boundary. Return an uncovered accepted proof obligation to the generator for completion.
-- Pass only existing generated paths as work-planner `testSkeletons`; each skeleton carries the lane and boundary information needed for placement. Consume valid null-lane reasons at this gate.
+- Verify each non-null `generatedFiles.<lane>` path exists. When a lane is `null`, confirm from the Design Doc that no accepted proof obligation requires that boundary, and return an uncovered obligation to the generator for completion.
+- Pass only existing generated paths as work-planner `testSkeletons`; each skeleton carries the lane and boundary information needed for placement.
 - Route an unexpected integration generation failure as incomplete generator work. A validated null E2E lane is complete.
 
 ## References

--- a/skills/subagents-orchestration-guide/references/monorepo-flow.md
+++ b/skills/subagents-orchestration-guide/references/monorepo-flow.md
@@ -27,7 +27,7 @@ This reference defines the orchestration flow for one feature spanning backend a
 | 11 | technical-designer-frontend | Frontend Design Doc with backend contracts, applicable UI Spec, and accepted ADR constraints | Frontend Design Doc |
 | 12 | code-verifier ×2 + orchestrator | Verify each Design Doc and apply Review Resolution | Resolved verification evidence |
 | 13 | document-reviewer ×2 | Review each Design Doc with resolved verification evidence | Reviews |
-| 14 | design-sync | Cross-layer consistency verification **[Stop]** | Sync status |
+| 14 | design-sync | Cross-layer consistency verification **[Stop when conflicts remain after Review Resolution]** | Sync status |
 | 15 | acceptance-test-generator | Integration/E2E skeletons selected from cross-layer contracts | Test skeletons |
 | 16 | work-planner | Work plan from both Design Docs | Work Plan |
 | 17 | document-reviewer | Work Plan review **[Stop: Batch approval]** | Approval |

--- a/skills/task-analyzer/references/skills-index.yaml
+++ b/skills/task-analyzer/references/skills-index.yaml
@@ -206,7 +206,6 @@ skills:
       - "references/template.md"
     sections:
       - "Purpose"
-      - "Scope Boundaries"
       - "Storage Locations (Two-Tier)"
       - "Reference Protocol (For Downstream Consumers)"
       - "Capturing and Updating Records"

--- a/skills/task-analyzer/references/skills-index.yaml
+++ b/skills/task-analyzer/references/skills-index.yaml
@@ -71,17 +71,12 @@ skills:
       - "Design Doc Culture - Google Engineering Practices"
       - "Single Source of Truth"
     sections:
-      - "Templates"
+      - "What Each Document Fixes"
       - "Creation Decision Matrix"
       - "Structural Scale"
       - "ADR Decision Filters"
-      - "Detailed Document Definitions"
-      - "Creation Process"
       - "Storage Locations"
-      - "ADR Status"
-      - "AI Automation Rules"
-      - "Diagram Requirements"
-      - "Common ADR Relationships"
+      - "References"
 
   implementation-approach:
     skill: "implementation-approach"
@@ -203,6 +198,7 @@ skills:
     tags: [cross-cutting, hearing-protocol, design-source, design-system, api-schema, iac-source, secrets, environment, two-tier-storage]
     typical-use: "Captures access methods for resources outside the repository (design origin, design system, API schema, IaC source, secrets, etc.) and persists them in a deterministic location for downstream agents"
     key-references:
+      - "references/hearing.md"
       - "references/frontend.md"
       - "references/backend.md"
       - "references/api.md"
@@ -212,11 +208,9 @@ skills:
       - "Purpose"
       - "Scope Boundaries"
       - "Storage Locations (Two-Tier)"
-      - "Hearing Protocol"
-      - "Storage Protocol"
       - "Reference Protocol (For Downstream Consumers)"
+      - "Capturing and Updating Records"
       - "Output Format"
-      - "Quality Checklist"
       - "References"
 
   requirement-convergence:


### PR DESCRIPTION
## Summary

Reviews the workflow against the distinction between constraints that protect a boundary and constraints that only create work, and removes the second kind. Three passes: escalation conditions, responsibility boundaries between templates / skills / agents, and artifacts that no consumer reads.

The net effect is that agents stop for fewer things, carry less text, and record evidence in one place instead of several.

## Escalation

`task-executor` and `task-executor-frontend` carried roughly twenty escalation statements across five sections, while the ENFORCEMENT rule at the end already limited escalation to a changed product outcome, a major approved design change, user-held authority, or an irreversible action. The checks above it no longer matched that rule.

Seven checks that map to those four categories remain. The rest now resolve from repository evidence and record the choice:

- Quality-standard bypasses move out of the pre-implementation judgment criteria into a positive delivery statement.
- Step 2 becomes the accepted-source rule for existing-test expectations, the one boundary in that group.
- Gray-zone examples become boundary classification feeding Step 1; similar-implementation overlap is decided by Step 3 evidence.
- `Implementation Continuable` is removed — its permission restated the escalation boundary rule in reverse.
- `dependency_version_uncertain` fires only when a concern needs a dependency or pattern the repository does not already use.

Elsewhere: `acceptance-test-generator` uses the budget-exception authority `integration-e2e-testing` already grants it instead of asking; document updates stop once at the end rather than three times; cross-layer sync stops only when conflicts remain; `security-reviewer` separates a missing input, which the orchestrator can supply, from committed credentials, which need user authority.

## Responsibility boundaries

**`external-resource-context`** — the hearing protocol needs `AskUserQuestion`, which no agent has. Eight agents declared the skill and could not run it. The producer side moves to `references/hearing.md` for the session that can ask; consumers execute the three-step lookup inline.

**`documentation-criteria`** — the skill now answers routing only: which documents a change requires and where they live. Per-document content requirements duplicated the six templates, which every authoring agent already reads by explicit instruction, so they move there. A new `What Each Document Fixes` section gives the always-loaded tier each document's purpose, its downstream consumer, and what an unfilled section costs.

**Generic skills** — `ai-development-guide`, `frontend-ai-guide`, and `implementation-approach` instructed writing into named Design Doc sections. They load into agents that hold governing documents read-only, so those instructions now name the artifact the agent owns.

Skill references are cited by path throughout, matching the existing convention, so content that moved into templates stays one hop away.

## Unread artifacts

- Work Plan review status: nothing wrote `approved`, nothing read it. Approval is the orchestrator's `[Stop]` gate.
- `Design Summary (Meta)`, the Agreement Checklist scope and constraint subsections, Work Plan progress notes: no consumer, and Requirement Convergence already carries scope and non-goals. Standards, assumed behaviors, and quality-assurance mechanisms stay — they are design evidence.
- `e2eAbsenceReason` and `budgetUsage`: the first made the generator justify every correctly empty lane in prose the orchestrator then graded; the orchestrator now confirms an empty lane against the Design Doc directly. The second had no consumer at all.
- Discovery commands in recipes: they pinned a base branch, filtered for template files the workflow never creates, and described searches the model performs without instruction.

## Compatibility

`e2eAbsenceReason` and `budgetUsage` are removed from the `acceptance-test-generator` result. The only in-repo consumer is updated in the same change. Released as a patch on that basis; anything reading that JSON externally would see a contract change.

## Verification

- `pnpm sync:check` — all plugin subdirectories in sync
- `claude plugin validate` — marketplace manifest and all four plugin manifests pass
- `pnpm check:skills-index` — all 13 skills consistent
- Relative markdown links across `skills/` resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)
