### PR TITLE
Remove Task tool dependencies from workflow prompts

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "dev-workflows",
       "source": "./dev-workflows",
       "strict": true,
-      "version": "0.24.6",
+      "version": "0.24.7",
       "description": "Skills + Subagents for backend development - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
       "author": {
         "name": "Shinsuke Kagawa",
@@ -82,7 +82,7 @@
       "name": "dev-workflows-frontend",
       "source": "./dev-workflows-frontend",
       "strict": true,
-      "version": "0.24.6",
+      "version": "0.24.7",
       "description": "Skills + Subagents for React/TypeScript - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
       "author": {
         "name": "Shinsuke Kagawa",
@@ -155,7 +155,7 @@
       "name": "dev-workflows-fullstack",
       "source": "./dev-workflows-fullstack",
       "strict": true,
-      "version": "0.24.6",
+      "version": "0.24.7",
       "description": "Skills + Subagents for fullstack development (backend + React/TypeScript) - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
       "author": {
         "name": "Shinsuke Kagawa",
@@ -244,7 +244,7 @@
       "name": "dev-skills",
       "source": "./dev-skills",
       "strict": true,
-      "version": "0.24.6",
+      "version": "0.24.7",
       "description": "Lightweight skills for users with existing workflows - coding best practices, testing principles, and design guidelines without recipe workflows or agents",
       "author": {
         "name": "Shinsuke Kagawa",

--- a/agents/acceptance-test-generator.md
+++ b/agents/acceptance-test-generator.md
@@ -1,7 +1,7 @@
 ---
 name: acceptance-test-generator
 description: Generates integration/E2E test skeletons from Design Doc ACs using ROI-based selection and journey-based E2E reservation. Use when Design Doc is complete and test design is needed, or when "test skeleton/AC/acceptance criteria" is mentioned. Behavior-first approach for minimal tests with maximum coverage.
-tools: Read, Write, Glob, LS, TaskCreate, TaskUpdate, Grep
+tools: Read, Write, Glob, LS, Grep
 skills:
   - testing-principles
   - documentation-criteria
@@ -13,9 +13,9 @@ You are a specialized AI that generates minimal, high-quality test skeletons fro
 
 Operates in an independent context, executing autonomously until task completion.
 
-## Mandatory Initial Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ### Implementation Approach Compliance
 - **Test Code Generation**: MUST strictly comply with Design Doc implementation patterns (function vs class selection)

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: code-reviewer
 description: Validates Design Doc compliance and implementation completeness from third-party perspective. Use PROACTIVELY after implementation completes or when "review/implementation check/compliance" is mentioned. Provides acceptance criteria validation and quality reports.
-tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate
+tools: Read, Grep, Glob, LS, Bash
 skills:
   - ai-development-guide
   - coding-principles
@@ -12,9 +12,9 @@ You are a code review AI assistant specializing in Design Doc compliance validat
 
 Operates in an independent context, executing autonomously until task completion.
 
-## Initial Required Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Key Responsibilities
 

--- a/agents/code-verifier.md
+++ b/agents/code-verifier.md
@@ -1,7 +1,7 @@
 ---
 name: code-verifier
 description: Verifies repository-backed claims and implementation feasibility in PRDs, Design Docs, or Work Plans. Use before document review, after implementation, or for reverse-engineered artifact verification.
-tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate
+tools: Read, Grep, Glob, LS, Bash
 skills:
   - documentation-criteria
   - ai-development-guide
@@ -12,9 +12,9 @@ You perform read-only verification of an authoritative document against reposito
 
 Your discrepancies are independent evidence for orchestrator Review Resolution. Confirmed requirements and selected ADR decisions define scope; the orchestrator determines correction obligations.
 
-## Required Initial Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Inputs
 

--- a/agents/codebase-analyzer.md
+++ b/agents/codebase-analyzer.md
@@ -1,7 +1,7 @@
 ---
 name: codebase-analyzer
 description: Collects compact repository evidence for scope confirmation, technical option selection, complete design, and verification. Use before Design Doc creation when repository facts can change scope, reuse, contracts, cost, or proof.
-tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate
+tools: Read, Grep, Glob, LS, Bash
 skills:
   - ai-development-guide
   - coding-principles
@@ -10,9 +10,9 @@ skills:
 
 You are an AI assistant specializing in objective codebase analysis for technical design preparation.
 
-## Required Initial Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Responsibilities
 

--- a/agents/design-sync.md
+++ b/agents/design-sync.md
@@ -1,7 +1,7 @@
 ---
 name: design-sync
 description: Detects conflicts across multiple Design Docs and provides structured reports. Use when multiple Design Docs exist, or when "consistency/conflict/sync/between documents" is mentioned. Focuses on detection and reporting only, no modifications.
-tools: Read, Grep, Glob, LS, TaskCreate, TaskUpdate
+tools: Read, Grep, Glob, LS
 skills:
   - documentation-criteria
   - coding-principles
@@ -12,9 +12,9 @@ You are an AI assistant specializing in consistency verification between Design 
 
 Operates in an independent context, executing autonomously until task completion.
 
-## Initial Mandatory Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Detection Criteria (The Only Rule)
 

--- a/agents/document-reviewer.md
+++ b/agents/document-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: document-reviewer
 description: Reviews one document or one ADR batch against governing requirements, repository evidence, and the needs of its next consumer. Use before user approval or when document consistency and completeness need verification.
-tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
+tools: Read, Grep, Glob, LS, Bash, WebSearch
 skills:
   - documentation-criteria
   - coding-principles
@@ -11,9 +11,9 @@ skills:
 
 You review one PRD, ADR batch, UI Spec, Design Doc, or Work Plan per invocation.
 
-## Initial Mandatory Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Inputs
 

--- a/agents/integration-test-reviewer.md
+++ b/agents/integration-test-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: integration-test-reviewer
 description: Verifies changed integration and E2E tests against skeletons, proof obligations, or explicit prompt claims. Use PROACTIVELY after test implementation completes, or when "test review/skeleton verification" is mentioned. Returns quality reports with failing items and fix instructions.
-tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate
+tools: Read, Grep, Glob, LS, Bash
 skills:
   - testing-principles
   - integration-e2e-testing
@@ -11,9 +11,9 @@ You are an AI assistant specializing in integration and E2E test quality review.
 
 Operates in an independent context, executing autonomously until task completion.
 
-## Initial Mandatory Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Responsibilities
 

--- a/agents/investigator.md
+++ b/agents/investigator.md
@@ -1,7 +1,7 @@
 ---
 name: investigator
 description: Comprehensively collects problem-related information and creates evidence matrix. Use PROACTIVELY when bug/error/issue/defect/not working/strange behavior is reported. Reports observations and evidence for downstream cause verification.
-tools: Read, Grep, Glob, LS, Bash, WebSearch, TaskCreate, TaskUpdate
+tools: Read, Grep, Glob, LS, Bash, WebSearch
 skills:
   - ai-development-guide
   - coding-principles
@@ -9,9 +9,9 @@ skills:
 
 You are an AI assistant specializing in problem investigation.
 
-## Required Initial Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Input and Responsibility Boundaries
 

--- a/agents/prd-creator.md
+++ b/agents/prd-creator.md
@@ -1,7 +1,7 @@
 ---
 name: prd-creator
 description: Creates PRD and structures business requirements. Use when new feature/project starts, or when "PRD/requirements definition/user story/what to build" is mentioned. Defines user value and success metrics.
-tools: Read, Write, Edit, MultiEdit, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
+tools: Read, Write, Edit, MultiEdit, Glob, LS, Bash, WebSearch
 skills:
   - documentation-criteria
   - llm-friendly-context
@@ -10,9 +10,9 @@ skills:
 
 You are a specialized AI assistant for creating Product Requirements Documents (PRD).
 
-## Initial Mandatory Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Responsibilities
 

--- a/agents/quality-fixer-frontend.md
+++ b/agents/quality-fixer-frontend.md
@@ -1,7 +1,7 @@
 ---
 name: quality-fixer-frontend
 description: Specialized agent for verifying React projects and fixing frontend quality failures within the current task scope. Use proactively after code changes or for quality, test, build, lint, format, type, or fix requests.
-tools: Bash, Read, Edit, MultiEdit, Grep, Glob, LS, TaskCreate, TaskUpdate
+tools: Bash, Read, Edit, MultiEdit, Grep, Glob, LS
 skills:
   - typescript-rules
   - test-implement
@@ -26,9 +26,9 @@ Executes applicable quality checks, fixes in-scope failures, and reports blocker
 - **qualityCommand** (optional): Quality command supplied by the caller or recorded in the task. Run it first, then cover the remaining applicable check categories.
 - **mutationEvidence** (optional): Upstream mutation results with restoration and target-revision proof
 
-## Initial Required Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ### Package Manager
 Use the appropriate run command based on the `packageManager` field in package.json.

--- a/agents/quality-fixer.md
+++ b/agents/quality-fixer.md
@@ -1,7 +1,7 @@
 ---
 name: quality-fixer
 description: Specialized agent for verifying software projects and fixing quality failures within the current task scope. Use proactively after code changes or for quality, test, build, lint, format, correctness, or fix requests.
-tools: Bash, Read, Edit, MultiEdit, Grep, Glob, LS, TaskCreate, TaskUpdate
+tools: Bash, Read, Edit, MultiEdit, Grep, Glob, LS
 skills:
   - coding-principles
   - testing-principles
@@ -26,9 +26,9 @@ Executes applicable quality checks, fixes in-scope failures, and reports blocker
 - **qualityCommand** (optional): Quality command supplied by the caller or recorded in the task. Run it first, then cover the remaining applicable check categories.
 - **mutationEvidence** (optional): Upstream mutation results with restoration and target-revision proof
 
-## Initial Required Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Workflow
 

--- a/agents/requirement-analyzer.md
+++ b/agents/requirement-analyzer.md
@@ -1,7 +1,7 @@
 ---
 name: requirement-analyzer
 description: Collects compact scope and cost evidence for requirement confirmation while the user and orchestrator retain requirements, Structural Scale, and document-routing decisions. Use when new requirements, scope, or implementation extent must be confirmed.
-tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate
+tools: Read, Grep, Glob, LS, Bash
 skills:
   - ai-development-guide
   - llm-friendly-context
@@ -9,9 +9,9 @@ skills:
 
 You collect decision material for requirement confirmation and workflow routing. The user owns product requirements; the orchestrator owns convergence, Structural Scale, ADR qualification, and document routing.
 
-## Initial Mandatory Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Inputs
 

--- a/agents/scope-discoverer.md
+++ b/agents/scope-discoverer.md
@@ -1,7 +1,7 @@
 ---
 name: scope-discoverer
 description: Discovers functional scope from existing codebase for reverse documentation. Identifies targets through multi-source discovery combining user-value and technical perspectives. Use when "reverse engineering/existing code analysis/scope discovery" is mentioned.
-tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate
+tools: Read, Grep, Glob, LS, Bash
 skills:
   - documentation-criteria
   - ai-development-guide
@@ -12,9 +12,9 @@ skills:
 
 You are an AI assistant specializing in codebase scope discovery for reverse documentation.
 
-## Required Initial Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Input Parameters
 

--- a/agents/security-reviewer.md
+++ b/agents/security-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: security-reviewer
 description: Reviews implementation for security compliance against an authoritative Design Doc or Work Plan. Use PROACTIVELY after all implementation tasks complete, or when "security review/security check/vulnerability check" is mentioned. Returns structured findings with risk classification and fix suggestions.
-tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
+tools: Read, Grep, Glob, LS, Bash, WebSearch
 skills:
   - coding-principles
 ---
@@ -10,9 +10,9 @@ You are an AI assistant specializing in security review of implemented code.
 
 Operates in an independent context, executing autonomously until task completion.
 
-## Initial Mandatory Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Responsibilities
 

--- a/agents/solver.md
+++ b/agents/solver.md
@@ -1,7 +1,7 @@
 ---
 name: solver
 description: Derives multiple solutions for verified causes and analyzes tradeoffs. Use when root cause verification has concluded, or when "solution/how to fix/fix method/remedy" is mentioned. Focuses on solutions from given conclusions without investigation.
-tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
+tools: Read, Grep, Glob, LS, Bash, WebSearch
 skills:
   - ai-development-guide
   - coding-principles
@@ -10,9 +10,9 @@ skills:
 
 You are an AI assistant specializing in solution derivation.
 
-## Required Initial Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Input and Responsibility Boundaries
 

--- a/agents/task-decomposer.md
+++ b/agents/task-decomposer.md
@@ -1,7 +1,7 @@
 ---
 name: task-decomposer
 description: Converts an approved Work Plan into the fewest executable implementation task files. Use when work plans are approved and task materialization is needed.
-tools: Read, Write, Edit, MultiEdit, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate
+tools: Read, Write, Edit, MultiEdit, Grep, Glob, LS, Bash
 skills:
   - ai-development-guide
   - documentation-criteria
@@ -13,9 +13,9 @@ skills:
 
 You convert an approved Work Plan into executable task files while preserving its task boundaries and implementation scope.
 
-## Initial Mandatory Tasks
+## Execution Gate
 
-Register work steps using TaskCreate. Include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Input
 

--- a/agents/task-executor-frontend.md
+++ b/agents/task-executor-frontend.md
@@ -1,7 +1,7 @@
 ---
 name: task-executor-frontend
 description: Executes React implementation completely self-contained from an explicit prompt or frontend task file. Use when frontend task files exist, or when "frontend implementation/React implementation/component creation" is mentioned. Asks no questions, executes consistently from investigation to implementation.
-tools: Read, Edit, Write, MultiEdit, Bash, Grep, Glob, LS, TaskCreate, TaskUpdate
+tools: Read, Edit, Write, MultiEdit, Bash, Grep, Glob, LS
 skills:
   - typescript-rules
   - test-implement
@@ -36,7 +36,7 @@ Implement the confirmed outcome and the maintenance, tests, and adjacent correct
 
 ## Mandatory Rules
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ### Package Manager
 Use the appropriate run command based on the `packageManager` field in package.json.

--- a/agents/task-executor.md
+++ b/agents/task-executor.md
@@ -1,7 +1,7 @@
 ---
 name: task-executor
 description: Executes implementation completely self-contained from an explicit prompt or task file. Use when task files exist in docs/plans/tasks/, or when "execute task/implement task/start implementation" is mentioned. Asks no questions, executes consistently from investigation to implementation.
-tools: Read, Edit, Write, MultiEdit, Bash, Grep, Glob, LS, TaskCreate, TaskUpdate
+tools: Read, Edit, Write, MultiEdit, Bash, Grep, Glob, LS
 skills:
   - coding-principles
   - testing-principles
@@ -34,7 +34,7 @@ Implement the confirmed outcome and the maintenance, tests, and adjacent correct
 
 ## Mandatory Rules
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ### Applying to Implementation
 Apply loaded architecture/coding/testing rules during implementation, including the selected test-first or behavior-preserving refactor flow; when a task file is provided, **MUST strictly adhere to its implementation patterns (function vs class selection)**.

--- a/agents/technical-designer-frontend.md
+++ b/agents/technical-designer-frontend.md
@@ -1,7 +1,7 @@
 ---
 name: technical-designer-frontend
 description: Creates a scoped frontend ADR batch or one Design Doc from confirmed UI requirements and decision-relevant repository evidence. Use when frontend technical choices or implementation design need an approved artifact.
-tools: Read, Write, Edit, MultiEdit, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
+tools: Read, Write, Edit, MultiEdit, Glob, LS, Bash, WebSearch
 skills:
   - documentation-criteria
   - frontend-ai-guide
@@ -16,9 +16,9 @@ skills:
 
 You create one complete frontend ADR batch or one frontend Design Doc per invocation.
 
-## Initial Mandatory Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Inputs
 

--- a/agents/technical-designer.md
+++ b/agents/technical-designer.md
@@ -1,7 +1,7 @@
 ---
 name: technical-designer
 description: Creates a scoped ADR batch or one backend/general Design Doc from confirmed requirements and decision-relevant repository evidence. Use when technical choices or implementation design need an approved artifact.
-tools: Read, Write, Edit, MultiEdit, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
+tools: Read, Write, Edit, MultiEdit, Glob, LS, Bash, WebSearch
 skills:
   - documentation-criteria
   - coding-principles
@@ -15,9 +15,9 @@ skills:
 
 You create one complete ADR batch or one Design Doc per invocation.
 
-## Initial Mandatory Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Inputs
 

--- a/agents/ui-analyzer.md
+++ b/agents/ui-analyzer.md
@@ -11,9 +11,9 @@ skills:
 
 You are an AI assistant specializing in UI fact gathering for frontend design.
 
-## Required Initial Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Input Parameters
 

--- a/agents/ui-spec-designer.md
+++ b/agents/ui-spec-designer.md
@@ -1,7 +1,7 @@
 ---
 name: ui-spec-designer
 description: Creates UI Specifications from confirmed requirements and optional prototype code. Use when frontend UI design is needed, or when "UI spec/screen design/component decomposition/UI specification" is mentioned.
-tools: Read, Write, Edit, MultiEdit, Glob, LS, Bash, TaskCreate, TaskUpdate
+tools: Read, Write, Edit, MultiEdit, Glob, LS, Bash
 skills:
   - documentation-criteria
   - typescript-rules
@@ -12,9 +12,9 @@ skills:
 
 You are a UI specification specialist AI assistant for creating UI Specification documents.
 
-## Initial Mandatory Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Main Responsibilities
 

--- a/agents/verifier.md
+++ b/agents/verifier.md
@@ -1,7 +1,7 @@
 ---
 name: verifier
 description: Critically evaluates investigation results, checks path coverage, and validates failure points using Devil's Advocate method. Use when investigation has completed, or when "verify/validate/double-check/confirm findings" is mentioned. Focuses on verification and conclusion derivation.
-tools: Read, Grep, Glob, LS, Bash, WebSearch, TaskCreate, TaskUpdate
+tools: Read, Grep, Glob, LS, Bash, WebSearch
 skills:
   - ai-development-guide
   - coding-principles
@@ -9,9 +9,9 @@ skills:
 
 You are an AI assistant specializing in investigation result verification.
 
-## Required Initial Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Input and Responsibility Boundaries
 

--- a/agents/work-planner.md
+++ b/agents/work-planner.md
@@ -1,7 +1,7 @@
 ---
 name: work-planner
 description: Creates implementation-focused work plans from approved Design Docs. Use when Design Doc is complete and implementation planning is needed, or when "work plan/implementation plan/task planning" is mentioned.
-tools: Read, Write, Edit, MultiEdit, Glob, LS, TaskCreate, TaskUpdate
+tools: Read, Write, Edit, MultiEdit, Glob, LS
 skills:
   - ai-development-guide
   - documentation-criteria
@@ -13,9 +13,9 @@ skills:
 
 You create Work Plans that translate approved Design Docs into executable repository implementation tasks.
 
-## Initial Mandatory Tasks
+## Execution Gate
 
-Register work steps using TaskCreate. Include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Inputs
 

--- a/dev-skills/.claude-plugin/plugin.json
+++ b/dev-skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-skills",
   "description": "Lightweight skills for users with existing workflows - coding best practices, testing principles, and design guidelines without recipe workflows or agents",
-  "version": "0.24.6",
+  "version": "0.24.7",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows-frontend/.claude-plugin/plugin.json
+++ b/dev-workflows-frontend/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflows-frontend",
   "description": "Skills + Subagents for React/TypeScript - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
-  "version": "0.24.6",
+  "version": "0.24.7",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows-frontend/agents/acceptance-test-generator.md
+++ b/dev-workflows-frontend/agents/acceptance-test-generator.md
@@ -1,7 +1,7 @@
 ---
 name: acceptance-test-generator
 description: Generates integration/E2E test skeletons from Design Doc ACs using ROI-based selection and journey-based E2E reservation. Use when Design Doc is complete and test design is needed, or when "test skeleton/AC/acceptance criteria" is mentioned. Behavior-first approach for minimal tests with maximum coverage.
-tools: Read, Write, Glob, LS, TaskCreate, TaskUpdate, Grep
+tools: Read, Write, Glob, LS, Grep
 skills:
   - testing-principles
   - documentation-criteria
@@ -13,9 +13,9 @@ You are a specialized AI that generates minimal, high-quality test skeletons fro
 
 Operates in an independent context, executing autonomously until task completion.
 
-## Mandatory Initial Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ### Implementation Approach Compliance
 - **Test Code Generation**: MUST strictly comply with Design Doc implementation patterns (function vs class selection)

--- a/dev-workflows-frontend/agents/code-reviewer.md
+++ b/dev-workflows-frontend/agents/code-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: code-reviewer
 description: Validates Design Doc compliance and implementation completeness from third-party perspective. Use PROACTIVELY after implementation completes or when "review/implementation check/compliance" is mentioned. Provides acceptance criteria validation and quality reports.
-tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate
+tools: Read, Grep, Glob, LS, Bash
 skills:
   - ai-development-guide
   - coding-principles
@@ -12,9 +12,9 @@ You are a code review AI assistant specializing in Design Doc compliance validat
 
 Operates in an independent context, executing autonomously until task completion.
 
-## Initial Required Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Key Responsibilities
 

--- a/dev-workflows-frontend/agents/code-verifier.md
+++ b/dev-workflows-frontend/agents/code-verifier.md
@@ -1,7 +1,7 @@
 ---
 name: code-verifier
 description: Verifies repository-backed claims and implementation feasibility in PRDs, Design Docs, or Work Plans. Use before document review, after implementation, or for reverse-engineered artifact verification.
-tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate
+tools: Read, Grep, Glob, LS, Bash
 skills:
   - documentation-criteria
   - ai-development-guide
@@ -12,9 +12,9 @@ You perform read-only verification of an authoritative document against reposito
 
 Your discrepancies are independent evidence for orchestrator Review Resolution. Confirmed requirements and selected ADR decisions define scope; the orchestrator determines correction obligations.
 
-## Required Initial Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Inputs
 

--- a/dev-workflows-frontend/agents/codebase-analyzer.md
+++ b/dev-workflows-frontend/agents/codebase-analyzer.md
@@ -1,7 +1,7 @@
 ---
 name: codebase-analyzer
 description: Collects compact repository evidence for scope confirmation, technical option selection, complete design, and verification. Use before Design Doc creation when repository facts can change scope, reuse, contracts, cost, or proof.
-tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate
+tools: Read, Grep, Glob, LS, Bash
 skills:
   - ai-development-guide
   - coding-principles
@@ -10,9 +10,9 @@ skills:
 
 You are an AI assistant specializing in objective codebase analysis for technical design preparation.
 
-## Required Initial Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Responsibilities
 

--- a/dev-workflows-frontend/agents/design-sync.md
+++ b/dev-workflows-frontend/agents/design-sync.md
@@ -1,7 +1,7 @@
 ---
 name: design-sync
 description: Detects conflicts across multiple Design Docs and provides structured reports. Use when multiple Design Docs exist, or when "consistency/conflict/sync/between documents" is mentioned. Focuses on detection and reporting only, no modifications.
-tools: Read, Grep, Glob, LS, TaskCreate, TaskUpdate
+tools: Read, Grep, Glob, LS
 skills:
   - documentation-criteria
   - coding-principles
@@ -12,9 +12,9 @@ You are an AI assistant specializing in consistency verification between Design 
 
 Operates in an independent context, executing autonomously until task completion.
 
-## Initial Mandatory Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Detection Criteria (The Only Rule)
 

--- a/dev-workflows-frontend/agents/document-reviewer.md
+++ b/dev-workflows-frontend/agents/document-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: document-reviewer
 description: Reviews one document or one ADR batch against governing requirements, repository evidence, and the needs of its next consumer. Use before user approval or when document consistency and completeness need verification.
-tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
+tools: Read, Grep, Glob, LS, Bash, WebSearch
 skills:
   - documentation-criteria
   - coding-principles
@@ -11,9 +11,9 @@ skills:
 
 You review one PRD, ADR batch, UI Spec, Design Doc, or Work Plan per invocation.
 
-## Initial Mandatory Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Inputs
 

--- a/dev-workflows-frontend/agents/integration-test-reviewer.md
+++ b/dev-workflows-frontend/agents/integration-test-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: integration-test-reviewer
 description: Verifies changed integration and E2E tests against skeletons, proof obligations, or explicit prompt claims. Use PROACTIVELY after test implementation completes, or when "test review/skeleton verification" is mentioned. Returns quality reports with failing items and fix instructions.
-tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate
+tools: Read, Grep, Glob, LS, Bash
 skills:
   - testing-principles
   - integration-e2e-testing
@@ -11,9 +11,9 @@ You are an AI assistant specializing in integration and E2E test quality review.
 
 Operates in an independent context, executing autonomously until task completion.
 
-## Initial Mandatory Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Responsibilities
 

--- a/dev-workflows-frontend/agents/investigator.md
+++ b/dev-workflows-frontend/agents/investigator.md
@@ -1,7 +1,7 @@
 ---
 name: investigator
 description: Comprehensively collects problem-related information and creates evidence matrix. Use PROACTIVELY when bug/error/issue/defect/not working/strange behavior is reported. Reports observations and evidence for downstream cause verification.
-tools: Read, Grep, Glob, LS, Bash, WebSearch, TaskCreate, TaskUpdate
+tools: Read, Grep, Glob, LS, Bash, WebSearch
 skills:
   - ai-development-guide
   - coding-principles
@@ -9,9 +9,9 @@ skills:
 
 You are an AI assistant specializing in problem investigation.
 
-## Required Initial Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Input and Responsibility Boundaries
 

--- a/dev-workflows-frontend/agents/prd-creator.md
+++ b/dev-workflows-frontend/agents/prd-creator.md
@@ -1,7 +1,7 @@
 ---
 name: prd-creator
 description: Creates PRD and structures business requirements. Use when new feature/project starts, or when "PRD/requirements definition/user story/what to build" is mentioned. Defines user value and success metrics.
-tools: Read, Write, Edit, MultiEdit, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
+tools: Read, Write, Edit, MultiEdit, Glob, LS, Bash, WebSearch
 skills:
   - documentation-criteria
   - llm-friendly-context
@@ -10,9 +10,9 @@ skills:
 
 You are a specialized AI assistant for creating Product Requirements Documents (PRD).
 
-## Initial Mandatory Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Responsibilities
 

--- a/dev-workflows-frontend/agents/quality-fixer-frontend.md
+++ b/dev-workflows-frontend/agents/quality-fixer-frontend.md
@@ -1,7 +1,7 @@
 ---
 name: quality-fixer-frontend
 description: Specialized agent for verifying React projects and fixing frontend quality failures within the current task scope. Use proactively after code changes or for quality, test, build, lint, format, type, or fix requests.
-tools: Bash, Read, Edit, MultiEdit, Grep, Glob, LS, TaskCreate, TaskUpdate
+tools: Bash, Read, Edit, MultiEdit, Grep, Glob, LS
 skills:
   - typescript-rules
   - test-implement
@@ -26,9 +26,9 @@ Executes applicable quality checks, fixes in-scope failures, and reports blocker
 - **qualityCommand** (optional): Quality command supplied by the caller or recorded in the task. Run it first, then cover the remaining applicable check categories.
 - **mutationEvidence** (optional): Upstream mutation results with restoration and target-revision proof
 
-## Initial Required Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ### Package Manager
 Use the appropriate run command based on the `packageManager` field in package.json.

--- a/dev-workflows-frontend/agents/requirement-analyzer.md
+++ b/dev-workflows-frontend/agents/requirement-analyzer.md
@@ -1,7 +1,7 @@
 ---
 name: requirement-analyzer
 description: Collects compact scope and cost evidence for requirement confirmation while the user and orchestrator retain requirements, Structural Scale, and document-routing decisions. Use when new requirements, scope, or implementation extent must be confirmed.
-tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate
+tools: Read, Grep, Glob, LS, Bash
 skills:
   - ai-development-guide
   - llm-friendly-context
@@ -9,9 +9,9 @@ skills:
 
 You collect decision material for requirement confirmation and workflow routing. The user owns product requirements; the orchestrator owns convergence, Structural Scale, ADR qualification, and document routing.
 
-## Initial Mandatory Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Inputs
 

--- a/dev-workflows-frontend/agents/security-reviewer.md
+++ b/dev-workflows-frontend/agents/security-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: security-reviewer
 description: Reviews implementation for security compliance against an authoritative Design Doc or Work Plan. Use PROACTIVELY after all implementation tasks complete, or when "security review/security check/vulnerability check" is mentioned. Returns structured findings with risk classification and fix suggestions.
-tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
+tools: Read, Grep, Glob, LS, Bash, WebSearch
 skills:
   - coding-principles
 ---
@@ -10,9 +10,9 @@ You are an AI assistant specializing in security review of implemented code.
 
 Operates in an independent context, executing autonomously until task completion.
 
-## Initial Mandatory Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Responsibilities
 

--- a/dev-workflows-frontend/agents/solver.md
+++ b/dev-workflows-frontend/agents/solver.md
@@ -1,7 +1,7 @@
 ---
 name: solver
 description: Derives multiple solutions for verified causes and analyzes tradeoffs. Use when root cause verification has concluded, or when "solution/how to fix/fix method/remedy" is mentioned. Focuses on solutions from given conclusions without investigation.
-tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
+tools: Read, Grep, Glob, LS, Bash, WebSearch
 skills:
   - ai-development-guide
   - coding-principles
@@ -10,9 +10,9 @@ skills:
 
 You are an AI assistant specializing in solution derivation.
 
-## Required Initial Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Input and Responsibility Boundaries
 

--- a/dev-workflows-frontend/agents/task-decomposer.md
+++ b/dev-workflows-frontend/agents/task-decomposer.md
@@ -1,7 +1,7 @@
 ---
 name: task-decomposer
 description: Converts an approved Work Plan into the fewest executable implementation task files. Use when work plans are approved and task materialization is needed.
-tools: Read, Write, Edit, MultiEdit, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate
+tools: Read, Write, Edit, MultiEdit, Grep, Glob, LS, Bash
 skills:
   - ai-development-guide
   - documentation-criteria
@@ -13,9 +13,9 @@ skills:
 
 You convert an approved Work Plan into executable task files while preserving its task boundaries and implementation scope.
 
-## Initial Mandatory Tasks
+## Execution Gate
 
-Register work steps using TaskCreate. Include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Input
 

--- a/dev-workflows-frontend/agents/task-executor-frontend.md
+++ b/dev-workflows-frontend/agents/task-executor-frontend.md
@@ -1,7 +1,7 @@
 ---
 name: task-executor-frontend
 description: Executes React implementation completely self-contained from an explicit prompt or frontend task file. Use when frontend task files exist, or when "frontend implementation/React implementation/component creation" is mentioned. Asks no questions, executes consistently from investigation to implementation.
-tools: Read, Edit, Write, MultiEdit, Bash, Grep, Glob, LS, TaskCreate, TaskUpdate
+tools: Read, Edit, Write, MultiEdit, Bash, Grep, Glob, LS
 skills:
   - typescript-rules
   - test-implement
@@ -36,7 +36,7 @@ Implement the confirmed outcome and the maintenance, tests, and adjacent correct
 
 ## Mandatory Rules
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ### Package Manager
 Use the appropriate run command based on the `packageManager` field in package.json.

--- a/dev-workflows-frontend/agents/technical-designer-frontend.md
+++ b/dev-workflows-frontend/agents/technical-designer-frontend.md
@@ -1,7 +1,7 @@
 ---
 name: technical-designer-frontend
 description: Creates a scoped frontend ADR batch or one Design Doc from confirmed UI requirements and decision-relevant repository evidence. Use when frontend technical choices or implementation design need an approved artifact.
-tools: Read, Write, Edit, MultiEdit, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
+tools: Read, Write, Edit, MultiEdit, Glob, LS, Bash, WebSearch
 skills:
   - documentation-criteria
   - frontend-ai-guide
@@ -16,9 +16,9 @@ skills:
 
 You create one complete frontend ADR batch or one frontend Design Doc per invocation.
 
-## Initial Mandatory Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Inputs
 

--- a/dev-workflows-frontend/agents/ui-analyzer.md
+++ b/dev-workflows-frontend/agents/ui-analyzer.md
@@ -11,9 +11,9 @@ skills:
 
 You are an AI assistant specializing in UI fact gathering for frontend design.
 
-## Required Initial Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Input Parameters
 

--- a/dev-workflows-frontend/agents/ui-spec-designer.md
+++ b/dev-workflows-frontend/agents/ui-spec-designer.md
@@ -1,7 +1,7 @@
 ---
 name: ui-spec-designer
 description: Creates UI Specifications from confirmed requirements and optional prototype code. Use when frontend UI design is needed, or when "UI spec/screen design/component decomposition/UI specification" is mentioned.
-tools: Read, Write, Edit, MultiEdit, Glob, LS, Bash, TaskCreate, TaskUpdate
+tools: Read, Write, Edit, MultiEdit, Glob, LS, Bash
 skills:
   - documentation-criteria
   - typescript-rules
@@ -12,9 +12,9 @@ skills:
 
 You are a UI specification specialist AI assistant for creating UI Specification documents.
 
-## Initial Mandatory Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Main Responsibilities
 

--- a/dev-workflows-frontend/agents/verifier.md
+++ b/dev-workflows-frontend/agents/verifier.md
@@ -1,7 +1,7 @@
 ---
 name: verifier
 description: Critically evaluates investigation results, checks path coverage, and validates failure points using Devil's Advocate method. Use when investigation has completed, or when "verify/validate/double-check/confirm findings" is mentioned. Focuses on verification and conclusion derivation.
-tools: Read, Grep, Glob, LS, Bash, WebSearch, TaskCreate, TaskUpdate
+tools: Read, Grep, Glob, LS, Bash, WebSearch
 skills:
   - ai-development-guide
   - coding-principles
@@ -9,9 +9,9 @@ skills:
 
 You are an AI assistant specializing in investigation result verification.
 
-## Required Initial Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Input and Responsibility Boundaries
 

--- a/dev-workflows-frontend/agents/work-planner.md
+++ b/dev-workflows-frontend/agents/work-planner.md
@@ -1,7 +1,7 @@
 ---
 name: work-planner
 description: Creates implementation-focused work plans from approved Design Docs. Use when Design Doc is complete and implementation planning is needed, or when "work plan/implementation plan/task planning" is mentioned.
-tools: Read, Write, Edit, MultiEdit, Glob, LS, TaskCreate, TaskUpdate
+tools: Read, Write, Edit, MultiEdit, Glob, LS
 skills:
   - ai-development-guide
   - documentation-criteria
@@ -13,9 +13,9 @@ skills:
 
 You create Work Plans that translate approved Design Docs into executable repository implementation tasks.
 
-## Initial Mandatory Tasks
+## Execution Gate
 
-Register work steps using TaskCreate. Include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Inputs
 

--- a/dev-workflows-frontend/skills/recipe-diagnose/SKILL.md
+++ b/dev-workflows-frontend/skills/recipe-diagnose/SKILL.md
@@ -4,6 +4,8 @@ description: Investigate problem, verify findings, and derive solutions
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before making workflow decisions, invoking agents, or resolving findings.
 
@@ -26,7 +28,7 @@ Orchestrator invokes sub-agents and passes structured JSON between them.
 
 At each Agent invocation below, build the prompt as a mechanical extraction: copy the named source values into the exact fields, apply only the declared serialization, then invoke immediately.
 
-**Task Registration**: Register execution steps using TaskCreate and proceed systematically. Update status using TaskUpdate.
+**Execution Gate**: Each step below establishes evidence required by the next decision. Complete Steps 0-7 in order, including every required investigation and verification retry. Advance only through the current step's stated quality or coverage condition; invoke solver only after coverage is closed.
 
 ## Step 0: Problem Structuring (Before investigator invocation)
 
@@ -89,8 +91,6 @@ material evidence unavailable → limitation/block report
 **Context Separation**: Pass only structured JSON output to each step. Each step starts fresh with the JSON data only.
 
 ## Execution Steps
-
-Register the following using TaskCreate and execute:
 
 ### Step 1: Investigation (investigator)
 

--- a/dev-workflows-frontend/skills/recipe-front-adjust/SKILL.md
+++ b/dev-workflows-frontend/skills/recipe-front-adjust/SKILL.md
@@ -4,6 +4,8 @@ description: Adjust an already-implemented UI in-session with verification again
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 
 **Context**: UI adjustment on already-implemented features. The verification loop (edit → check against the design source → refine) runs in the parent session.
@@ -17,9 +19,9 @@ Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or g
 2. **Run in the parent session** (multi-step loops and user dialogs): external-resource hearing via AskUserQuestion, write-set inspection, scale judgment, adjustment-context approval, adjustment edits, verification against the design source, iteration until acceptance.
 3. **Stop at every `[Stop: ...]` marker** before proceeding.
 
-## Initial Mandatory Tasks
+## Execution Gate
 
-**Task Registration**: Before Step 1, register the recipe's execution flow using TaskCreate so progress is trackable. Register Steps 1-7 below as individual tasks plus a final task "Verify completion against Completion Criteria". Update status using TaskUpdate as each step starts and completes.
+Complete Steps 1-7 in order for each adjustment unit. Advance only through the current step's stated evidence, quality result, or user stop; skip work only when its stated condition is false. Report completion after every applicable Completion Criterion and retained-limitation retry is satisfied.
 
 ## Workflow Overview
 

--- a/dev-workflows-frontend/skills/recipe-front-build/SKILL.md
+++ b/dev-workflows-frontend/skills/recipe-front-build/SKILL.md
@@ -4,6 +4,8 @@ description: Execute materialized frontend task files in autonomous execution mo
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before making workflow decisions, invoking agents, or resolving findings.
 
@@ -20,7 +22,7 @@ Before the first finding disposition, read `references/review-resolution.md` fro
 1. **Invoke named specialists for deliverable production** — pass deliverable paths between them and validate their results (see subagents-orchestration-guide "Orchestrator Execution Boundary")
 2. **Follow the 4-step task cycle exactly**: execute → branch on executor result → quality-fix → commit
 3. **Enter autonomous mode** when user provides execution instruction with existing task files — this IS the batch approval
-4. **Scope**: Complete when all tasks are committed or escalation occurs
+4. **Scope**: Complete consumed task-set execution, post-implementation verification, consumed-task cleanup, and completion reporting in order, or stop autonomous execution at the current phase for a valid user-owned escalation. Advance only when the current phase's stated transition condition is satisfied.
 
 **CRITICAL**: Run quality-fixer-frontend before every commit.
 
@@ -85,8 +87,6 @@ Recompute the Consumed Task Set using the same restricted pattern from the Consu
 
 ## Task Execution Cycle (4-Step Cycle)
 **MANDATORY EXECUTION CYCLE**: `execute → branch on executor result → quality-fix → commit`
-
-Before the loop, register `"Execute consumed task set"`, `"Run post-implementation verification"`, `"Clean up consumed task files"`, and `"Report completion"` once with TaskCreate; mark and advance the active phase with TaskUpdate.
 
 For EACH task in the Consumed Task Set, YOU MUST:
 1. **EXECUTE**: invoke Agent tool (subagent_type: "dev-workflows-frontend:task-executor-frontend") → Record the current HEAD as `diffBase`, pass `task_file: [path]`, and receive the structured response

--- a/dev-workflows-frontend/skills/recipe-front-design/SKILL.md
+++ b/dev-workflows-frontend/skills/recipe-front-design/SKILL.md
@@ -4,6 +4,8 @@ description: Execute from repository evidence through applicable UI Spec and opt
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: documentation-criteria before document routing or creation.
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before invoking agents or resolving findings.

--- a/dev-workflows-frontend/skills/recipe-front-plan/SKILL.md
+++ b/dev-workflows-frontend/skills/recipe-front-plan/SKILL.md
@@ -4,6 +4,8 @@ description: Create frontend work plan from design document and obtain plan appr
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before making workflow decisions, invoking agents, or resolving findings.
 

--- a/dev-workflows-frontend/skills/recipe-front-review/SKILL.md
+++ b/dev-workflows-frontend/skills/recipe-front-review/SKILL.md
@@ -4,6 +4,8 @@ description: Design Doc compliance and security validation with optional auto-fi
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before making workflow decisions, invoking agents, or resolving findings.
 
@@ -18,7 +20,7 @@ Execute Skill: subagents-orchestration-guide before making workflow decisions, i
 **Review Resolution Gate [MANDATORY]**: Resolve every actionable deliverable-review finding through subagents-orchestration-guide `Review Resolution` before correction or progression.
 Before the first finding disposition, read `references/review-resolution.md` from the loaded subagents-orchestration-guide skill.
 
-**First Action**: Register Steps 1-10 using TaskCreate before any execution.
+**Execution Gate**: Complete Steps 1-10 in order, following only the branches activated by their stated conditions. Advance through each review, correction, and re-validation transition only at its declared convergence condition. Present the final report after every applicable finding and retained quality limitation reaches its required disposition or retry result.
 
 ## Execution Method
 

--- a/dev-workflows-frontend/skills/recipe-task/SKILL.md
+++ b/dev-workflows-frontend/skills/recipe-task/SKILL.md
@@ -4,6 +4,8 @@ description: Execute tasks following appropriate rules with rule-advisor metacog
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before making workflow decisions, invoking agents, or resolving findings.
 
@@ -40,23 +42,15 @@ After receiving rule-advisor's JSON response, proceed with:
    - Start with recommended action
    - Use suggested tools first
 
-**Step 3: Create Task List with TaskCreate**
+**Step 3: Bind the Execution Sequence**
 
-Register work steps using TaskCreate. Use "Select and map applicable rules" as the first task and "Verify selected rules and report completion" as the final task.
-
-Break down the task based on rule-advisor's guidance:
-- Reflect `taskAnalysis.essence` in task descriptions
-- Apply `metaCognitiveGuidance.firstStep` to first task
-- Restructure tasks considering `warningPatterns`
-- Set priorities based on dependency order and warningPatterns severity
-- Update each task with TaskUpdate as execution progresses
+Before implementation, derive the smallest dependency-ordered sequence required by the rule-advisor result. Its first gate applies and maps the selected rules; its final gate verifies those rules and the requested outcome. Execute one gate at a time, advancing only when its required evidence exists. Add or reorder a gate only when new evidence changes a dependency or completion condition.
 
 **Step 4: Execute Implementation**
 
 Proceed with task execution following:
 - Start with `metaCognitiveGuidance.firstStep` action from rule-advisor
-- Update task structure with TaskUpdate to reflect rule-advisor insights
 - Selected rules from rule-advisor
-- Task structure (managed via TaskCreate/TaskUpdate)
+- Dependency-ordered execution sequence from Step 3
 - Quality standards from the selected skills and sections named by rule-advisor
 - Monitor warningPatterns flags throughout execution and adjust approach when triggered

--- a/dev-workflows-frontend/skills/recipe-update-doc/SKILL.md
+++ b/dev-workflows-frontend/skills/recipe-update-doc/SKILL.md
@@ -4,6 +4,8 @@ description: Update existing design documents (Design Doc / PRD / ADR) with revi
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before making workflow decisions, invoking agents, or resolving findings.
 
@@ -18,7 +20,7 @@ Execute Skill: subagents-orchestration-guide before making workflow decisions, i
 **Review Resolution Gate [MANDATORY]**: Resolve every actionable deliverable-review finding through subagents-orchestration-guide `Review Resolution` before correction or progression.
 Before the first finding disposition, read `references/review-resolution.md` from the loaded subagents-orchestration-guide skill.
 
-**First Action**: Register Steps 1-6 using TaskCreate before any execution.
+**Execution Gate**: Complete Steps 1-6 in order, following only the branches activated by document type and review result. Advance only through each step's stated evidence, review convergence, or approval condition. Complete after the final approval gate and every applicable Completion Criterion is satisfied.
 
 **Execution Protocol**:
 1. **Invoke named specialists for deliverable production** — pass deliverable paths between them and validate their results (see subagents-orchestration-guide "Orchestrator Execution Boundary")

--- a/dev-workflows-frontend/skills/subagents-orchestration-guide/SKILL.md
+++ b/dev-workflows-frontend/skills/subagents-orchestration-guide/SKILL.md
@@ -7,6 +7,8 @@ description: Guides subagent coordination through implementation workflows. Use 
 
 ## Role: The Orchestrator
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in the invoked recipe. Execute each applicable call when its prerequisites are met.
+
 The orchestrator owns workflow decisions, routing, progress management, user interaction, the investigation and validation needed for those decisions, and explicitly assigned mechanical operations, using any available tool. Named specialists own explicitly assigned investigation and semantic deliverable creation or modification; invoke them before producing or changing code, tests, configuration, documents, task files, or other artifacts.
 
 ### Workflow Subagent Context — Mandatory
@@ -154,6 +156,8 @@ Rules:
 - `task-decomposer` begins only after work plan review (document-reviewer, doc_type WorkPlan; Medium/Large) and batch approval
 - Work plan review runs Review Resolution through its correction re-review, escalation, and convergence transitions; batch approval is available only at its convergence condition
 
+Treat the applicable Structural Scale flow as an evidence-gated sequence. Advance only when the current phase has the artifact, approval, or result required by its stated routing condition. Before reporting completion, resume the earliest applicable phase without that evidence.
+
 ## Autonomous Execution Mode
 
 ### Pre-Execution Gate
@@ -206,7 +210,7 @@ For Small, execute one direct-scope 4-step cycle. Complete after `approved`, or 
 | A requirement changes | Apply Requirement Change Detection above. After task-decomposer starts, invalidate affected tasks; restart document design only when re-analysis changes an approved requirement, contract, data flow, verification strategy, or task boundary. |
 | The user stops or interrupts | Stop autonomous execution. |
 
-### Task Management: 4-Step Cycle
+### Task Execution Cycle
 
 #### Commit Boundary Check
 
@@ -239,8 +243,6 @@ Derive the values from the quality-fixer result. Keep the complete result in orc
    - `verification_incomplete` → Retain the complete result for final retry and proceed to step 4
    - `approved` → Proceed to step 4
 4. **Commit**: apply Commit Boundary Check, then compose the message from `changeSummary` and execute git commit with Bash after `approved` or `verification_incomplete`; append the verification trailers for the latter
-
-Register overall phases using TaskCreate and update each phase with TaskUpdate as it completes.
 
 Before post-implementation verifiers, collect retained verification limitations from orchestration state and the verification trailers on task-boundary commits created by the workflow, then re-invoke the applicable quality-fixer once for each limitation using the same task inputs and its affected check or command. Clear an `approved` result, route newly discovered incomplete implementation through the normal cycle, and retain a repeated `verification_incomplete` result for the final report. Commit any fixes produced by this retry through the same task cycle, then continue post-implementation verification.
 

--- a/dev-workflows-fullstack/.claude-plugin/plugin.json
+++ b/dev-workflows-fullstack/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflows-fullstack",
   "description": "Skills + Subagents for fullstack development (backend + React/TypeScript) - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
-  "version": "0.24.6",
+  "version": "0.24.7",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows-fullstack/agents/acceptance-test-generator.md
+++ b/dev-workflows-fullstack/agents/acceptance-test-generator.md
@@ -1,7 +1,7 @@
 ---
 name: acceptance-test-generator
 description: Generates integration/E2E test skeletons from Design Doc ACs using ROI-based selection and journey-based E2E reservation. Use when Design Doc is complete and test design is needed, or when "test skeleton/AC/acceptance criteria" is mentioned. Behavior-first approach for minimal tests with maximum coverage.
-tools: Read, Write, Glob, LS, TaskCreate, TaskUpdate, Grep
+tools: Read, Write, Glob, LS, Grep
 skills:
   - testing-principles
   - documentation-criteria
@@ -13,9 +13,9 @@ You are a specialized AI that generates minimal, high-quality test skeletons fro
 
 Operates in an independent context, executing autonomously until task completion.
 
-## Mandatory Initial Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ### Implementation Approach Compliance
 - **Test Code Generation**: MUST strictly comply with Design Doc implementation patterns (function vs class selection)

--- a/dev-workflows-fullstack/agents/code-reviewer.md
+++ b/dev-workflows-fullstack/agents/code-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: code-reviewer
 description: Validates Design Doc compliance and implementation completeness from third-party perspective. Use PROACTIVELY after implementation completes or when "review/implementation check/compliance" is mentioned. Provides acceptance criteria validation and quality reports.
-tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate
+tools: Read, Grep, Glob, LS, Bash
 skills:
   - ai-development-guide
   - coding-principles
@@ -12,9 +12,9 @@ You are a code review AI assistant specializing in Design Doc compliance validat
 
 Operates in an independent context, executing autonomously until task completion.
 
-## Initial Required Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Key Responsibilities
 

--- a/dev-workflows-fullstack/agents/code-verifier.md
+++ b/dev-workflows-fullstack/agents/code-verifier.md
@@ -1,7 +1,7 @@
 ---
 name: code-verifier
 description: Verifies repository-backed claims and implementation feasibility in PRDs, Design Docs, or Work Plans. Use before document review, after implementation, or for reverse-engineered artifact verification.
-tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate
+tools: Read, Grep, Glob, LS, Bash
 skills:
   - documentation-criteria
   - ai-development-guide
@@ -12,9 +12,9 @@ You perform read-only verification of an authoritative document against reposito
 
 Your discrepancies are independent evidence for orchestrator Review Resolution. Confirmed requirements and selected ADR decisions define scope; the orchestrator determines correction obligations.
 
-## Required Initial Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Inputs
 

--- a/dev-workflows-fullstack/agents/codebase-analyzer.md
+++ b/dev-workflows-fullstack/agents/codebase-analyzer.md
@@ -1,7 +1,7 @@
 ---
 name: codebase-analyzer
 description: Collects compact repository evidence for scope confirmation, technical option selection, complete design, and verification. Use before Design Doc creation when repository facts can change scope, reuse, contracts, cost, or proof.
-tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate
+tools: Read, Grep, Glob, LS, Bash
 skills:
   - ai-development-guide
   - coding-principles
@@ -10,9 +10,9 @@ skills:
 
 You are an AI assistant specializing in objective codebase analysis for technical design preparation.
 
-## Required Initial Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Responsibilities
 

--- a/dev-workflows-fullstack/agents/design-sync.md
+++ b/dev-workflows-fullstack/agents/design-sync.md
@@ -1,7 +1,7 @@
 ---
 name: design-sync
 description: Detects conflicts across multiple Design Docs and provides structured reports. Use when multiple Design Docs exist, or when "consistency/conflict/sync/between documents" is mentioned. Focuses on detection and reporting only, no modifications.
-tools: Read, Grep, Glob, LS, TaskCreate, TaskUpdate
+tools: Read, Grep, Glob, LS
 skills:
   - documentation-criteria
   - coding-principles
@@ -12,9 +12,9 @@ You are an AI assistant specializing in consistency verification between Design 
 
 Operates in an independent context, executing autonomously until task completion.
 
-## Initial Mandatory Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Detection Criteria (The Only Rule)
 

--- a/dev-workflows-fullstack/agents/document-reviewer.md
+++ b/dev-workflows-fullstack/agents/document-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: document-reviewer
 description: Reviews one document or one ADR batch against governing requirements, repository evidence, and the needs of its next consumer. Use before user approval or when document consistency and completeness need verification.
-tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
+tools: Read, Grep, Glob, LS, Bash, WebSearch
 skills:
   - documentation-criteria
   - coding-principles
@@ -11,9 +11,9 @@ skills:
 
 You review one PRD, ADR batch, UI Spec, Design Doc, or Work Plan per invocation.
 
-## Initial Mandatory Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Inputs
 

--- a/dev-workflows-fullstack/agents/integration-test-reviewer.md
+++ b/dev-workflows-fullstack/agents/integration-test-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: integration-test-reviewer
 description: Verifies changed integration and E2E tests against skeletons, proof obligations, or explicit prompt claims. Use PROACTIVELY after test implementation completes, or when "test review/skeleton verification" is mentioned. Returns quality reports with failing items and fix instructions.
-tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate
+tools: Read, Grep, Glob, LS, Bash
 skills:
   - testing-principles
   - integration-e2e-testing
@@ -11,9 +11,9 @@ You are an AI assistant specializing in integration and E2E test quality review.
 
 Operates in an independent context, executing autonomously until task completion.
 
-## Initial Mandatory Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Responsibilities
 

--- a/dev-workflows-fullstack/agents/investigator.md
+++ b/dev-workflows-fullstack/agents/investigator.md
@@ -1,7 +1,7 @@
 ---
 name: investigator
 description: Comprehensively collects problem-related information and creates evidence matrix. Use PROACTIVELY when bug/error/issue/defect/not working/strange behavior is reported. Reports observations and evidence for downstream cause verification.
-tools: Read, Grep, Glob, LS, Bash, WebSearch, TaskCreate, TaskUpdate
+tools: Read, Grep, Glob, LS, Bash, WebSearch
 skills:
   - ai-development-guide
   - coding-principles
@@ -9,9 +9,9 @@ skills:
 
 You are an AI assistant specializing in problem investigation.
 
-## Required Initial Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Input and Responsibility Boundaries
 

--- a/dev-workflows-fullstack/agents/prd-creator.md
+++ b/dev-workflows-fullstack/agents/prd-creator.md
@@ -1,7 +1,7 @@
 ---
 name: prd-creator
 description: Creates PRD and structures business requirements. Use when new feature/project starts, or when "PRD/requirements definition/user story/what to build" is mentioned. Defines user value and success metrics.
-tools: Read, Write, Edit, MultiEdit, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
+tools: Read, Write, Edit, MultiEdit, Glob, LS, Bash, WebSearch
 skills:
   - documentation-criteria
   - llm-friendly-context
@@ -10,9 +10,9 @@ skills:
 
 You are a specialized AI assistant for creating Product Requirements Documents (PRD).
 
-## Initial Mandatory Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Responsibilities
 

--- a/dev-workflows-fullstack/agents/quality-fixer-frontend.md
+++ b/dev-workflows-fullstack/agents/quality-fixer-frontend.md
@@ -1,7 +1,7 @@
 ---
 name: quality-fixer-frontend
 description: Specialized agent for verifying React projects and fixing frontend quality failures within the current task scope. Use proactively after code changes or for quality, test, build, lint, format, type, or fix requests.
-tools: Bash, Read, Edit, MultiEdit, Grep, Glob, LS, TaskCreate, TaskUpdate
+tools: Bash, Read, Edit, MultiEdit, Grep, Glob, LS
 skills:
   - typescript-rules
   - test-implement
@@ -26,9 +26,9 @@ Executes applicable quality checks, fixes in-scope failures, and reports blocker
 - **qualityCommand** (optional): Quality command supplied by the caller or recorded in the task. Run it first, then cover the remaining applicable check categories.
 - **mutationEvidence** (optional): Upstream mutation results with restoration and target-revision proof
 
-## Initial Required Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ### Package Manager
 Use the appropriate run command based on the `packageManager` field in package.json.

--- a/dev-workflows-fullstack/agents/quality-fixer.md
+++ b/dev-workflows-fullstack/agents/quality-fixer.md
@@ -1,7 +1,7 @@
 ---
 name: quality-fixer
 description: Specialized agent for verifying software projects and fixing quality failures within the current task scope. Use proactively after code changes or for quality, test, build, lint, format, correctness, or fix requests.
-tools: Bash, Read, Edit, MultiEdit, Grep, Glob, LS, TaskCreate, TaskUpdate
+tools: Bash, Read, Edit, MultiEdit, Grep, Glob, LS
 skills:
   - coding-principles
   - testing-principles
@@ -26,9 +26,9 @@ Executes applicable quality checks, fixes in-scope failures, and reports blocker
 - **qualityCommand** (optional): Quality command supplied by the caller or recorded in the task. Run it first, then cover the remaining applicable check categories.
 - **mutationEvidence** (optional): Upstream mutation results with restoration and target-revision proof
 
-## Initial Required Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Workflow
 

--- a/dev-workflows-fullstack/agents/requirement-analyzer.md
+++ b/dev-workflows-fullstack/agents/requirement-analyzer.md
@@ -1,7 +1,7 @@
 ---
 name: requirement-analyzer
 description: Collects compact scope and cost evidence for requirement confirmation while the user and orchestrator retain requirements, Structural Scale, and document-routing decisions. Use when new requirements, scope, or implementation extent must be confirmed.
-tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate
+tools: Read, Grep, Glob, LS, Bash
 skills:
   - ai-development-guide
   - llm-friendly-context
@@ -9,9 +9,9 @@ skills:
 
 You collect decision material for requirement confirmation and workflow routing. The user owns product requirements; the orchestrator owns convergence, Structural Scale, ADR qualification, and document routing.
 
-## Initial Mandatory Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Inputs
 

--- a/dev-workflows-fullstack/agents/scope-discoverer.md
+++ b/dev-workflows-fullstack/agents/scope-discoverer.md
@@ -1,7 +1,7 @@
 ---
 name: scope-discoverer
 description: Discovers functional scope from existing codebase for reverse documentation. Identifies targets through multi-source discovery combining user-value and technical perspectives. Use when "reverse engineering/existing code analysis/scope discovery" is mentioned.
-tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate
+tools: Read, Grep, Glob, LS, Bash
 skills:
   - documentation-criteria
   - ai-development-guide
@@ -12,9 +12,9 @@ skills:
 
 You are an AI assistant specializing in codebase scope discovery for reverse documentation.
 
-## Required Initial Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Input Parameters
 

--- a/dev-workflows-fullstack/agents/security-reviewer.md
+++ b/dev-workflows-fullstack/agents/security-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: security-reviewer
 description: Reviews implementation for security compliance against an authoritative Design Doc or Work Plan. Use PROACTIVELY after all implementation tasks complete, or when "security review/security check/vulnerability check" is mentioned. Returns structured findings with risk classification and fix suggestions.
-tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
+tools: Read, Grep, Glob, LS, Bash, WebSearch
 skills:
   - coding-principles
 ---
@@ -10,9 +10,9 @@ You are an AI assistant specializing in security review of implemented code.
 
 Operates in an independent context, executing autonomously until task completion.
 
-## Initial Mandatory Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Responsibilities
 

--- a/dev-workflows-fullstack/agents/solver.md
+++ b/dev-workflows-fullstack/agents/solver.md
@@ -1,7 +1,7 @@
 ---
 name: solver
 description: Derives multiple solutions for verified causes and analyzes tradeoffs. Use when root cause verification has concluded, or when "solution/how to fix/fix method/remedy" is mentioned. Focuses on solutions from given conclusions without investigation.
-tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
+tools: Read, Grep, Glob, LS, Bash, WebSearch
 skills:
   - ai-development-guide
   - coding-principles
@@ -10,9 +10,9 @@ skills:
 
 You are an AI assistant specializing in solution derivation.
 
-## Required Initial Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Input and Responsibility Boundaries
 

--- a/dev-workflows-fullstack/agents/task-decomposer.md
+++ b/dev-workflows-fullstack/agents/task-decomposer.md
@@ -1,7 +1,7 @@
 ---
 name: task-decomposer
 description: Converts an approved Work Plan into the fewest executable implementation task files. Use when work plans are approved and task materialization is needed.
-tools: Read, Write, Edit, MultiEdit, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate
+tools: Read, Write, Edit, MultiEdit, Grep, Glob, LS, Bash
 skills:
   - ai-development-guide
   - documentation-criteria
@@ -13,9 +13,9 @@ skills:
 
 You convert an approved Work Plan into executable task files while preserving its task boundaries and implementation scope.
 
-## Initial Mandatory Tasks
+## Execution Gate
 
-Register work steps using TaskCreate. Include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Input
 

--- a/dev-workflows-fullstack/agents/task-executor-frontend.md
+++ b/dev-workflows-fullstack/agents/task-executor-frontend.md
@@ -1,7 +1,7 @@
 ---
 name: task-executor-frontend
 description: Executes React implementation completely self-contained from an explicit prompt or frontend task file. Use when frontend task files exist, or when "frontend implementation/React implementation/component creation" is mentioned. Asks no questions, executes consistently from investigation to implementation.
-tools: Read, Edit, Write, MultiEdit, Bash, Grep, Glob, LS, TaskCreate, TaskUpdate
+tools: Read, Edit, Write, MultiEdit, Bash, Grep, Glob, LS
 skills:
   - typescript-rules
   - test-implement
@@ -36,7 +36,7 @@ Implement the confirmed outcome and the maintenance, tests, and adjacent correct
 
 ## Mandatory Rules
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ### Package Manager
 Use the appropriate run command based on the `packageManager` field in package.json.

--- a/dev-workflows-fullstack/agents/task-executor.md
+++ b/dev-workflows-fullstack/agents/task-executor.md
@@ -1,7 +1,7 @@
 ---
 name: task-executor
 description: Executes implementation completely self-contained from an explicit prompt or task file. Use when task files exist in docs/plans/tasks/, or when "execute task/implement task/start implementation" is mentioned. Asks no questions, executes consistently from investigation to implementation.
-tools: Read, Edit, Write, MultiEdit, Bash, Grep, Glob, LS, TaskCreate, TaskUpdate
+tools: Read, Edit, Write, MultiEdit, Bash, Grep, Glob, LS
 skills:
   - coding-principles
   - testing-principles
@@ -34,7 +34,7 @@ Implement the confirmed outcome and the maintenance, tests, and adjacent correct
 
 ## Mandatory Rules
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ### Applying to Implementation
 Apply loaded architecture/coding/testing rules during implementation, including the selected test-first or behavior-preserving refactor flow; when a task file is provided, **MUST strictly adhere to its implementation patterns (function vs class selection)**.

--- a/dev-workflows-fullstack/agents/technical-designer-frontend.md
+++ b/dev-workflows-fullstack/agents/technical-designer-frontend.md
@@ -1,7 +1,7 @@
 ---
 name: technical-designer-frontend
 description: Creates a scoped frontend ADR batch or one Design Doc from confirmed UI requirements and decision-relevant repository evidence. Use when frontend technical choices or implementation design need an approved artifact.
-tools: Read, Write, Edit, MultiEdit, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
+tools: Read, Write, Edit, MultiEdit, Glob, LS, Bash, WebSearch
 skills:
   - documentation-criteria
   - frontend-ai-guide
@@ -16,9 +16,9 @@ skills:
 
 You create one complete frontend ADR batch or one frontend Design Doc per invocation.
 
-## Initial Mandatory Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Inputs
 

--- a/dev-workflows-fullstack/agents/technical-designer.md
+++ b/dev-workflows-fullstack/agents/technical-designer.md
@@ -1,7 +1,7 @@
 ---
 name: technical-designer
 description: Creates a scoped ADR batch or one backend/general Design Doc from confirmed requirements and decision-relevant repository evidence. Use when technical choices or implementation design need an approved artifact.
-tools: Read, Write, Edit, MultiEdit, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
+tools: Read, Write, Edit, MultiEdit, Glob, LS, Bash, WebSearch
 skills:
   - documentation-criteria
   - coding-principles
@@ -15,9 +15,9 @@ skills:
 
 You create one complete ADR batch or one Design Doc per invocation.
 
-## Initial Mandatory Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Inputs
 

--- a/dev-workflows-fullstack/agents/ui-analyzer.md
+++ b/dev-workflows-fullstack/agents/ui-analyzer.md
@@ -11,9 +11,9 @@ skills:
 
 You are an AI assistant specializing in UI fact gathering for frontend design.
 
-## Required Initial Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Input Parameters
 

--- a/dev-workflows-fullstack/agents/ui-spec-designer.md
+++ b/dev-workflows-fullstack/agents/ui-spec-designer.md
@@ -1,7 +1,7 @@
 ---
 name: ui-spec-designer
 description: Creates UI Specifications from confirmed requirements and optional prototype code. Use when frontend UI design is needed, or when "UI spec/screen design/component decomposition/UI specification" is mentioned.
-tools: Read, Write, Edit, MultiEdit, Glob, LS, Bash, TaskCreate, TaskUpdate
+tools: Read, Write, Edit, MultiEdit, Glob, LS, Bash
 skills:
   - documentation-criteria
   - typescript-rules
@@ -12,9 +12,9 @@ skills:
 
 You are a UI specification specialist AI assistant for creating UI Specification documents.
 
-## Initial Mandatory Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Main Responsibilities
 

--- a/dev-workflows-fullstack/agents/verifier.md
+++ b/dev-workflows-fullstack/agents/verifier.md
@@ -1,7 +1,7 @@
 ---
 name: verifier
 description: Critically evaluates investigation results, checks path coverage, and validates failure points using Devil's Advocate method. Use when investigation has completed, or when "verify/validate/double-check/confirm findings" is mentioned. Focuses on verification and conclusion derivation.
-tools: Read, Grep, Glob, LS, Bash, WebSearch, TaskCreate, TaskUpdate
+tools: Read, Grep, Glob, LS, Bash, WebSearch
 skills:
   - ai-development-guide
   - coding-principles
@@ -9,9 +9,9 @@ skills:
 
 You are an AI assistant specializing in investigation result verification.
 
-## Required Initial Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Input and Responsibility Boundaries
 

--- a/dev-workflows-fullstack/agents/work-planner.md
+++ b/dev-workflows-fullstack/agents/work-planner.md
@@ -1,7 +1,7 @@
 ---
 name: work-planner
 description: Creates implementation-focused work plans from approved Design Docs. Use when Design Doc is complete and implementation planning is needed, or when "work plan/implementation plan/task planning" is mentioned.
-tools: Read, Write, Edit, MultiEdit, Glob, LS, TaskCreate, TaskUpdate
+tools: Read, Write, Edit, MultiEdit, Glob, LS
 skills:
   - ai-development-guide
   - documentation-criteria
@@ -13,9 +13,9 @@ skills:
 
 You create Work Plans that translate approved Design Docs into executable repository implementation tasks.
 
-## Initial Mandatory Tasks
+## Execution Gate
 
-Register work steps using TaskCreate. Include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Inputs
 

--- a/dev-workflows-fullstack/skills/recipe-add-integration-tests/SKILL.md
+++ b/dev-workflows-fullstack/skills/recipe-add-integration-tests/SKILL.md
@@ -4,6 +4,8 @@ description: Add integration/E2E tests to existing codebase using Design Docs
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before making workflow decisions, invoking agents, or resolving findings.
 
@@ -18,7 +20,7 @@ Execute Skill: subagents-orchestration-guide before making workflow decisions, i
 **Review Resolution Gate [MANDATORY]**: Resolve every actionable deliverable-review finding through subagents-orchestration-guide `Review Resolution` before correction or progression.
 Before the first finding disposition, read `references/review-resolution.md` from the loaded subagents-orchestration-guide skill.
 
-**First Action**: Register Steps 1-7 using TaskCreate before any execution.
+**Execution Gate**: Complete Steps 1-7 in order for each generated layer. Advance only through the current step's stated output or response gate; skip work only when its stated condition is false. Report completion after every layer has completed its review, quality, commit, and retained-limitation retry.
 
 **Why Delegate**: Orchestrator's context is shared across all steps. Direct implementation consumes context needed for review and quality check phases. Subagents work in isolated context.
 

--- a/dev-workflows-fullstack/skills/recipe-build/SKILL.md
+++ b/dev-workflows-fullstack/skills/recipe-build/SKILL.md
@@ -4,6 +4,8 @@ description: Execute materialized task files in autonomous execution mode
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before making workflow decisions, invoking agents, or resolving findings.
 
@@ -20,7 +22,7 @@ Before the first finding disposition, read `references/review-resolution.md` fro
 1. **Invoke named specialists for deliverable production** — pass deliverable paths between them and validate their results (see subagents-orchestration-guide "Orchestrator Execution Boundary")
 2. **Follow the 4-step task cycle exactly**: execute → branch on executor result → quality-fix → commit
 3. **Enter autonomous mode** when user provides execution instruction with existing task files — this IS the batch approval
-4. **Scope**: Complete when all tasks are committed or escalation occurs
+4. **Scope**: Complete consumed task-set execution, post-implementation verification, consumed-task cleanup, and completion reporting in order, or stop autonomous execution at the current phase for a valid user-owned escalation. Advance only when the current phase's stated transition condition is satisfied.
 
 **CRITICAL**: Run quality-fixer before every commit.
 
@@ -85,8 +87,6 @@ Recompute the Consumed Task Set using the same restricted pattern from the Consu
 
 ## Task Execution Cycle (4-Step Cycle)
 **MANDATORY EXECUTION CYCLE**: `execute → branch on executor result → quality-fix → commit`
-
-Before the loop, register `"Execute consumed task set"`, `"Run post-implementation verification"`, `"Clean up consumed task files"`, and `"Report completion"` once with TaskCreate; mark and advance the active phase with TaskUpdate.
 
 For EACH task in the Consumed Task Set, YOU MUST:
 1. **EXECUTE**: invoke Agent tool (subagent_type: "dev-workflows-fullstack:task-executor") → Record the current HEAD as `diffBase`, pass `task_file: [path]`, and receive the structured response

--- a/dev-workflows-fullstack/skills/recipe-design/SKILL.md
+++ b/dev-workflows-fullstack/skills/recipe-design/SKILL.md
@@ -4,6 +4,8 @@ description: Execute from codebase-scoped analysis through optional ADR decision
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: documentation-criteria before document routing or creation.
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before invoking agents or resolving findings.

--- a/dev-workflows-fullstack/skills/recipe-diagnose/SKILL.md
+++ b/dev-workflows-fullstack/skills/recipe-diagnose/SKILL.md
@@ -4,6 +4,8 @@ description: Investigate problem, verify findings, and derive solutions
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before making workflow decisions, invoking agents, or resolving findings.
 
@@ -26,7 +28,7 @@ Orchestrator invokes sub-agents and passes structured JSON between them.
 
 At each Agent invocation below, build the prompt as a mechanical extraction: copy the named source values into the exact fields, apply only the declared serialization, then invoke immediately.
 
-**Task Registration**: Register execution steps using TaskCreate and proceed systematically. Update status using TaskUpdate.
+**Execution Gate**: Each step below establishes evidence required by the next decision. Complete Steps 0-7 in order, including every required investigation and verification retry. Advance only through the current step's stated quality or coverage condition; invoke solver only after coverage is closed.
 
 ## Step 0: Problem Structuring (Before investigator invocation)
 
@@ -89,8 +91,6 @@ material evidence unavailable → limitation/block report
 **Context Separation**: Pass only structured JSON output to each step. Each step starts fresh with the JSON data only.
 
 ## Execution Steps
-
-Register the following using TaskCreate and execute:
 
 ### Step 1: Investigation (investigator)
 

--- a/dev-workflows-fullstack/skills/recipe-front-adjust/SKILL.md
+++ b/dev-workflows-fullstack/skills/recipe-front-adjust/SKILL.md
@@ -4,6 +4,8 @@ description: Adjust an already-implemented UI in-session with verification again
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 
 **Context**: UI adjustment on already-implemented features. The verification loop (edit → check against the design source → refine) runs in the parent session.
@@ -17,9 +19,9 @@ Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or g
 2. **Run in the parent session** (multi-step loops and user dialogs): external-resource hearing via AskUserQuestion, write-set inspection, scale judgment, adjustment-context approval, adjustment edits, verification against the design source, iteration until acceptance.
 3. **Stop at every `[Stop: ...]` marker** before proceeding.
 
-## Initial Mandatory Tasks
+## Execution Gate
 
-**Task Registration**: Before Step 1, register the recipe's execution flow using TaskCreate so progress is trackable. Register Steps 1-7 below as individual tasks plus a final task "Verify completion against Completion Criteria". Update status using TaskUpdate as each step starts and completes.
+Complete Steps 1-7 in order for each adjustment unit. Advance only through the current step's stated evidence, quality result, or user stop; skip work only when its stated condition is false. Report completion after every applicable Completion Criterion and retained-limitation retry is satisfied.
 
 ## Workflow Overview
 

--- a/dev-workflows-fullstack/skills/recipe-front-build/SKILL.md
+++ b/dev-workflows-fullstack/skills/recipe-front-build/SKILL.md
@@ -4,6 +4,8 @@ description: Execute materialized frontend task files in autonomous execution mo
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before making workflow decisions, invoking agents, or resolving findings.
 
@@ -20,7 +22,7 @@ Before the first finding disposition, read `references/review-resolution.md` fro
 1. **Invoke named specialists for deliverable production** — pass deliverable paths between them and validate their results (see subagents-orchestration-guide "Orchestrator Execution Boundary")
 2. **Follow the 4-step task cycle exactly**: execute → branch on executor result → quality-fix → commit
 3. **Enter autonomous mode** when user provides execution instruction with existing task files — this IS the batch approval
-4. **Scope**: Complete when all tasks are committed or escalation occurs
+4. **Scope**: Complete consumed task-set execution, post-implementation verification, consumed-task cleanup, and completion reporting in order, or stop autonomous execution at the current phase for a valid user-owned escalation. Advance only when the current phase's stated transition condition is satisfied.
 
 **CRITICAL**: Run quality-fixer-frontend before every commit.
 
@@ -85,8 +87,6 @@ Recompute the Consumed Task Set using the same restricted pattern from the Consu
 
 ## Task Execution Cycle (4-Step Cycle)
 **MANDATORY EXECUTION CYCLE**: `execute → branch on executor result → quality-fix → commit`
-
-Before the loop, register `"Execute consumed task set"`, `"Run post-implementation verification"`, `"Clean up consumed task files"`, and `"Report completion"` once with TaskCreate; mark and advance the active phase with TaskUpdate.
 
 For EACH task in the Consumed Task Set, YOU MUST:
 1. **EXECUTE**: invoke Agent tool (subagent_type: "dev-workflows-fullstack:task-executor-frontend") → Record the current HEAD as `diffBase`, pass `task_file: [path]`, and receive the structured response

--- a/dev-workflows-fullstack/skills/recipe-front-design/SKILL.md
+++ b/dev-workflows-fullstack/skills/recipe-front-design/SKILL.md
@@ -4,6 +4,8 @@ description: Execute from repository evidence through applicable UI Spec and opt
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: documentation-criteria before document routing or creation.
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before invoking agents or resolving findings.

--- a/dev-workflows-fullstack/skills/recipe-front-plan/SKILL.md
+++ b/dev-workflows-fullstack/skills/recipe-front-plan/SKILL.md
@@ -4,6 +4,8 @@ description: Create frontend work plan from design document and obtain plan appr
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before making workflow decisions, invoking agents, or resolving findings.
 

--- a/dev-workflows-fullstack/skills/recipe-front-review/SKILL.md
+++ b/dev-workflows-fullstack/skills/recipe-front-review/SKILL.md
@@ -4,6 +4,8 @@ description: Design Doc compliance and security validation with optional auto-fi
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before making workflow decisions, invoking agents, or resolving findings.
 
@@ -18,7 +20,7 @@ Execute Skill: subagents-orchestration-guide before making workflow decisions, i
 **Review Resolution Gate [MANDATORY]**: Resolve every actionable deliverable-review finding through subagents-orchestration-guide `Review Resolution` before correction or progression.
 Before the first finding disposition, read `references/review-resolution.md` from the loaded subagents-orchestration-guide skill.
 
-**First Action**: Register Steps 1-10 using TaskCreate before any execution.
+**Execution Gate**: Complete Steps 1-10 in order, following only the branches activated by their stated conditions. Advance through each review, correction, and re-validation transition only at its declared convergence condition. Present the final report after every applicable finding and retained quality limitation reaches its required disposition or retry result.
 
 ## Execution Method
 

--- a/dev-workflows-fullstack/skills/recipe-fullstack-build/SKILL.md
+++ b/dev-workflows-fullstack/skills/recipe-fullstack-build/SKILL.md
@@ -4,6 +4,8 @@ description: Execute materialized fullstack task files with layer-aware agent ro
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before making workflow decisions, invoking agents, or resolving findings.
 
@@ -28,7 +30,7 @@ Before the first finding disposition, read `references/review-resolution.md` fro
    - `*-frontend-task-*` → task-executor-frontend + quality-fixer-frontend
 3. **Follow the 4-step task cycle exactly**: execute → branch on executor result → quality-fix → commit
 4. **Enter autonomous mode** when user provides execution instruction with existing task files — this IS the batch approval
-5. **Scope**: Complete when all tasks are committed or escalation occurs
+5. **Scope**: Complete consumed task-set execution, post-implementation verification, consumed-task cleanup, and completion reporting in order, or stop autonomous execution at the current phase for a valid user-owned escalation. Advance only when the current phase's stated transition condition is satisfied.
 
 **CRITICAL**: Run layer-appropriate quality-fixer(s) before every commit.
 
@@ -103,8 +105,6 @@ Recompute the Consumed Task Set using the same restricted pattern from the Consu
 ### Task Execution (4-Step Cycle)
 
 **MANDATORY EXECUTION CYCLE**: `execute → branch on executor result → quality-fix → commit`
-
-Before the loop, register `"Execute consumed task set"`, `"Run post-implementation verification"`, `"Clean up consumed task files"`, and `"Report completion"` once with TaskCreate; mark and advance the active phase with TaskUpdate.
 
 For EACH task, YOU MUST:
 1. **EXECUTE**: invoke Agent tool (subagent_type per routing table) → Record the current HEAD as `diffBase`, pass `task_file: [path]`, and receive the structured response

--- a/dev-workflows-fullstack/skills/recipe-fullstack-implement/SKILL.md
+++ b/dev-workflows-fullstack/skills/recipe-fullstack-implement/SKILL.md
@@ -4,6 +4,8 @@ description: Orchestrate full-cycle implementation across backend and frontend l
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before making workflow decisions, invoking agents, or resolving findings.
 
@@ -68,9 +70,9 @@ Key points to enforce as the orchestrator runs the flow:
 - Pass all Design Docs to work-planner (subagent_type: "dev-workflows-fullstack:work-planner") with vertical slicing instruction
 - Pass the Work Plan to document-reviewer (`doc_type: WorkPlan`) and request batch approval only after the review passes
 
-### 4. Register All Flow Steps Using TaskCreate (MANDATORY)
+### 4. Bind the Applicable Flow
 
-After scale determination, use TaskCreate to register each design/planning step and the implementation, verification, cleanup, and report phases. Complete registration before invoking subagents; mark and advance the active phase with TaskUpdate.
+After Structural Scale is determined, follow only that scale's applicable path. Treat each applicable design, review, approval, planning, implementation, verification, cleanup, and reporting phase as a gate. Advance only when the current phase's stated evidence or approval exists; skip only branches whose stated condition is false.
 
 ## After requirement-analyzer [Stop]
 

--- a/dev-workflows-fullstack/skills/recipe-implement/SKILL.md
+++ b/dev-workflows-fullstack/skills/recipe-implement/SKILL.md
@@ -4,6 +4,8 @@ description: Orchestrate the complete implementation lifecycle from requirements
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before making workflow decisions, invoking agents, or resolving findings.
 
@@ -71,9 +73,9 @@ When user responds to questions:
 - Repeat the hearing until every convergence field is `ready` or `weak-but-explicit`, then proceed with the resulting Scale.
 - For Small, the user's requirement confirmation authorizes the direct implementation scope; proceed to the 4-step cycle without a Work Plan.
 
-### 4. Register All Flow Steps Using TaskCreate (MANDATORY)
+### 4. Bind the Applicable Flow
 
-After scale determination, use TaskCreate to register the applicable design/planning steps and the implementation, verification, report, and Medium/Large cleanup phases. Complete registration before invoking subagents; mark and advance the active phase with TaskUpdate.
+After Structural Scale is determined, follow only that scale's applicable path. Treat each applicable design, review, approval, planning, implementation, verification, cleanup, and reporting phase as a gate. Advance only when the current phase's stated evidence or approval exists; skip only branches whose stated condition is false.
 
 ## Subagents Orchestration Guide Compliance Execution
 

--- a/dev-workflows-fullstack/skills/recipe-plan/SKILL.md
+++ b/dev-workflows-fullstack/skills/recipe-plan/SKILL.md
@@ -4,6 +4,8 @@ description: Create work plan from design document and obtain plan approval
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before making workflow decisions, invoking agents, or resolving findings.
 

--- a/dev-workflows-fullstack/skills/recipe-reverse-engineer/SKILL.md
+++ b/dev-workflows-fullstack/skills/recipe-reverse-engineer/SKILL.md
@@ -4,6 +4,8 @@ description: Generate PRD and Design Docs from existing codebase through discove
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before making workflow decisions, invoking agents, or resolving findings.
 
@@ -27,7 +29,7 @@ Before the first finding disposition, read `references/review-resolution.md` fro
 
 At each Agent invocation below, build the prompt as a mechanical extraction: copy the named source values into the exact fields, apply only the declared serialization, then invoke immediately.
 
-**Task Registration**: Register phases first using TaskCreate, then steps within each phase as you enter it. Update status using TaskUpdate.
+**Execution Gate**: Complete Phase 1 before Phase 2. Within each phase, complete one unit's generation, verification, review, and required revision to convergence before starting the next unit. Advance only when the current step's stated output and quality gate are satisfied. At each loop boundary, select the first unit in the current phase's declared order whose Unit Completion conditions are unsatisfied and that is not logged as a generation failure. A document path proves generation only.
 
 ## Step 0: Initial Configuration
 
@@ -62,10 +64,6 @@ Phase 2: Design Doc Generation (if requested)
 ```
 
 ## Phase 1: PRD Generation
-
-**Register using TaskCreate**:
-- Step 1: PRD Scope Discovery
-- Per-unit processing (Steps 2-5 for each unit)
 
 ### Step 1: PRD Scope Discovery
 
@@ -196,10 +194,6 @@ prompt: |
 ## Phase 2: Design Doc Generation
 
 *Execute only if Design Docs were requested in Step 0*
-
-**Register using TaskCreate**:
-- Step 6: Design Doc Scope Mapping
-- Per-unit processing (Steps 7-10 for each unit)
 
 ### Step 6: Design Doc Scope Mapping
 

--- a/dev-workflows-fullstack/skills/recipe-review/SKILL.md
+++ b/dev-workflows-fullstack/skills/recipe-review/SKILL.md
@@ -4,6 +4,8 @@ description: Design Doc compliance and security validation with optional auto-fi
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before making workflow decisions, invoking agents, or resolving findings.
 
@@ -18,7 +20,7 @@ Execute Skill: subagents-orchestration-guide before making workflow decisions, i
 **Review Resolution Gate [MANDATORY]**: Resolve every actionable deliverable-review finding through subagents-orchestration-guide `Review Resolution` before correction or progression.
 Before the first finding disposition, read `references/review-resolution.md` from the loaded subagents-orchestration-guide skill.
 
-**First Action**: Register Steps 1-10 using TaskCreate before any execution.
+**Execution Gate**: Complete Steps 1-10 in order, following only the branches activated by their stated conditions. Advance through each review, correction, and re-validation transition only at its declared convergence condition. Present the final report after every applicable finding and retained quality limitation reaches its required disposition or retry result.
 
 ## Execution Method
 

--- a/dev-workflows-fullstack/skills/recipe-task/SKILL.md
+++ b/dev-workflows-fullstack/skills/recipe-task/SKILL.md
@@ -4,6 +4,8 @@ description: Execute tasks following appropriate rules with rule-advisor metacog
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before making workflow decisions, invoking agents, or resolving findings.
 
@@ -40,23 +42,15 @@ After receiving rule-advisor's JSON response, proceed with:
    - Start with recommended action
    - Use suggested tools first
 
-**Step 3: Create Task List with TaskCreate**
+**Step 3: Bind the Execution Sequence**
 
-Register work steps using TaskCreate. Use "Select and map applicable rules" as the first task and "Verify selected rules and report completion" as the final task.
-
-Break down the task based on rule-advisor's guidance:
-- Reflect `taskAnalysis.essence` in task descriptions
-- Apply `metaCognitiveGuidance.firstStep` to first task
-- Restructure tasks considering `warningPatterns`
-- Set priorities based on dependency order and warningPatterns severity
-- Update each task with TaskUpdate as execution progresses
+Before implementation, derive the smallest dependency-ordered sequence required by the rule-advisor result. Its first gate applies and maps the selected rules; its final gate verifies those rules and the requested outcome. Execute one gate at a time, advancing only when its required evidence exists. Add or reorder a gate only when new evidence changes a dependency or completion condition.
 
 **Step 4: Execute Implementation**
 
 Proceed with task execution following:
 - Start with `metaCognitiveGuidance.firstStep` action from rule-advisor
-- Update task structure with TaskUpdate to reflect rule-advisor insights
 - Selected rules from rule-advisor
-- Task structure (managed via TaskCreate/TaskUpdate)
+- Dependency-ordered execution sequence from Step 3
 - Quality standards from the selected skills and sections named by rule-advisor
 - Monitor warningPatterns flags throughout execution and adjust approach when triggered

--- a/dev-workflows-fullstack/skills/recipe-update-doc/SKILL.md
+++ b/dev-workflows-fullstack/skills/recipe-update-doc/SKILL.md
@@ -4,6 +4,8 @@ description: Update existing design documents (Design Doc / PRD / ADR) with revi
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before making workflow decisions, invoking agents, or resolving findings.
 
@@ -18,7 +20,7 @@ Execute Skill: subagents-orchestration-guide before making workflow decisions, i
 **Review Resolution Gate [MANDATORY]**: Resolve every actionable deliverable-review finding through subagents-orchestration-guide `Review Resolution` before correction or progression.
 Before the first finding disposition, read `references/review-resolution.md` from the loaded subagents-orchestration-guide skill.
 
-**First Action**: Register Steps 1-6 using TaskCreate before any execution.
+**Execution Gate**: Complete Steps 1-6 in order, following only the branches activated by document type and review result. Advance only through each step's stated evidence, review convergence, or approval condition. Complete after the final approval gate and every applicable Completion Criterion is satisfied.
 
 **Execution Protocol**:
 1. **Invoke named specialists for deliverable production** — pass deliverable paths between them and validate their results (see subagents-orchestration-guide "Orchestrator Execution Boundary")

--- a/dev-workflows-fullstack/skills/subagents-orchestration-guide/SKILL.md
+++ b/dev-workflows-fullstack/skills/subagents-orchestration-guide/SKILL.md
@@ -7,6 +7,8 @@ description: Guides subagent coordination through implementation workflows. Use 
 
 ## Role: The Orchestrator
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in the invoked recipe. Execute each applicable call when its prerequisites are met.
+
 The orchestrator owns workflow decisions, routing, progress management, user interaction, the investigation and validation needed for those decisions, and explicitly assigned mechanical operations, using any available tool. Named specialists own explicitly assigned investigation and semantic deliverable creation or modification; invoke them before producing or changing code, tests, configuration, documents, task files, or other artifacts.
 
 ### Workflow Subagent Context — Mandatory
@@ -154,6 +156,8 @@ Rules:
 - `task-decomposer` begins only after work plan review (document-reviewer, doc_type WorkPlan; Medium/Large) and batch approval
 - Work plan review runs Review Resolution through its correction re-review, escalation, and convergence transitions; batch approval is available only at its convergence condition
 
+Treat the applicable Structural Scale flow as an evidence-gated sequence. Advance only when the current phase has the artifact, approval, or result required by its stated routing condition. Before reporting completion, resume the earliest applicable phase without that evidence.
+
 ## Autonomous Execution Mode
 
 ### Pre-Execution Gate
@@ -206,7 +210,7 @@ For Small, execute one direct-scope 4-step cycle. Complete after `approved`, or 
 | A requirement changes | Apply Requirement Change Detection above. After task-decomposer starts, invalidate affected tasks; restart document design only when re-analysis changes an approved requirement, contract, data flow, verification strategy, or task boundary. |
 | The user stops or interrupts | Stop autonomous execution. |
 
-### Task Management: 4-Step Cycle
+### Task Execution Cycle
 
 #### Commit Boundary Check
 
@@ -239,8 +243,6 @@ Derive the values from the quality-fixer result. Keep the complete result in orc
    - `verification_incomplete` → Retain the complete result for final retry and proceed to step 4
    - `approved` → Proceed to step 4
 4. **Commit**: apply Commit Boundary Check, then compose the message from `changeSummary` and execute git commit with Bash after `approved` or `verification_incomplete`; append the verification trailers for the latter
-
-Register overall phases using TaskCreate and update each phase with TaskUpdate as it completes.
 
 Before post-implementation verifiers, collect retained verification limitations from orchestration state and the verification trailers on task-boundary commits created by the workflow, then re-invoke the applicable quality-fixer once for each limitation using the same task inputs and its affected check or command. Clear an `approved` result, route newly discovered incomplete implementation through the normal cycle, and retain a repeated `verification_incomplete` result for the final report. Commit any fixes produced by this retry through the same task cycle, then continue post-implementation verification.
 

--- a/dev-workflows/.claude-plugin/plugin.json
+++ b/dev-workflows/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflows",
   "description": "Skills + Subagents for backend development - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
-  "version": "0.24.6",
+  "version": "0.24.7",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows/agents/acceptance-test-generator.md
+++ b/dev-workflows/agents/acceptance-test-generator.md
@@ -1,7 +1,7 @@
 ---
 name: acceptance-test-generator
 description: Generates integration/E2E test skeletons from Design Doc ACs using ROI-based selection and journey-based E2E reservation. Use when Design Doc is complete and test design is needed, or when "test skeleton/AC/acceptance criteria" is mentioned. Behavior-first approach for minimal tests with maximum coverage.
-tools: Read, Write, Glob, LS, TaskCreate, TaskUpdate, Grep
+tools: Read, Write, Glob, LS, Grep
 skills:
   - testing-principles
   - documentation-criteria
@@ -13,9 +13,9 @@ You are a specialized AI that generates minimal, high-quality test skeletons fro
 
 Operates in an independent context, executing autonomously until task completion.
 
-## Mandatory Initial Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ### Implementation Approach Compliance
 - **Test Code Generation**: MUST strictly comply with Design Doc implementation patterns (function vs class selection)

--- a/dev-workflows/agents/code-reviewer.md
+++ b/dev-workflows/agents/code-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: code-reviewer
 description: Validates Design Doc compliance and implementation completeness from third-party perspective. Use PROACTIVELY after implementation completes or when "review/implementation check/compliance" is mentioned. Provides acceptance criteria validation and quality reports.
-tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate
+tools: Read, Grep, Glob, LS, Bash
 skills:
   - ai-development-guide
   - coding-principles
@@ -12,9 +12,9 @@ You are a code review AI assistant specializing in Design Doc compliance validat
 
 Operates in an independent context, executing autonomously until task completion.
 
-## Initial Required Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Key Responsibilities
 

--- a/dev-workflows/agents/code-verifier.md
+++ b/dev-workflows/agents/code-verifier.md
@@ -1,7 +1,7 @@
 ---
 name: code-verifier
 description: Verifies repository-backed claims and implementation feasibility in PRDs, Design Docs, or Work Plans. Use before document review, after implementation, or for reverse-engineered artifact verification.
-tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate
+tools: Read, Grep, Glob, LS, Bash
 skills:
   - documentation-criteria
   - ai-development-guide
@@ -12,9 +12,9 @@ You perform read-only verification of an authoritative document against reposito
 
 Your discrepancies are independent evidence for orchestrator Review Resolution. Confirmed requirements and selected ADR decisions define scope; the orchestrator determines correction obligations.
 
-## Required Initial Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Inputs
 

--- a/dev-workflows/agents/codebase-analyzer.md
+++ b/dev-workflows/agents/codebase-analyzer.md
@@ -1,7 +1,7 @@
 ---
 name: codebase-analyzer
 description: Collects compact repository evidence for scope confirmation, technical option selection, complete design, and verification. Use before Design Doc creation when repository facts can change scope, reuse, contracts, cost, or proof.
-tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate
+tools: Read, Grep, Glob, LS, Bash
 skills:
   - ai-development-guide
   - coding-principles
@@ -10,9 +10,9 @@ skills:
 
 You are an AI assistant specializing in objective codebase analysis for technical design preparation.
 
-## Required Initial Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Responsibilities
 

--- a/dev-workflows/agents/design-sync.md
+++ b/dev-workflows/agents/design-sync.md
@@ -1,7 +1,7 @@
 ---
 name: design-sync
 description: Detects conflicts across multiple Design Docs and provides structured reports. Use when multiple Design Docs exist, or when "consistency/conflict/sync/between documents" is mentioned. Focuses on detection and reporting only, no modifications.
-tools: Read, Grep, Glob, LS, TaskCreate, TaskUpdate
+tools: Read, Grep, Glob, LS
 skills:
   - documentation-criteria
   - coding-principles
@@ -12,9 +12,9 @@ You are an AI assistant specializing in consistency verification between Design 
 
 Operates in an independent context, executing autonomously until task completion.
 
-## Initial Mandatory Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Detection Criteria (The Only Rule)
 

--- a/dev-workflows/agents/document-reviewer.md
+++ b/dev-workflows/agents/document-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: document-reviewer
 description: Reviews one document or one ADR batch against governing requirements, repository evidence, and the needs of its next consumer. Use before user approval or when document consistency and completeness need verification.
-tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
+tools: Read, Grep, Glob, LS, Bash, WebSearch
 skills:
   - documentation-criteria
   - coding-principles
@@ -11,9 +11,9 @@ skills:
 
 You review one PRD, ADR batch, UI Spec, Design Doc, or Work Plan per invocation.
 
-## Initial Mandatory Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Inputs
 

--- a/dev-workflows/agents/integration-test-reviewer.md
+++ b/dev-workflows/agents/integration-test-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: integration-test-reviewer
 description: Verifies changed integration and E2E tests against skeletons, proof obligations, or explicit prompt claims. Use PROACTIVELY after test implementation completes, or when "test review/skeleton verification" is mentioned. Returns quality reports with failing items and fix instructions.
-tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate
+tools: Read, Grep, Glob, LS, Bash
 skills:
   - testing-principles
   - integration-e2e-testing
@@ -11,9 +11,9 @@ You are an AI assistant specializing in integration and E2E test quality review.
 
 Operates in an independent context, executing autonomously until task completion.
 
-## Initial Mandatory Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Responsibilities
 

--- a/dev-workflows/agents/investigator.md
+++ b/dev-workflows/agents/investigator.md
@@ -1,7 +1,7 @@
 ---
 name: investigator
 description: Comprehensively collects problem-related information and creates evidence matrix. Use PROACTIVELY when bug/error/issue/defect/not working/strange behavior is reported. Reports observations and evidence for downstream cause verification.
-tools: Read, Grep, Glob, LS, Bash, WebSearch, TaskCreate, TaskUpdate
+tools: Read, Grep, Glob, LS, Bash, WebSearch
 skills:
   - ai-development-guide
   - coding-principles
@@ -9,9 +9,9 @@ skills:
 
 You are an AI assistant specializing in problem investigation.
 
-## Required Initial Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Input and Responsibility Boundaries
 

--- a/dev-workflows/agents/prd-creator.md
+++ b/dev-workflows/agents/prd-creator.md
@@ -1,7 +1,7 @@
 ---
 name: prd-creator
 description: Creates PRD and structures business requirements. Use when new feature/project starts, or when "PRD/requirements definition/user story/what to build" is mentioned. Defines user value and success metrics.
-tools: Read, Write, Edit, MultiEdit, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
+tools: Read, Write, Edit, MultiEdit, Glob, LS, Bash, WebSearch
 skills:
   - documentation-criteria
   - llm-friendly-context
@@ -10,9 +10,9 @@ skills:
 
 You are a specialized AI assistant for creating Product Requirements Documents (PRD).
 
-## Initial Mandatory Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Responsibilities
 

--- a/dev-workflows/agents/quality-fixer.md
+++ b/dev-workflows/agents/quality-fixer.md
@@ -1,7 +1,7 @@
 ---
 name: quality-fixer
 description: Specialized agent for verifying software projects and fixing quality failures within the current task scope. Use proactively after code changes or for quality, test, build, lint, format, correctness, or fix requests.
-tools: Bash, Read, Edit, MultiEdit, Grep, Glob, LS, TaskCreate, TaskUpdate
+tools: Bash, Read, Edit, MultiEdit, Grep, Glob, LS
 skills:
   - coding-principles
   - testing-principles
@@ -26,9 +26,9 @@ Executes applicable quality checks, fixes in-scope failures, and reports blocker
 - **qualityCommand** (optional): Quality command supplied by the caller or recorded in the task. Run it first, then cover the remaining applicable check categories.
 - **mutationEvidence** (optional): Upstream mutation results with restoration and target-revision proof
 
-## Initial Required Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Workflow
 

--- a/dev-workflows/agents/requirement-analyzer.md
+++ b/dev-workflows/agents/requirement-analyzer.md
@@ -1,7 +1,7 @@
 ---
 name: requirement-analyzer
 description: Collects compact scope and cost evidence for requirement confirmation while the user and orchestrator retain requirements, Structural Scale, and document-routing decisions. Use when new requirements, scope, or implementation extent must be confirmed.
-tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate
+tools: Read, Grep, Glob, LS, Bash
 skills:
   - ai-development-guide
   - llm-friendly-context
@@ -9,9 +9,9 @@ skills:
 
 You collect decision material for requirement confirmation and workflow routing. The user owns product requirements; the orchestrator owns convergence, Structural Scale, ADR qualification, and document routing.
 
-## Initial Mandatory Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Inputs
 

--- a/dev-workflows/agents/scope-discoverer.md
+++ b/dev-workflows/agents/scope-discoverer.md
@@ -1,7 +1,7 @@
 ---
 name: scope-discoverer
 description: Discovers functional scope from existing codebase for reverse documentation. Identifies targets through multi-source discovery combining user-value and technical perspectives. Use when "reverse engineering/existing code analysis/scope discovery" is mentioned.
-tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate
+tools: Read, Grep, Glob, LS, Bash
 skills:
   - documentation-criteria
   - ai-development-guide
@@ -12,9 +12,9 @@ skills:
 
 You are an AI assistant specializing in codebase scope discovery for reverse documentation.
 
-## Required Initial Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Input Parameters
 

--- a/dev-workflows/agents/security-reviewer.md
+++ b/dev-workflows/agents/security-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: security-reviewer
 description: Reviews implementation for security compliance against an authoritative Design Doc or Work Plan. Use PROACTIVELY after all implementation tasks complete, or when "security review/security check/vulnerability check" is mentioned. Returns structured findings with risk classification and fix suggestions.
-tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
+tools: Read, Grep, Glob, LS, Bash, WebSearch
 skills:
   - coding-principles
 ---
@@ -10,9 +10,9 @@ You are an AI assistant specializing in security review of implemented code.
 
 Operates in an independent context, executing autonomously until task completion.
 
-## Initial Mandatory Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Responsibilities
 

--- a/dev-workflows/agents/solver.md
+++ b/dev-workflows/agents/solver.md
@@ -1,7 +1,7 @@
 ---
 name: solver
 description: Derives multiple solutions for verified causes and analyzes tradeoffs. Use when root cause verification has concluded, or when "solution/how to fix/fix method/remedy" is mentioned. Focuses on solutions from given conclusions without investigation.
-tools: Read, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
+tools: Read, Grep, Glob, LS, Bash, WebSearch
 skills:
   - ai-development-guide
   - coding-principles
@@ -10,9 +10,9 @@ skills:
 
 You are an AI assistant specializing in solution derivation.
 
-## Required Initial Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Input and Responsibility Boundaries
 

--- a/dev-workflows/agents/task-decomposer.md
+++ b/dev-workflows/agents/task-decomposer.md
@@ -1,7 +1,7 @@
 ---
 name: task-decomposer
 description: Converts an approved Work Plan into the fewest executable implementation task files. Use when work plans are approved and task materialization is needed.
-tools: Read, Write, Edit, MultiEdit, Grep, Glob, LS, Bash, TaskCreate, TaskUpdate
+tools: Read, Write, Edit, MultiEdit, Grep, Glob, LS, Bash
 skills:
   - ai-development-guide
   - documentation-criteria
@@ -13,9 +13,9 @@ skills:
 
 You convert an approved Work Plan into executable task files while preserving its task boundaries and implementation scope.
 
-## Initial Mandatory Tasks
+## Execution Gate
 
-Register work steps using TaskCreate. Include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Input
 

--- a/dev-workflows/agents/task-executor.md
+++ b/dev-workflows/agents/task-executor.md
@@ -1,7 +1,7 @@
 ---
 name: task-executor
 description: Executes implementation completely self-contained from an explicit prompt or task file. Use when task files exist in docs/plans/tasks/, or when "execute task/implement task/start implementation" is mentioned. Asks no questions, executes consistently from investigation to implementation.
-tools: Read, Edit, Write, MultiEdit, Bash, Grep, Glob, LS, TaskCreate, TaskUpdate
+tools: Read, Edit, Write, MultiEdit, Bash, Grep, Glob, LS
 skills:
   - coding-principles
   - testing-principles
@@ -34,7 +34,7 @@ Implement the confirmed outcome and the maintenance, tests, and adjacent correct
 
 ## Mandatory Rules
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ### Applying to Implementation
 Apply loaded architecture/coding/testing rules during implementation, including the selected test-first or behavior-preserving refactor flow; when a task file is provided, **MUST strictly adhere to its implementation patterns (function vs class selection)**.

--- a/dev-workflows/agents/technical-designer.md
+++ b/dev-workflows/agents/technical-designer.md
@@ -1,7 +1,7 @@
 ---
 name: technical-designer
 description: Creates a scoped ADR batch or one backend/general Design Doc from confirmed requirements and decision-relevant repository evidence. Use when technical choices or implementation design need an approved artifact.
-tools: Read, Write, Edit, MultiEdit, Glob, LS, Bash, TaskCreate, TaskUpdate, WebSearch
+tools: Read, Write, Edit, MultiEdit, Glob, LS, Bash, WebSearch
 skills:
   - documentation-criteria
   - coding-principles
@@ -15,9 +15,9 @@ skills:
 
 You create one complete ADR batch or one Design Doc per invocation.
 
-## Initial Mandatory Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Inputs
 

--- a/dev-workflows/agents/verifier.md
+++ b/dev-workflows/agents/verifier.md
@@ -1,7 +1,7 @@
 ---
 name: verifier
 description: Critically evaluates investigation results, checks path coverage, and validates failure points using Devil's Advocate method. Use when investigation has completed, or when "verify/validate/double-check/confirm findings" is mentioned. Focuses on verification and conclusion derivation.
-tools: Read, Grep, Glob, LS, Bash, WebSearch, TaskCreate, TaskUpdate
+tools: Read, Grep, Glob, LS, Bash, WebSearch
 skills:
   - ai-development-guide
   - coding-principles
@@ -9,9 +9,9 @@ skills:
 
 You are an AI assistant specializing in investigation result verification.
 
-## Required Initial Tasks
+## Execution Gate
 
-**Task Registration**: Register work steps using TaskCreate. Always include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Input and Responsibility Boundaries
 

--- a/dev-workflows/agents/work-planner.md
+++ b/dev-workflows/agents/work-planner.md
@@ -1,7 +1,7 @@
 ---
 name: work-planner
 description: Creates implementation-focused work plans from approved Design Docs. Use when Design Doc is complete and implementation planning is needed, or when "work plan/implementation plan/task planning" is mentioned.
-tools: Read, Write, Edit, MultiEdit, Glob, LS, TaskCreate, TaskUpdate
+tools: Read, Write, Edit, MultiEdit, Glob, LS
 skills:
   - ai-development-guide
   - documentation-criteria
@@ -13,9 +13,9 @@ skills:
 
 You create Work Plans that translate approved Design Docs into executable repository implementation tasks.
 
-## Initial Mandatory Tasks
+## Execution Gate
 
-Register work steps using TaskCreate. Include first task "Map preloaded skills to applicable concrete rules" and final task "Verify the mapped rules before final JSON". Update status using TaskUpdate upon each completion.
+Before acting, map the preloaded skills to concrete rules for this task. Follow the applicable process below, advancing only when the current step's required evidence is present. Before returning, verify that the result satisfies those rules and the output requirements below.
 
 ## Inputs
 

--- a/dev-workflows/skills/recipe-add-integration-tests/SKILL.md
+++ b/dev-workflows/skills/recipe-add-integration-tests/SKILL.md
@@ -4,6 +4,8 @@ description: Add integration/E2E tests to existing codebase using Design Docs
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before making workflow decisions, invoking agents, or resolving findings.
 
@@ -18,7 +20,7 @@ Execute Skill: subagents-orchestration-guide before making workflow decisions, i
 **Review Resolution Gate [MANDATORY]**: Resolve every actionable deliverable-review finding through subagents-orchestration-guide `Review Resolution` before correction or progression.
 Before the first finding disposition, read `references/review-resolution.md` from the loaded subagents-orchestration-guide skill.
 
-**First Action**: Register Steps 1-7 using TaskCreate before any execution.
+**Execution Gate**: Complete Steps 1-7 in order for each generated layer. Advance only through the current step's stated output or response gate; skip work only when its stated condition is false. Report completion after every layer has completed its review, quality, commit, and retained-limitation retry.
 
 **Why Delegate**: Orchestrator's context is shared across all steps. Direct implementation consumes context needed for review and quality check phases. Subagents work in isolated context.
 

--- a/dev-workflows/skills/recipe-build/SKILL.md
+++ b/dev-workflows/skills/recipe-build/SKILL.md
@@ -4,6 +4,8 @@ description: Execute materialized task files in autonomous execution mode
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before making workflow decisions, invoking agents, or resolving findings.
 
@@ -20,7 +22,7 @@ Before the first finding disposition, read `references/review-resolution.md` fro
 1. **Invoke named specialists for deliverable production** — pass deliverable paths between them and validate their results (see subagents-orchestration-guide "Orchestrator Execution Boundary")
 2. **Follow the 4-step task cycle exactly**: execute → branch on executor result → quality-fix → commit
 3. **Enter autonomous mode** when user provides execution instruction with existing task files — this IS the batch approval
-4. **Scope**: Complete when all tasks are committed or escalation occurs
+4. **Scope**: Complete consumed task-set execution, post-implementation verification, consumed-task cleanup, and completion reporting in order, or stop autonomous execution at the current phase for a valid user-owned escalation. Advance only when the current phase's stated transition condition is satisfied.
 
 **CRITICAL**: Run quality-fixer before every commit.
 
@@ -85,8 +87,6 @@ Recompute the Consumed Task Set using the same restricted pattern from the Consu
 
 ## Task Execution Cycle (4-Step Cycle)
 **MANDATORY EXECUTION CYCLE**: `execute → branch on executor result → quality-fix → commit`
-
-Before the loop, register `"Execute consumed task set"`, `"Run post-implementation verification"`, `"Clean up consumed task files"`, and `"Report completion"` once with TaskCreate; mark and advance the active phase with TaskUpdate.
 
 For EACH task in the Consumed Task Set, YOU MUST:
 1. **EXECUTE**: invoke Agent tool (subagent_type: "dev-workflows:task-executor") → Record the current HEAD as `diffBase`, pass `task_file: [path]`, and receive the structured response

--- a/dev-workflows/skills/recipe-design/SKILL.md
+++ b/dev-workflows/skills/recipe-design/SKILL.md
@@ -4,6 +4,8 @@ description: Execute from codebase-scoped analysis through optional ADR decision
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: documentation-criteria before document routing or creation.
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before invoking agents or resolving findings.

--- a/dev-workflows/skills/recipe-diagnose/SKILL.md
+++ b/dev-workflows/skills/recipe-diagnose/SKILL.md
@@ -4,6 +4,8 @@ description: Investigate problem, verify findings, and derive solutions
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before making workflow decisions, invoking agents, or resolving findings.
 
@@ -26,7 +28,7 @@ Orchestrator invokes sub-agents and passes structured JSON between them.
 
 At each Agent invocation below, build the prompt as a mechanical extraction: copy the named source values into the exact fields, apply only the declared serialization, then invoke immediately.
 
-**Task Registration**: Register execution steps using TaskCreate and proceed systematically. Update status using TaskUpdate.
+**Execution Gate**: Each step below establishes evidence required by the next decision. Complete Steps 0-7 in order, including every required investigation and verification retry. Advance only through the current step's stated quality or coverage condition; invoke solver only after coverage is closed.
 
 ## Step 0: Problem Structuring (Before investigator invocation)
 
@@ -89,8 +91,6 @@ material evidence unavailable → limitation/block report
 **Context Separation**: Pass only structured JSON output to each step. Each step starts fresh with the JSON data only.
 
 ## Execution Steps
-
-Register the following using TaskCreate and execute:
 
 ### Step 1: Investigation (investigator)
 

--- a/dev-workflows/skills/recipe-implement/SKILL.md
+++ b/dev-workflows/skills/recipe-implement/SKILL.md
@@ -4,6 +4,8 @@ description: Orchestrate the complete implementation lifecycle from requirements
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before making workflow decisions, invoking agents, or resolving findings.
 
@@ -71,9 +73,9 @@ When user responds to questions:
 - Repeat the hearing until every convergence field is `ready` or `weak-but-explicit`, then proceed with the resulting Scale.
 - For Small, the user's requirement confirmation authorizes the direct implementation scope; proceed to the 4-step cycle without a Work Plan.
 
-### 4. Register All Flow Steps Using TaskCreate (MANDATORY)
+### 4. Bind the Applicable Flow
 
-After scale determination, use TaskCreate to register the applicable design/planning steps and the implementation, verification, report, and Medium/Large cleanup phases. Complete registration before invoking subagents; mark and advance the active phase with TaskUpdate.
+After Structural Scale is determined, follow only that scale's applicable path. Treat each applicable design, review, approval, planning, implementation, verification, cleanup, and reporting phase as a gate. Advance only when the current phase's stated evidence or approval exists; skip only branches whose stated condition is false.
 
 ## Subagents Orchestration Guide Compliance Execution
 

--- a/dev-workflows/skills/recipe-plan/SKILL.md
+++ b/dev-workflows/skills/recipe-plan/SKILL.md
@@ -4,6 +4,8 @@ description: Create work plan from design document and obtain plan approval
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before making workflow decisions, invoking agents, or resolving findings.
 

--- a/dev-workflows/skills/recipe-reverse-engineer/SKILL.md
+++ b/dev-workflows/skills/recipe-reverse-engineer/SKILL.md
@@ -4,6 +4,8 @@ description: Generate PRD and Design Docs from existing codebase through discove
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before making workflow decisions, invoking agents, or resolving findings.
 
@@ -27,7 +29,7 @@ Before the first finding disposition, read `references/review-resolution.md` fro
 
 At each Agent invocation below, build the prompt as a mechanical extraction: copy the named source values into the exact fields, apply only the declared serialization, then invoke immediately.
 
-**Task Registration**: Register phases first using TaskCreate, then steps within each phase as you enter it. Update status using TaskUpdate.
+**Execution Gate**: Complete Phase 1 before Phase 2. Within each phase, complete one unit's generation, verification, review, and required revision to convergence before starting the next unit. Advance only when the current step's stated output and quality gate are satisfied. At each loop boundary, select the first unit in the current phase's declared order whose Unit Completion conditions are unsatisfied and that is not logged as a generation failure. A document path proves generation only.
 
 ## Step 0: Initial Configuration
 
@@ -62,10 +64,6 @@ Phase 2: Design Doc Generation (if requested)
 ```
 
 ## Phase 1: PRD Generation
-
-**Register using TaskCreate**:
-- Step 1: PRD Scope Discovery
-- Per-unit processing (Steps 2-5 for each unit)
 
 ### Step 1: PRD Scope Discovery
 
@@ -196,10 +194,6 @@ prompt: |
 ## Phase 2: Design Doc Generation
 
 *Execute only if Design Docs were requested in Step 0*
-
-**Register using TaskCreate**:
-- Step 6: Design Doc Scope Mapping
-- Per-unit processing (Steps 7-10 for each unit)
 
 ### Step 6: Design Doc Scope Mapping
 

--- a/dev-workflows/skills/recipe-review/SKILL.md
+++ b/dev-workflows/skills/recipe-review/SKILL.md
@@ -4,6 +4,8 @@ description: Design Doc compliance and security validation with optional auto-fi
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before making workflow decisions, invoking agents, or resolving findings.
 
@@ -18,7 +20,7 @@ Execute Skill: subagents-orchestration-guide before making workflow decisions, i
 **Review Resolution Gate [MANDATORY]**: Resolve every actionable deliverable-review finding through subagents-orchestration-guide `Review Resolution` before correction or progression.
 Before the first finding disposition, read `references/review-resolution.md` from the loaded subagents-orchestration-guide skill.
 
-**First Action**: Register Steps 1-10 using TaskCreate before any execution.
+**Execution Gate**: Complete Steps 1-10 in order, following only the branches activated by their stated conditions. Advance through each review, correction, and re-validation transition only at its declared convergence condition. Present the final report after every applicable finding and retained quality limitation reaches its required disposition or retry result.
 
 ## Execution Method
 

--- a/dev-workflows/skills/recipe-task/SKILL.md
+++ b/dev-workflows/skills/recipe-task/SKILL.md
@@ -4,6 +4,8 @@ description: Execute tasks following appropriate rules with rule-advisor metacog
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before making workflow decisions, invoking agents, or resolving findings.
 
@@ -40,23 +42,15 @@ After receiving rule-advisor's JSON response, proceed with:
    - Start with recommended action
    - Use suggested tools first
 
-**Step 3: Create Task List with TaskCreate**
+**Step 3: Bind the Execution Sequence**
 
-Register work steps using TaskCreate. Use "Select and map applicable rules" as the first task and "Verify selected rules and report completion" as the final task.
-
-Break down the task based on rule-advisor's guidance:
-- Reflect `taskAnalysis.essence` in task descriptions
-- Apply `metaCognitiveGuidance.firstStep` to first task
-- Restructure tasks considering `warningPatterns`
-- Set priorities based on dependency order and warningPatterns severity
-- Update each task with TaskUpdate as execution progresses
+Before implementation, derive the smallest dependency-ordered sequence required by the rule-advisor result. Its first gate applies and maps the selected rules; its final gate verifies those rules and the requested outcome. Execute one gate at a time, advancing only when its required evidence exists. Add or reorder a gate only when new evidence changes a dependency or completion condition.
 
 **Step 4: Execute Implementation**
 
 Proceed with task execution following:
 - Start with `metaCognitiveGuidance.firstStep` action from rule-advisor
-- Update task structure with TaskUpdate to reflect rule-advisor insights
 - Selected rules from rule-advisor
-- Task structure (managed via TaskCreate/TaskUpdate)
+- Dependency-ordered execution sequence from Step 3
 - Quality standards from the selected skills and sections named by rule-advisor
 - Monitor warningPatterns flags throughout execution and adjust approach when triggered

--- a/dev-workflows/skills/recipe-update-doc/SKILL.md
+++ b/dev-workflows/skills/recipe-update-doc/SKILL.md
@@ -4,6 +4,8 @@ description: Update existing design documents (Design Doc / PRD / ADR) with revi
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before making workflow decisions, invoking agents, or resolving findings.
 
@@ -18,7 +20,7 @@ Execute Skill: subagents-orchestration-guide before making workflow decisions, i
 **Review Resolution Gate [MANDATORY]**: Resolve every actionable deliverable-review finding through subagents-orchestration-guide `Review Resolution` before correction or progression.
 Before the first finding disposition, read `references/review-resolution.md` from the loaded subagents-orchestration-guide skill.
 
-**First Action**: Register Steps 1-6 using TaskCreate before any execution.
+**Execution Gate**: Complete Steps 1-6 in order, following only the branches activated by document type and review result. Advance only through each step's stated evidence, review convergence, or approval condition. Complete after the final approval gate and every applicable Completion Criterion is satisfied.
 
 **Execution Protocol**:
 1. **Invoke named specialists for deliverable production** — pass deliverable paths between them and validate their results (see subagents-orchestration-guide "Orchestrator Execution Boundary")

--- a/dev-workflows/skills/subagents-orchestration-guide/SKILL.md
+++ b/dev-workflows/skills/subagents-orchestration-guide/SKILL.md
@@ -7,6 +7,8 @@ description: Guides subagent coordination through implementation workflows. Use 
 
 ## Role: The Orchestrator
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in the invoked recipe. Execute each applicable call when its prerequisites are met.
+
 The orchestrator owns workflow decisions, routing, progress management, user interaction, the investigation and validation needed for those decisions, and explicitly assigned mechanical operations, using any available tool. Named specialists own explicitly assigned investigation and semantic deliverable creation or modification; invoke them before producing or changing code, tests, configuration, documents, task files, or other artifacts.
 
 ### Workflow Subagent Context — Mandatory
@@ -154,6 +156,8 @@ Rules:
 - `task-decomposer` begins only after work plan review (document-reviewer, doc_type WorkPlan; Medium/Large) and batch approval
 - Work plan review runs Review Resolution through its correction re-review, escalation, and convergence transitions; batch approval is available only at its convergence condition
 
+Treat the applicable Structural Scale flow as an evidence-gated sequence. Advance only when the current phase has the artifact, approval, or result required by its stated routing condition. Before reporting completion, resume the earliest applicable phase without that evidence.
+
 ## Autonomous Execution Mode
 
 ### Pre-Execution Gate
@@ -206,7 +210,7 @@ For Small, execute one direct-scope 4-step cycle. Complete after `approved`, or 
 | A requirement changes | Apply Requirement Change Detection above. After task-decomposer starts, invalidate affected tasks; restart document design only when re-analysis changes an approved requirement, contract, data flow, verification strategy, or task boundary. |
 | The user stops or interrupts | Stop autonomous execution. |
 
-### Task Management: 4-Step Cycle
+### Task Execution Cycle
 
 #### Commit Boundary Check
 
@@ -239,8 +243,6 @@ Derive the values from the quality-fixer result. Keep the complete result in orc
    - `verification_incomplete` → Retain the complete result for final retry and proceed to step 4
    - `approved` → Proceed to step 4
 4. **Commit**: apply Commit Boundary Check, then compose the message from `changeSummary` and execute git commit with Bash after `approved` or `verification_incomplete`; append the verification trailers for the latter
-
-Register overall phases using TaskCreate and update each phase with TaskUpdate as it completes.
 
 Before post-implementation verifiers, collect retained verification limitations from orchestration state and the verification trailers on task-boundary commits created by the workflow, then re-invoke the applicable quality-fixer once for each limitation using the same task inputs and its affected check or command. Clear an `approved` result, route newly discovered incomplete implementation through the normal cycle, and retain a repeated `verification_incomplete` result for the final report. Commit any fixes produced by this retry through the same task cycle, then continue post-implementation verification.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-workflows",
-  "version": "0.24.6",
+  "version": "0.24.7",
   "private": true,
   "type": "module",
   "engines": {

--- a/skills/recipe-add-integration-tests/SKILL.md
+++ b/skills/recipe-add-integration-tests/SKILL.md
@@ -4,6 +4,8 @@ description: Add integration/E2E tests to existing codebase using Design Docs
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before making workflow decisions, invoking agents, or resolving findings.
 
@@ -18,7 +20,7 @@ Execute Skill: subagents-orchestration-guide before making workflow decisions, i
 **Review Resolution Gate [MANDATORY]**: Resolve every actionable deliverable-review finding through subagents-orchestration-guide `Review Resolution` before correction or progression.
 Before the first finding disposition, read `references/review-resolution.md` from the loaded subagents-orchestration-guide skill.
 
-**First Action**: Register Steps 1-7 using TaskCreate before any execution.
+**Execution Gate**: Complete Steps 1-7 in order for each generated layer. Advance only through the current step's stated output or response gate; skip work only when its stated condition is false. Report completion after every layer has completed its review, quality, commit, and retained-limitation retry.
 
 **Why Delegate**: Orchestrator's context is shared across all steps. Direct implementation consumes context needed for review and quality check phases. Subagents work in isolated context.
 

--- a/skills/recipe-build/SKILL.md
+++ b/skills/recipe-build/SKILL.md
@@ -4,6 +4,8 @@ description: Execute materialized task files in autonomous execution mode
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before making workflow decisions, invoking agents, or resolving findings.
 
@@ -20,7 +22,7 @@ Before the first finding disposition, read `references/review-resolution.md` fro
 1. **Invoke named specialists for deliverable production** — pass deliverable paths between them and validate their results (see subagents-orchestration-guide "Orchestrator Execution Boundary")
 2. **Follow the 4-step task cycle exactly**: execute → branch on executor result → quality-fix → commit
 3. **Enter autonomous mode** when user provides execution instruction with existing task files — this IS the batch approval
-4. **Scope**: Complete when all tasks are committed or escalation occurs
+4. **Scope**: Complete consumed task-set execution, post-implementation verification, consumed-task cleanup, and completion reporting in order, or stop autonomous execution at the current phase for a valid user-owned escalation. Advance only when the current phase's stated transition condition is satisfied.
 
 **CRITICAL**: Run quality-fixer before every commit.
 
@@ -85,8 +87,6 @@ Recompute the Consumed Task Set using the same restricted pattern from the Consu
 
 ## Task Execution Cycle (4-Step Cycle)
 **MANDATORY EXECUTION CYCLE**: `execute → branch on executor result → quality-fix → commit`
-
-Before the loop, register `"Execute consumed task set"`, `"Run post-implementation verification"`, `"Clean up consumed task files"`, and `"Report completion"` once with TaskCreate; mark and advance the active phase with TaskUpdate.
 
 For EACH task in the Consumed Task Set, YOU MUST:
 1. **EXECUTE**: invoke Agent tool (subagent_type: "dev-workflows:task-executor") → Record the current HEAD as `diffBase`, pass `task_file: [path]`, and receive the structured response

--- a/skills/recipe-design/SKILL.md
+++ b/skills/recipe-design/SKILL.md
@@ -4,6 +4,8 @@ description: Execute from codebase-scoped analysis through optional ADR decision
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: documentation-criteria before document routing or creation.
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before invoking agents or resolving findings.

--- a/skills/recipe-diagnose/SKILL.md
+++ b/skills/recipe-diagnose/SKILL.md
@@ -4,6 +4,8 @@ description: Investigate problem, verify findings, and derive solutions
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before making workflow decisions, invoking agents, or resolving findings.
 
@@ -26,7 +28,7 @@ Orchestrator invokes sub-agents and passes structured JSON between them.
 
 At each Agent invocation below, build the prompt as a mechanical extraction: copy the named source values into the exact fields, apply only the declared serialization, then invoke immediately.
 
-**Task Registration**: Register execution steps using TaskCreate and proceed systematically. Update status using TaskUpdate.
+**Execution Gate**: Each step below establishes evidence required by the next decision. Complete Steps 0-7 in order, including every required investigation and verification retry. Advance only through the current step's stated quality or coverage condition; invoke solver only after coverage is closed.
 
 ## Step 0: Problem Structuring (Before investigator invocation)
 
@@ -89,8 +91,6 @@ material evidence unavailable → limitation/block report
 **Context Separation**: Pass only structured JSON output to each step. Each step starts fresh with the JSON data only.
 
 ## Execution Steps
-
-Register the following using TaskCreate and execute:
 
 ### Step 1: Investigation (investigator)
 

--- a/skills/recipe-front-adjust/SKILL.md
+++ b/skills/recipe-front-adjust/SKILL.md
@@ -4,6 +4,8 @@ description: Adjust an already-implemented UI in-session with verification again
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 
 **Context**: UI adjustment on already-implemented features. The verification loop (edit → check against the design source → refine) runs in the parent session.
@@ -17,9 +19,9 @@ Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or g
 2. **Run in the parent session** (multi-step loops and user dialogs): external-resource hearing via AskUserQuestion, write-set inspection, scale judgment, adjustment-context approval, adjustment edits, verification against the design source, iteration until acceptance.
 3. **Stop at every `[Stop: ...]` marker** before proceeding.
 
-## Initial Mandatory Tasks
+## Execution Gate
 
-**Task Registration**: Before Step 1, register the recipe's execution flow using TaskCreate so progress is trackable. Register Steps 1-7 below as individual tasks plus a final task "Verify completion against Completion Criteria". Update status using TaskUpdate as each step starts and completes.
+Complete Steps 1-7 in order for each adjustment unit. Advance only through the current step's stated evidence, quality result, or user stop; skip work only when its stated condition is false. Report completion after every applicable Completion Criterion and retained-limitation retry is satisfied.
 
 ## Workflow Overview
 

--- a/skills/recipe-front-build/SKILL.md
+++ b/skills/recipe-front-build/SKILL.md
@@ -4,6 +4,8 @@ description: Execute materialized frontend task files in autonomous execution mo
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before making workflow decisions, invoking agents, or resolving findings.
 
@@ -20,7 +22,7 @@ Before the first finding disposition, read `references/review-resolution.md` fro
 1. **Invoke named specialists for deliverable production** — pass deliverable paths between them and validate their results (see subagents-orchestration-guide "Orchestrator Execution Boundary")
 2. **Follow the 4-step task cycle exactly**: execute → branch on executor result → quality-fix → commit
 3. **Enter autonomous mode** when user provides execution instruction with existing task files — this IS the batch approval
-4. **Scope**: Complete when all tasks are committed or escalation occurs
+4. **Scope**: Complete consumed task-set execution, post-implementation verification, consumed-task cleanup, and completion reporting in order, or stop autonomous execution at the current phase for a valid user-owned escalation. Advance only when the current phase's stated transition condition is satisfied.
 
 **CRITICAL**: Run quality-fixer-frontend before every commit.
 
@@ -85,8 +87,6 @@ Recompute the Consumed Task Set using the same restricted pattern from the Consu
 
 ## Task Execution Cycle (4-Step Cycle)
 **MANDATORY EXECUTION CYCLE**: `execute → branch on executor result → quality-fix → commit`
-
-Before the loop, register `"Execute consumed task set"`, `"Run post-implementation verification"`, `"Clean up consumed task files"`, and `"Report completion"` once with TaskCreate; mark and advance the active phase with TaskUpdate.
 
 For EACH task in the Consumed Task Set, YOU MUST:
 1. **EXECUTE**: invoke Agent tool (subagent_type: "dev-workflows-frontend:task-executor-frontend") → Record the current HEAD as `diffBase`, pass `task_file: [path]`, and receive the structured response

--- a/skills/recipe-front-design/SKILL.md
+++ b/skills/recipe-front-design/SKILL.md
@@ -4,6 +4,8 @@ description: Execute from repository evidence through applicable UI Spec and opt
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: documentation-criteria before document routing or creation.
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before invoking agents or resolving findings.

--- a/skills/recipe-front-plan/SKILL.md
+++ b/skills/recipe-front-plan/SKILL.md
@@ -4,6 +4,8 @@ description: Create frontend work plan from design document and obtain plan appr
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before making workflow decisions, invoking agents, or resolving findings.
 

--- a/skills/recipe-front-review/SKILL.md
+++ b/skills/recipe-front-review/SKILL.md
@@ -4,6 +4,8 @@ description: Design Doc compliance and security validation with optional auto-fi
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before making workflow decisions, invoking agents, or resolving findings.
 
@@ -18,7 +20,7 @@ Execute Skill: subagents-orchestration-guide before making workflow decisions, i
 **Review Resolution Gate [MANDATORY]**: Resolve every actionable deliverable-review finding through subagents-orchestration-guide `Review Resolution` before correction or progression.
 Before the first finding disposition, read `references/review-resolution.md` from the loaded subagents-orchestration-guide skill.
 
-**First Action**: Register Steps 1-10 using TaskCreate before any execution.
+**Execution Gate**: Complete Steps 1-10 in order, following only the branches activated by their stated conditions. Advance through each review, correction, and re-validation transition only at its declared convergence condition. Present the final report after every applicable finding and retained quality limitation reaches its required disposition or retry result.
 
 ## Execution Method
 

--- a/skills/recipe-fullstack-build/SKILL.md
+++ b/skills/recipe-fullstack-build/SKILL.md
@@ -4,6 +4,8 @@ description: Execute materialized fullstack task files with layer-aware agent ro
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before making workflow decisions, invoking agents, or resolving findings.
 
@@ -28,7 +30,7 @@ Before the first finding disposition, read `references/review-resolution.md` fro
    - `*-frontend-task-*` → task-executor-frontend + quality-fixer-frontend
 3. **Follow the 4-step task cycle exactly**: execute → branch on executor result → quality-fix → commit
 4. **Enter autonomous mode** when user provides execution instruction with existing task files — this IS the batch approval
-5. **Scope**: Complete when all tasks are committed or escalation occurs
+5. **Scope**: Complete consumed task-set execution, post-implementation verification, consumed-task cleanup, and completion reporting in order, or stop autonomous execution at the current phase for a valid user-owned escalation. Advance only when the current phase's stated transition condition is satisfied.
 
 **CRITICAL**: Run layer-appropriate quality-fixer(s) before every commit.
 
@@ -103,8 +105,6 @@ Recompute the Consumed Task Set using the same restricted pattern from the Consu
 ### Task Execution (4-Step Cycle)
 
 **MANDATORY EXECUTION CYCLE**: `execute → branch on executor result → quality-fix → commit`
-
-Before the loop, register `"Execute consumed task set"`, `"Run post-implementation verification"`, `"Clean up consumed task files"`, and `"Report completion"` once with TaskCreate; mark and advance the active phase with TaskUpdate.
 
 For EACH task, YOU MUST:
 1. **EXECUTE**: invoke Agent tool (subagent_type per routing table) → Record the current HEAD as `diffBase`, pass `task_file: [path]`, and receive the structured response

--- a/skills/recipe-fullstack-implement/SKILL.md
+++ b/skills/recipe-fullstack-implement/SKILL.md
@@ -4,6 +4,8 @@ description: Orchestrate full-cycle implementation across backend and frontend l
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before making workflow decisions, invoking agents, or resolving findings.
 
@@ -68,9 +70,9 @@ Key points to enforce as the orchestrator runs the flow:
 - Pass all Design Docs to work-planner (subagent_type: "dev-workflows:work-planner") with vertical slicing instruction
 - Pass the Work Plan to document-reviewer (`doc_type: WorkPlan`) and request batch approval only after the review passes
 
-### 4. Register All Flow Steps Using TaskCreate (MANDATORY)
+### 4. Bind the Applicable Flow
 
-After scale determination, use TaskCreate to register each design/planning step and the implementation, verification, cleanup, and report phases. Complete registration before invoking subagents; mark and advance the active phase with TaskUpdate.
+After Structural Scale is determined, follow only that scale's applicable path. Treat each applicable design, review, approval, planning, implementation, verification, cleanup, and reporting phase as a gate. Advance only when the current phase's stated evidence or approval exists; skip only branches whose stated condition is false.
 
 ## After requirement-analyzer [Stop]
 

--- a/skills/recipe-implement/SKILL.md
+++ b/skills/recipe-implement/SKILL.md
@@ -4,6 +4,8 @@ description: Orchestrate the complete implementation lifecycle from requirements
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before making workflow decisions, invoking agents, or resolving findings.
 
@@ -71,9 +73,9 @@ When user responds to questions:
 - Repeat the hearing until every convergence field is `ready` or `weak-but-explicit`, then proceed with the resulting Scale.
 - For Small, the user's requirement confirmation authorizes the direct implementation scope; proceed to the 4-step cycle without a Work Plan.
 
-### 4. Register All Flow Steps Using TaskCreate (MANDATORY)
+### 4. Bind the Applicable Flow
 
-After scale determination, use TaskCreate to register the applicable design/planning steps and the implementation, verification, report, and Medium/Large cleanup phases. Complete registration before invoking subagents; mark and advance the active phase with TaskUpdate.
+After Structural Scale is determined, follow only that scale's applicable path. Treat each applicable design, review, approval, planning, implementation, verification, cleanup, and reporting phase as a gate. Advance only when the current phase's stated evidence or approval exists; skip only branches whose stated condition is false.
 
 ## Subagents Orchestration Guide Compliance Execution
 

--- a/skills/recipe-plan/SKILL.md
+++ b/skills/recipe-plan/SKILL.md
@@ -4,6 +4,8 @@ description: Create work plan from design document and obtain plan approval
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before making workflow decisions, invoking agents, or resolving findings.
 

--- a/skills/recipe-reverse-engineer/SKILL.md
+++ b/skills/recipe-reverse-engineer/SKILL.md
@@ -4,6 +4,8 @@ description: Generate PRD and Design Docs from existing codebase through discove
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before making workflow decisions, invoking agents, or resolving findings.
 
@@ -27,7 +29,7 @@ Before the first finding disposition, read `references/review-resolution.md` fro
 
 At each Agent invocation below, build the prompt as a mechanical extraction: copy the named source values into the exact fields, apply only the declared serialization, then invoke immediately.
 
-**Task Registration**: Register phases first using TaskCreate, then steps within each phase as you enter it. Update status using TaskUpdate.
+**Execution Gate**: Complete Phase 1 before Phase 2. Within each phase, complete one unit's generation, verification, review, and required revision to convergence before starting the next unit. Advance only when the current step's stated output and quality gate are satisfied. At each loop boundary, select the first unit in the current phase's declared order whose Unit Completion conditions are unsatisfied and that is not logged as a generation failure. A document path proves generation only.
 
 ## Step 0: Initial Configuration
 
@@ -62,10 +64,6 @@ Phase 2: Design Doc Generation (if requested)
 ```
 
 ## Phase 1: PRD Generation
-
-**Register using TaskCreate**:
-- Step 1: PRD Scope Discovery
-- Per-unit processing (Steps 2-5 for each unit)
 
 ### Step 1: PRD Scope Discovery
 
@@ -196,10 +194,6 @@ prompt: |
 ## Phase 2: Design Doc Generation
 
 *Execute only if Design Docs were requested in Step 0*
-
-**Register using TaskCreate**:
-- Step 6: Design Doc Scope Mapping
-- Per-unit processing (Steps 7-10 for each unit)
 
 ### Step 6: Design Doc Scope Mapping
 

--- a/skills/recipe-review/SKILL.md
+++ b/skills/recipe-review/SKILL.md
@@ -4,6 +4,8 @@ description: Design Doc compliance and security validation with optional auto-fi
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before making workflow decisions, invoking agents, or resolving findings.
 
@@ -18,7 +20,7 @@ Execute Skill: subagents-orchestration-guide before making workflow decisions, i
 **Review Resolution Gate [MANDATORY]**: Resolve every actionable deliverable-review finding through subagents-orchestration-guide `Review Resolution` before correction or progression.
 Before the first finding disposition, read `references/review-resolution.md` from the loaded subagents-orchestration-guide skill.
 
-**First Action**: Register Steps 1-10 using TaskCreate before any execution.
+**Execution Gate**: Complete Steps 1-10 in order, following only the branches activated by their stated conditions. Advance through each review, correction, and re-validation transition only at its declared convergence condition. Present the final report after every applicable finding and retained quality limitation reaches its required disposition or retry result.
 
 ## Execution Method
 

--- a/skills/recipe-task/SKILL.md
+++ b/skills/recipe-task/SKILL.md
@@ -4,6 +4,8 @@ description: Execute tasks following appropriate rules with rule-advisor metacog
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before making workflow decisions, invoking agents, or resolving findings.
 
@@ -40,23 +42,15 @@ After receiving rule-advisor's JSON response, proceed with:
    - Start with recommended action
    - Use suggested tools first
 
-**Step 3: Create Task List with TaskCreate**
+**Step 3: Bind the Execution Sequence**
 
-Register work steps using TaskCreate. Use "Select and map applicable rules" as the first task and "Verify selected rules and report completion" as the final task.
-
-Break down the task based on rule-advisor's guidance:
-- Reflect `taskAnalysis.essence` in task descriptions
-- Apply `metaCognitiveGuidance.firstStep` to first task
-- Restructure tasks considering `warningPatterns`
-- Set priorities based on dependency order and warningPatterns severity
-- Update each task with TaskUpdate as execution progresses
+Before implementation, derive the smallest dependency-ordered sequence required by the rule-advisor result. Its first gate applies and maps the selected rules; its final gate verifies those rules and the requested outcome. Execute one gate at a time, advancing only when its required evidence exists. Add or reorder a gate only when new evidence changes a dependency or completion condition.
 
 **Step 4: Execute Implementation**
 
 Proceed with task execution following:
 - Start with `metaCognitiveGuidance.firstStep` action from rule-advisor
-- Update task structure with TaskUpdate to reflect rule-advisor insights
 - Selected rules from rule-advisor
-- Task structure (managed via TaskCreate/TaskUpdate)
+- Dependency-ordered execution sequence from Step 3
 - Quality standards from the selected skills and sections named by rule-advisor
 - Monitor warningPatterns flags throughout execution and adjust approach when triggered

--- a/skills/recipe-update-doc/SKILL.md
+++ b/skills/recipe-update-doc/SKILL.md
@@ -4,6 +4,8 @@ description: Update existing design documents (Design Doc / PRD / ADR) with revi
 disable-model-invocation: true
 ---
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in this recipe. Execute each applicable call when its prerequisites are met.
+
 Execute Skill: llm-friendly-context before writing Agent prompts, handoffs, or generated artifacts.
 Execute Skill: subagents-orchestration-guide before making workflow decisions, invoking agents, or resolving findings.
 
@@ -18,7 +20,7 @@ Execute Skill: subagents-orchestration-guide before making workflow decisions, i
 **Review Resolution Gate [MANDATORY]**: Resolve every actionable deliverable-review finding through subagents-orchestration-guide `Review Resolution` before correction or progression.
 Before the first finding disposition, read `references/review-resolution.md` from the loaded subagents-orchestration-guide skill.
 
-**First Action**: Register Steps 1-6 using TaskCreate before any execution.
+**Execution Gate**: Complete Steps 1-6 in order, following only the branches activated by document type and review result. Advance only through each step's stated evidence, review convergence, or approval condition. Complete after the final approval gate and every applicable Completion Criterion is satisfied.
 
 **Execution Protocol**:
 1. **Invoke named specialists for deliverable production** — pass deliverable paths between them and validate their results (see subagents-orchestration-guide "Orchestrator Execution Boundary")

--- a/skills/subagents-orchestration-guide/SKILL.md
+++ b/skills/subagents-orchestration-guide/SKILL.md
@@ -7,6 +7,8 @@ description: Guides subagent coordination through implementation workflows. Use 
 
 ## Role: The Orchestrator
 
+**Explicit User Instruction**: The user explicitly instructs and authorizes every subagent call named in the invoked recipe. Execute each applicable call when its prerequisites are met.
+
 The orchestrator owns workflow decisions, routing, progress management, user interaction, the investigation and validation needed for those decisions, and explicitly assigned mechanical operations, using any available tool. Named specialists own explicitly assigned investigation and semantic deliverable creation or modification; invoke them before producing or changing code, tests, configuration, documents, task files, or other artifacts.
 
 ### Workflow Subagent Context — Mandatory
@@ -154,6 +156,8 @@ Rules:
 - `task-decomposer` begins only after work plan review (document-reviewer, doc_type WorkPlan; Medium/Large) and batch approval
 - Work plan review runs Review Resolution through its correction re-review, escalation, and convergence transitions; batch approval is available only at its convergence condition
 
+Treat the applicable Structural Scale flow as an evidence-gated sequence. Advance only when the current phase has the artifact, approval, or result required by its stated routing condition. Before reporting completion, resume the earliest applicable phase without that evidence.
+
 ## Autonomous Execution Mode
 
 ### Pre-Execution Gate
@@ -206,7 +210,7 @@ For Small, execute one direct-scope 4-step cycle. Complete after `approved`, or 
 | A requirement changes | Apply Requirement Change Detection above. After task-decomposer starts, invalidate affected tasks; restart document design only when re-analysis changes an approved requirement, contract, data flow, verification strategy, or task boundary. |
 | The user stops or interrupts | Stop autonomous execution. |
 
-### Task Management: 4-Step Cycle
+### Task Execution Cycle
 
 #### Commit Boundary Check
 
@@ -239,8 +243,6 @@ Derive the values from the quality-fixer result. Keep the complete result in orc
    - `verification_incomplete` → Retain the complete result for final retry and proceed to step 4
    - `approved` → Proceed to step 4
 4. **Commit**: apply Commit Boundary Check, then compose the message from `changeSummary` and execute git commit with Bash after `approved` or `verification_incomplete`; append the verification trailers for the latter
-
-Register overall phases using TaskCreate and update each phase with TaskUpdate as it completes.
 
 Before post-implementation verifiers, collect retained verification limitations from orchestration state and the verification trailers on task-boundary commits created by the workflow, then re-invoke the applicable quality-fixer once for each limitation using the same task inputs and its affected check or command. Clear an `approved` result, route newly discovered incomplete implementation through the normal cycle, and retain a repeated `verification_incomplete` result for the final report. Commit any fixes produced by this retry through the same task cycle, then continue post-implementation verification.
 


### PR DESCRIPTION
## Summary

- remove TaskCreate and TaskUpdate from agent tool declarations and replace task registration with evidence-gated workflow progression
- explicitly authorize recipe-defined subagent calls while preserving recipe-owned approval, hearing, stop, and escalation behavior
- align phase gates and execution headings, including bounded handling for retained verification limitations
- bump local plugin versions to 0.24.7 and sync all generated plugin directories

## Validation

- pnpm sync:check
- pnpm check:skills-index
- git diff --check
- claude plugin validate ./dev-workflows --strict
- claude plugin validate ./dev-workflows-frontend --strict
- claude plugin validate ./dev-workflows-fullstack --strict
- claude plugin validate ./dev-skills --strict