### PR TITLE
docs: add multilingual README translations

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,466 @@
+# Flujos de desarrollo para Claude Code
+
+[![Claude Code](https://img.shields.io/badge/Claude%20Code-Plugin-purple)](https://claude.ai/code)
+[![GitHub Stars](https://img.shields.io/github/stars/shinpr/claude-code-workflows?style=social)](https://github.com/shinpr/claude-code-workflows)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/shinpr/claude-code-workflows/pulls)
+
+[English](README.md) | [简体中文](README.zh-CN.md) | [日本語](README.ja.md) | **Español** | [한국어](README.ko.md) | [Português (Brasil)](README.pt-BR.md)
+
+Claude Code puede explorar una base de código a fondo. En trabajos complejos, el verdadero reto no es explorar, sino llegar a una conclusión. Mientras diseña un flujo de recuperación de cuentas, Claude podría detectar una inconsistencia real en el manejo de tokens y dedicarle casi todo el diseño, dejando impreciso el comportamiento de recuperación que se había solicitado.
+
+claude-code-workflows mantiene esa exploración enfocada en un resultado acordado. Antes de diseñar, define el objetivo y lo que queda fuera de alcance; contrasta los diseños con el repositorio; verifica cada tarea antes de hacer commit y, en cambios grandes, somete la implementación terminada a revisiones independientes de comportamiento y seguridad. Dentro de esos límites, Claude decide los detalles de implementación a partir de la base de código.
+
+Usa Claude Code directamente cuando el resultado y los límites seguros de implementación ya estén claros. Usa estos flujos cuando un cambio requiera acordar el alcance, conservar decisiones de diseño, transferir el trabajo entre contextos de forma confiable o contar con una verificación independiente.
+
+---
+
+## ¿Cuándo conviene usar estos flujos?
+
+El flujo añade llamadas a agentes y genera documentos, así que debe justificar ese costo. Resulta útil cuando un hallazgo secundario real puede desviar un cambio grande de su objetivo, cuando un diseño coherente podría no cubrir el comportamiento solicitado o cuando una prueba que pasa no observa en realidad aquello que afirma verificar.
+
+Una vez aprobado el alcance de implementación, Claude lleva las tareas por la verificación específica, los controles de calidad del repositorio, los commits y la revisión final, sin consultar decisiones rutinarias. Los cambios de producto y las decisiones importantes de diseño vuelven al usuario; Claude resuelve las decisiones de implementación reversibles. Al distribuirse como un plugin de Claude Code, un equipo puede aplicar los mismos controles en distintos repositorios sin imponerle a Claude una secuencia fija de pasos.
+
+---
+
+## Inicio rápido
+
+Requiere una versión de Claude Code compatible con el marketplace de plugins.
+
+### Elige un recorrido
+
+| ¿Qué necesitas? | Empieza con | Plugin |
+|---|---|---|
+| Entregar de principio a fin un cambio de backend, API, CLI o propósito general | `/recipe-implement` | `dev-workflows` |
+| Diseñar un cambio de backend o propósito general antes de implementarlo | `/recipe-design` | `dev-workflows` |
+| Diseñar e implementar un frontend en React / TypeScript | `/recipe-front-design` → `/recipe-front-plan` → `/recipe-front-build` | `dev-workflows-frontend` |
+| Entregar juntos un backend y un frontend React | `/recipe-fullstack-implement` | `dev-workflows-fullstack` |
+| Revisar una implementación contra su diseño | `/recipe-review` o `/recipe-front-review` | `dev-workflows` o `dev-workflows-frontend` |
+| Investigar un problema antes de elegir una solución | `/recipe-diagnose` | Cualquier plugin de flujos |
+| Documentar un sistema existente a partir del código | `/recipe-reverse-engineer` | `dev-workflows` o `dev-workflows-fullstack` |
+| Hacer un experimento descartable o un prototipo | Usa Claude Code directamente | Ninguno |
+
+### Configuración común
+
+```bash
+# 1. Inicia Claude Code
+claude
+
+# 2. Añade el marketplace
+/plugin marketplace add shinpr/claude-code-workflows
+```
+
+### Instala un solo plugin de flujos
+
+Instala el plugin adecuado para tu proyecto. Si la instalación te pide ejecutar `/reload-plugins`, hazlo antes de invocar una recipe.
+
+```bash
+# Backend o propósito general
+/plugin install dev-workflows@claude-code-workflows
+/recipe-implement "Add rate limiting to the public API"
+
+# Frontend
+/plugin install dev-workflows-frontend@claude-code-workflows
+/recipe-front-design "Add account recovery screens"
+
+# Full stack
+/plugin install dev-workflows-fullstack@claude-code-workflows
+/recipe-fullstack-implement "Add user authentication with JWT + login form"
+```
+
+Instala solo uno de los plugins de flujos. `dev-workflows-fullstack` ya incluye los flujos de backend y frontend. Si antes utilizabas las recipes full stack de `dev-workflows`, migra a `dev-workflows-fullstack`.
+
+`/recipe-front-design` se detiene después de que la UI Spec y el Design Doc aplicables hayan sido revisados y aprobados. Ejecuta `/recipe-front-plan` y `/recipe-front-build` cuando quieras continuar. Para backend o cambios generales, `/recipe-design`, `/recipe-plan` y `/recipe-build` ofrecen las mismas etapas.
+
+### Configuración para equipos
+
+Claude Code admite marketplaces y plugins con alcance de proyecto. Incluye el archivo `.claude/settings.json` resultante en el repositorio para que los colaboradores usen el mismo plugin.
+
+```bash
+claude plugin marketplace add shinpr/claude-code-workflows --scope project
+claude plugin install dev-workflows-fullstack@claude-code-workflows --scope project
+```
+
+Sustituye `dev-workflows-fullstack` por el plugin correspondiente a tu repositorio. Consulta la [documentación de plugins de Claude Code](https://code.claude.com/docs/en/discover-plugins#configure-team-marketplaces) para conocer las opciones de instalación con alcance de proyecto y de instalación administrada.
+
+---
+
+## Cómo funciona
+
+```mermaid
+flowchart LR
+    A[Request] --> B[Agree on outcome and exclusions]
+    B --> C{One evident implementation path?}
+    C -->|Yes| S[Direct task cycle]
+    S --> J[Complete]
+    C -->|No| D[Inspect, design, and review]
+    D --> E[Approve implementation scope]
+    E --> F[Per task: implement, verify, quality-check, commit]
+    F --> I[Independent implementation and security review]
+    I -->|Correction| F
+    I -->|Boundary changed| B
+    I -->|Passed| J[Complete]
+```
+
+El recorrido depende de la cantidad de decisiones de producto y diseño, no del número de archivos ni del volumen de implementación.
+
+| Escala | Qué necesita el cambio | Qué ocurre |
+|---|---|---|
+| Small | Un resultado que sigue un patrón existente dentro de una sola responsabilidad | Ciclo directo de tareas → controles específicos y del repositorio → revisión de seguridad |
+| Medium | Un resultado que cruza responsabilidades o requiere una decisión de diseño duradera | Design Doc revisado, más UI Spec / ADR cuando corresponda → verificación de integración/E2E seleccionada → Work Plan revisado → ciclos de tareas → revisión final |
+| Large | Varios resultados de producto independientes que requieren decisiones de diseño separadas | PRD y Design Docs revisados, más UI Spec / ADR cuando corresponda → verificación de integración/E2E seleccionada → Work Plan revisado → ciclos de tareas → revisión final |
+
+Las UI Specs, los ADR y los esqueletos de pruebas de integración o E2E solo aparecen cuando hacen falta sus decisiones o sus límites de verificación.
+
+Generar un documento no hace avanzar el flujo por sí solo. Las afirmaciones del diseño se comprueban contra el repositorio antes de aprobarlo. El Work Plan se revisa para comprobar cobertura, orden de dependencias y verificaciones ejecutables antes de autorizar la implementación. Cada tarea se incorpora a un commit solo después de pasar sus controles específicos y los controles aplicables del repositorio. Al terminar la implementación por etapas, revisiones separadas examinan la coherencia con el diseño, la cobertura observable y la seguridad.
+
+La sesión principal decide qué hallazgos pertenecen al resultado actual, resuelve preguntas de implementación a partir del repositorio y mantiene en marcha el trabajo no afectado. Las sugerencias de una revisión no se convierten automáticamente en tareas. Las correcciones aceptadas vuelven a implementación y atraviesan de nuevo los controles correspondientes.
+
+### Cómo sobreviven las decisiones a nuevos contextos
+
+Usar un contexto nuevo para cada fase evita que el razonamiento de una fase se convierta silenciosamente en la autoridad de la siguiente. La [plantilla de Work Plan](skills/documentation-criteria/references/plan-template.md) incluida exige que cada requisito técnico aprobado en un Design Doc tenga una tarea que lo cubra o una brecha explícita. No convierte cada sección del documento ni cada sugerencia de revisión en una tarea. Una brecha significa que un requisito aprobado todavía no tiene una tarea de implementación o verificación.
+
+```markdown
+| Design Doc | DD Section | DD Item | Category | Covered By Task(s) | Gap Status | Notes |
+|---|---|---|---|---|---|---|
+| docs/design/example.md | API contract | Preserve the error response shape | contract-change | Phase 2 Task 1 | covered | |
+| docs/design/example.md | Verification | Exercise cache invalidation | verification | | gap | Add a covering task before approval |
+```
+
+La [plantilla de Task](skills/documentation-criteria/references/task-template.md) lleva a implementación las decisiones obligatorias y los valores observables de los contratos, cada uno con una comprobación de cumplimiento que se responde con sí o no. Después de ejecutar la tarea, los controles aplicables del repositorio se ejecutan sobre el cambio completo antes del commit. Los revisores finales leen las mismas fuentes aprobadas y el código terminado, en lugar de depender de la conversación de implementación.
+
+### Una ejecución real
+
+La [sincronización incremental de mcp-local-rag](https://github.com/shinpr/mcp-local-rag/pull/171) fue un cambio de 42 archivos que abarcó el escaneo del sistema de archivos, el almacenamiento, la CLI y las interfaces MCP. Una revisión de seguridad independiente devolvió la implementación dos veces. Detectó lecturas de archivos antes de la validación y una forma de escapar de los límites de ruta mediante un directorio padre enlazado simbólicamente.
+
+La ejecución comenzó con un Work Plan existente que hacía referencia a un ADR y un Design Doc ausentes, por lo que no estaba clara la fuente aprobada para las decisiones técnicas. El usuario eligió tratar el Work Plan como fuente de autoridad y el flujo lo dividió en 13 tareas. La implementación final incluyó los cambios necesarios para verificar el comportamiento aprobado, mientras que el PR dejó constancia de por qué el modo watch y los trabajos persistentes quedaron fuera de alcance.
+
+### Qué revisar después de la primera ejecución
+
+- ¿El enfoque acordado amplía lo que ya existe y aporta evidencia para cada añadido?
+- ¿Puedes seguir cada requisito hasta una tarea y un método de verificación observable?
+- ¿Cada tarea terminada pasó los controles específicos y del repositorio antes del commit?
+- ¿La revisión final comparó el cambio completo con el comportamiento esperado y los requisitos de seguridad?
+- Cuando un revisor propuso más trabajo, ¿el informe explica por qué se aplicó o se descartó?
+
+---
+
+## Flujos habituales
+
+### Desarrollo completo de backend o propósito general
+
+```bash
+/recipe-implement "Add rate limiting to the public API"
+```
+
+El flujo delimita el cambio, inspecciona la implementación actual, crea únicamente los documentos necesarios para las decisiones y se detiene cuando hace falta una aprobación. Después continúa con la implementación planificada y la revisión final.
+
+### Diseñar primero e implementar más tarde
+
+```bash
+# Backend o propósito general
+/recipe-design "Design rate limiting for the public API"
+/recipe-plan
+/recipe-build
+
+# Frontend React
+/recipe-front-design "Build a user profile dashboard"
+/recipe-front-plan
+/recipe-front-build
+```
+
+Los flujos de diseño inspeccionan la implementación existente, confirman el alcance, crean los documentos necesarios, realizan una revisión de coherencia independiente y se detienen para solicitar aprobación. La planificación y la implementación pueden continuar más adelante, en un contexto nuevo o a cargo de otra persona, a partir de esos documentos aprobados.
+
+El recorrido de frontend añade análisis de UI y una UI Spec cuando todavía hay que diseñar la estructura o el comportamiento de la interfaz, además de arquitectura de componentes, React Testing Library y controles de TypeScript.
+
+Por ejemplo, dos componentes de un panel pueden manejar correctamente sus estados de carga por separado, pero la pantalla combinada quizá no defina qué ocurre si uno sigue cargando y el otro falla. La UI Spec registra esa combinación de estados y la vincula con el trabajo de diseño y pruebas antes de integrar los componentes.
+
+### Desarrollo full stack
+
+```bash
+/recipe-fullstack-implement "Add user authentication with JWT + React login form"
+```
+
+Cuando el cambio contiene varios resultados de producto independientes, un único PRD cubre toda la funcionalidad. Los diseños de backend y frontend permanecen separados, `design-sync` comprueba el límite entre ambos y el Work Plan utiliza cortes verticales para probar la integración desde el principio.
+
+Usa `/recipe-fullstack-build` para continuar desde un Work Plan full stack existente. El plugin full stack también incluye los flujos de backend y frontend aplicables.
+
+<details>
+<summary>Más ejemplos de flujos</summary>
+
+#### Revisar una implementación contra su diseño
+
+```bash
+/recipe-review
+```
+
+El flujo de revisión compara la implementación con los Design Docs y ejecuta una revisión de seguridad independiente. Una corrección que cambie una decisión aprobada vuelve al documento correspondiente en vez de modificar el contrato de forma silenciosa.
+
+#### Investigar antes de elegir una solución
+
+```bash
+/recipe-diagnose "API returns 500 on user login"
+```
+
+El flujo de diagnóstico traza las rutas de ejecución, verifica posibles puntos de fallo y presenta las ventajas y desventajas de cada solución. No modifica el código.
+
+#### Documentar un sistema existente desde el código
+
+```bash
+/recipe-reverse-engineer "src/auth module"
+```
+
+Este flujo deriva PRD y Design Docs del código y los verifica contra la implementación. Usa la opción full stack cuando la funcionalidad abarque backend y frontend.
+
+Consulta [How I Made Legacy Code AI-Friendly with Auto-Generated Docs](https://dev.to/shinpr/how-i-made-legacy-code-ai-friendly-with-auto-generated-docs-4353) para ver un ejemplo completo.
+
+#### Ajustar una UI implementada según una fuente de diseño
+
+```bash
+/recipe-front-adjust "Align the card spacing and actions with the design source"
+```
+
+El plugin de frontend registra cómo llegar a la fuente de diseño externa, confirma el conjunto de archivos a modificar y repite la verificación visual hasta que el ajuste pasa los controles.
+
+</details>
+
+---
+
+## Referencia de recipes
+
+Todos los puntos de entrada usan el prefijo `recipe-`. Escribe `/recipe-` y usa Tab para ver las opciones instaladas.
+
+<details>
+<summary>Ver todas las recipes de backend y propósito general</summary>
+
+| Recipe | Finalidad | Cuándo usarla |
+|---|---|---|
+| `/recipe-implement` | Implementar una funcionalidad de principio a fin | Funcionalidades nuevas y flujos completos |
+| `/recipe-design` | Crear documentación de diseño | Planificación de arquitectura |
+| `/recipe-plan` | Generar un Work Plan a partir del diseño | Fase de planificación |
+| `/recipe-build` | Ejecutar un Work Plan existente | Retomar una implementación |
+| `/recipe-review` | Verificar la implementación contra los Design Docs | Comprobación posterior a la implementación |
+| `/recipe-diagnose` | Investigar un problema y comparar soluciones | Análisis de causa raíz |
+| `/recipe-reverse-engineer` | Derivar PRD y Design Docs del código | Documentación de sistemas existentes |
+| `/recipe-add-integration-tests` | Añadir pruebas de integración o E2E | Cobertura de código existente |
+| `/recipe-update-doc` | Actualizar y revisar documentos existentes | Cambios de requisitos o diseño |
+| `/recipe-task` | Ejecutar directamente una tarea guiada por reglas | Trabajo que no requiere traspasos entre etapas |
+
+</details>
+
+<details>
+<summary>Ver todas las recipes de frontend</summary>
+
+El plugin de frontend añade análisis específico de React, arquitectura de componentes, React Testing Library, controles de TypeScript y la generación de una UI Spec a partir de código de prototipo cuando corresponda.
+
+| Recipe | Finalidad | Cuándo usarla |
+|---|---|---|
+| `/recipe-front-design` | Crear la UI Spec y el Design Doc de frontend aplicables | Arquitectura de componentes React |
+| `/recipe-front-plan` | Generar un Work Plan de frontend | Planificación de componentes |
+| `/recipe-front-build` | Ejecutar el Work Plan de frontend | Retomar una implementación React |
+| `/recipe-front-adjust` | Ajustar una UI implementada con verificación externa | Mejoras visuales |
+| `/recipe-front-review` | Verificar la implementación contra los Design Docs de frontend | Comprobación posterior a la implementación |
+| `/recipe-diagnose` | Investigar un problema y comparar soluciones | Análisis de causa raíz |
+| `/recipe-update-doc` | Actualizar y revisar documentos existentes | Cambios de requisitos o diseño |
+| `/recipe-task` | Ejecutar directamente una tarea guiada por reglas | Trabajo que no requiere traspasos entre etapas |
+
+</details>
+
+---
+
+## Qué incluyen los plugins
+
+Los agentes especializados mantienen separados el análisis y el diseño de la ejecución y la revisión final. Cada plugin incluye solo los roles que usan sus flujos; el plugin full stack combina los roles de backend y frontend. La lista completa está disponible a continuación.
+
+<details>
+<summary>Ver todos los roles de agentes especializados</summary>
+
+### Agentes compartidos
+
+Estos agentes se comparten entre los plugins de backend, frontend y full stack:
+
+| Agente | Función |
+|---|---|
+| **requirement-analyzer** | Reúne evidencia concisa sobre alcance y costo para las decisiones de requisitos y flujo del orquestador |
+| **prd-creator** | Define requisitos de producto para funcionalidades grandes |
+| **codebase-analyzer** | Inspecciona el código y las dependencias existentes antes del diseño |
+| **code-verifier** | Compara los documentos con la implementación |
+| **work-planner** | Convierte las decisiones de diseño en un Work Plan ejecutable |
+| **task-decomposer** | Divide un Work Plan en tareas listas para commit |
+| **acceptance-test-generator** | Crea esqueletos de pruebas de integración y E2E a partir de requisitos |
+| **integration-test-reviewer** | Revisa las pruebas de integración y E2E contra la cobertura prevista |
+| **code-reviewer** | Comprueba la implementación contra los Design Docs |
+| **document-reviewer** | Comprueba la integridad del documento y el cumplimiento de las reglas |
+| **design-sync** | Detecta conflictos entre varios Design Docs |
+| **investigator** | Traza rutas de ejecución e identifica posibles puntos de fallo |
+| **verifier** | Cuestiona los puntos de fallo sospechosos y comprueba la cobertura de rutas |
+| **solver** | Compara soluciones y sus trade-offs |
+| **security-reviewer** | Revisa la implementación terminada en busca de problemas de seguridad |
+| **rule-advisor** | Selecciona las reglas de desarrollo pertinentes para la tarea |
+
+### Agentes específicos de backend
+
+| Agente | Función |
+|---|---|
+| **technical-designer** | Diseña el enfoque técnico y la arquitectura |
+| **scope-discoverer** | Encuentra límites funcionales en la implementación existente |
+| **task-executor** | Implementa tareas de backend con verificación orientada por pruebas |
+| **quality-fixer** | Ejecuta pruebas, controles de tipos, lint y otros controles de calidad |
+
+### Agentes específicos de frontend
+
+| Agente | Función |
+|---|---|
+| **ui-spec-designer** | Crea una UI Spec a partir de requisitos y un prototipo opcional |
+| **ui-analyzer** | Obtiene fuentes y sistemas de diseño, consulta las guías e inspecciona la UI existente |
+| **technical-designer-frontend** | Diseña la arquitectura de componentes React y la gestión de estado |
+| **task-executor-frontend** | Implementa componentes React con cobertura basada en React Testing Library |
+| **quality-fixer-frontend** | Ejecuta pruebas de frontend, controles de TypeScript, lint y builds |
+
+</details>
+
+<details>
+<summary>Ver las guías de desarrollo incluidas</summary>
+
+- **Coding Principles.** Estándares de calidad del código.
+- **Testing Principles.** TDD, cobertura y patrones de pruebas.
+- **Implementation Approach.** Decisiones de implementación y sus trade-offs.
+- **Documentation Standards.** Documentación clara y mantenible.
+- **External Resource Context.** Registra cómo llegar a fuentes y sistemas de diseño, esquemas de API, definiciones de infraestructura y otros recursos externos.
+- **LLM-Friendly Context.** Prompts, entregas, documentos e instrucciones claras para que los agentes posteriores puedan trabajar sin adivinar.
+
+Los agentes cargan estas skills cuando el trabajo las requiere. El plugin de frontend también incluye reglas específicas de React y TypeScript.
+
+</details>
+
+<details>
+<summary>Usar las guías sin el flujo (dev-skills)</summary>
+
+Si ya tienes orquestación mediante prompts propios o CI y solo necesitas guías de buenas prácticas, usa `dev-skills`. Si quieres que Claude planifique, ejecute y verifique el cambio de principio a fin, instala el plugin de flujos adecuado.
+
+- Uso mínimo de contexto, sin agentes
+- Guías de desarrollo, pruebas, diseño y documentación sin imponer un proceso
+- Carga automática de las skills pertinentes para cada tarea
+
+> **No instales `dev-skills` junto con un plugin de flujos.** Comparten las mismas skills y las descripciones duplicadas pueden hacer que Claude Code las ignore después de alcanzar su límite de contexto.
+
+```bash
+/plugin install dev-skills@claude-code-workflows
+```
+
+Para cambiar de tipo de plugin:
+
+```bash
+# dev-skills -> dev-workflows
+/plugin uninstall dev-skills@claude-code-workflows
+/plugin install dev-workflows@claude-code-workflows
+
+# dev-workflows -> dev-skills
+/plugin uninstall dev-workflows@claude-code-workflows
+/plugin install dev-skills@claude-code-workflows
+```
+
+</details>
+
+<details>
+<summary>Ver complementos opcionales</summary>
+
+Estos plugins cubren funciones relacionadas sin cambiar el flujo principal:
+
+- [claude-code-discover](https://github.com/shinpr/claude-code-discover): convierte ideas de funcionalidades en PRD respaldados por evidencia.
+- [metronome](https://github.com/shinpr/metronome): detecta atajos y pide a Claude que siga el procedimiento definido.
+- [linear-prism](https://github.com/shinpr/linear-prism): valida requisitos y los convierte en tareas estructuradas de Linear.
+- [pr-review](https://github.com/shinpr/pr-review-skill): revisa PR de GitHub con criterios propios del repositorio y publica únicamente los hallazgos aprobados.
+
+```bash
+/plugin install discover@claude-code-workflows
+/plugin install metronome@claude-code-workflows
+/plugin install linear-prism@claude-code-workflows
+/plugin install pr-review@claude-code-workflows
+```
+
+</details>
+
+---
+
+## Preguntas frecuentes
+
+**P: ¿Qué ocurre si hay errores?**
+
+R: Los agentes quality-fixer resuelven fallos de pruebas, tipos, lint y build dentro del resultado aprobado, incluidos los cambios adyacentes necesarios para la misma responsabilidad o contrato.
+
+El flujo solo se detiene cuando una corrección:
+
+- cambia el resultado de producto, un contrato aprobado o una decisión importante de diseño;
+- requiere una autorización que solo tiene el usuario;
+- realiza una acción externa irreversible que no está cubierta por la autorización existente.
+
+**P: ¿Existe una versión para OpenAI Codex CLI?**
+
+R: Sí. **[codex-workflows](https://github.com/shinpr/codex-workflows)** ofrece el mismo modelo de flujo, adaptado al entorno de Codex CLI.
+
+**P: ¿Debo incluir en los commits el Work Plan y los archivos de tareas de `docs/plans/`?**
+
+R: No. Los flujos tratan `docs/plans/` como estado de trabajo temporal. Los archivos de tareas consumidos y los archivos de correcciones intermedias se eliminan al terminar correctamente. El Work Plan puede permanecer para una revisión o una ejecución posterior y se puede borrar cuando deje de ser necesario. Añade esta línea al `.gitignore` de tu proyecto para que ese estado no quede bajo control de versiones:
+
+```
+docs/plans/
+```
+
+Los PRD, ADR, UI Specs y Design Docs se guardan en `docs/prd/`, `docs/adr/`, `docs/ui-spec/` y `docs/design/`, respectivamente, y sí están destinados a formar parte del repositorio.
+
+---
+
+## Contribuir plugins externos
+
+Este marketplace cubre el ciclo completo de creación de productos con IA: calidad del producto, descubrimiento, control de la implementación y verificación. Si tu plugin ayuda a los agentes de programación a crear mejores productos, nos interesa conocerlo.
+
+Consulta [CONTRIBUTING.md](CONTRIBUTING.md) para ver las instrucciones y los criterios de aceptación.
+
+<details>
+<summary>Ver la estructura del repositorio</summary>
+
+```
+claude-code-workflows/
+├── .claude-plugin/
+│   └── marketplace.json        # Plugin definitions and per-plugin contents
+├── agents/                     # Specialized analysis, design, execution, and review roles
+├── skills/
+│   ├── recipe-*/               # Workflow entry points
+│   ├── documentation-criteria/ # Document rules and templates
+│   ├── coding-principles/
+│   ├── testing-principles/
+│   ├── external-resource-context/
+│   ├── llm-friendly-context/
+│   └── ...
+├── LICENSE
+└── README.md
+```
+
+</details>
+
+---
+
+## Fundamentos del diseño
+
+<details>
+<summary>Lecturas relacionadas</summary>
+
+- [Why LLMs Are Bad at 'First Try' and Great at Verification](https://www.norsica.jp/blog/llm-verification-over-generation): por qué la retroalimentación externa y los contextos nuevos son más confiables que pedirle a una misma sesión que genere y evalúe su propio trabajo.
+- [When Better Models Make Old Agent Workflows Worse](https://www.norsica.jp/blog/when-better-models-make-old-agent-workflows-worse): por qué el flujo es estricto con los límites y la evidencia sin imponer una ruta concreta.
+- [Reasoning Effort Is Not a Quality Setting](https://www.norsica.jp/blog/reasoning-effort-is-not-a-quality-setting): por qué una exploración más amplia todavía debe converger en el trabajo que justifica el resultado actual.
+- [Stop Putting Everything in AGENTS.md](https://www.norsica.jp/blog/stop-putting-everything-in-agents-md): por qué las instrucciones permanentes deben ser breves y las skills, decisiones de diseño y guías de tareas deben cargarse cuando hacen falta.
+
+</details>
+
+---
+
+## Licencia
+
+Licencia MIT. Puedes usar, modificar y distribuir este software libremente.
+
+Consulta [LICENSE](LICENSE) para obtener más información.
+
+---
+
+Desarrollado y mantenido por [@shinpr](https://github.com/shinpr).

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,466 @@
+# Claude Code 開発ワークフロー
+
+[![Claude Code](https://img.shields.io/badge/Claude%20Code-Plugin-purple)](https://claude.ai/code)
+[![GitHub Stars](https://img.shields.io/github/stars/shinpr/claude-code-workflows?style=social)](https://github.com/shinpr/claude-code-workflows)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/shinpr/claude-code-workflows/pulls)
+
+[English](README.md) | [简体中文](README.zh-CN.md) | **日本語** | [Español](README.es.md) | [한국어](README.ko.md) | [Português (Brasil)](README.pt-BR.md)
+
+Claude Codeはコードベースを深く探索できます。しかし、複雑な作業でより難しいのは、探索そのものではなく結論へ収束させることです。たとえばアカウント復旧フローを設計している途中で、トークン処理の不整合を見つけ、その調査に大半を費やした結果、本来求められていた復旧時の動作が曖昧なまま残ることがあります。
+
+claude-code-workflowsは、探索を合意済みの成果へ向け続けるための仕組みです。設計前に成果と対象外を合意し、設計内容をリポジトリと照合し、コミット前に各タスクを検証します。規模の大きな変更では、完成した実装が意図した動作とセキュリティ要件を満たすかを独立してレビューします。その範囲内で、実装の詳細はClaudeがコードベースから判断します。
+
+成果と安全な実装範囲がすでに明確なら、Claude Codeをそのまま使うのが適しています。スコープの合意、後から参照できる設計判断、コンテキスト間の確実な引き継ぎ、独立した検証が必要な変更では、このワークフローを使ってください。
+
+---
+
+## どんなときに役立つか
+
+このワークフローはエージェント呼び出しと成果物を増やすため、そのコストに見合う場面で使うものです。関連する問題の発見によって変更の目的がずれそうな場合、筋の通った設計でも要求された動作を外す可能性がある場合、あるいはテストが通っていても確認したい動作を実際には観測できていない場合に効果を発揮します。
+
+実装範囲の承認後は、Claudeが各タスクに絞った検証、リポジトリの品質チェック、コミット、最終レビューまで進めます。通常の実装判断で逐一確認を求めることはありません。プロダクト変更や重要な設計変更はユーザーに戻し、元に戻せる実装上の選択はClaudeが判断します。Claude Codeプラグインとして提供されるため、Claudeの手順を固定せずに、複数のリポジトリへ同じ統制を適用できます。
+
+---
+
+## クイックスタート
+
+プラグインマーケットプレイスに対応したバージョンのClaude Codeが必要です。
+
+### 目的に合うルートを選ぶ
+
+| やりたいこと | 最初に実行するもの | プラグイン |
+|---|---|---|
+| バックエンド、API、CLI、一般的な変更を一通り完了させる | `/recipe-implement` | `dev-workflows` |
+| 実装前にバックエンドまたは一般的な変更を設計する | `/recipe-design` | `dev-workflows` |
+| React / TypeScriptフロントエンドを設計・実装する | `/recipe-front-design` → `/recipe-front-plan` → `/recipe-front-build` | `dev-workflows-frontend` |
+| バックエンドとReactフロントエンドをまとめて実装する | `/recipe-fullstack-implement` | `dev-workflows-fullstack` |
+| 設計に照らして実装をレビューする | `/recipe-review` または `/recipe-front-review` | `dev-workflows` または `dev-workflows-frontend` |
+| 修正を決める前に問題を調査する | `/recipe-diagnose` | 任意のワークフロープラグイン |
+| コードから既存システムを文書化する | `/recipe-reverse-engineer` | `dev-workflows` または `dev-workflows-fullstack` |
+| 使い捨ての実験やプロトタイプを作る | Claude Codeを直接使う | なし |
+
+### 共通セットアップ
+
+```bash
+# 1. Claude Codeを起動
+claude
+
+# 2. マーケットプレイスを追加
+/plugin marketplace add shinpr/claude-code-workflows
+```
+
+### ワークフロープラグインを1つインストールする
+
+プロジェクトに合うプラグインを選びます。インストール後に`/reload-plugins`の実行を求められた場合は、レシピを呼び出す前に実行してください。
+
+```bash
+# バックエンドまたは一般的な変更
+/plugin install dev-workflows@claude-code-workflows
+/recipe-implement "Add rate limiting to the public API"
+
+# フロントエンド
+/plugin install dev-workflows-frontend@claude-code-workflows
+/recipe-front-design "Add account recovery screens"
+
+# フルスタック
+/plugin install dev-workflows-fullstack@claude-code-workflows
+/recipe-fullstack-implement "Add user authentication with JWT + login form"
+```
+
+インストールするワークフロープラグインは1つだけにしてください。`dev-workflows-fullstack`にはバックエンドとフロントエンドの両方が含まれています。以前`dev-workflows`のフルスタックレシピを使っていた場合は、`dev-workflows-fullstack`へ移行してください。
+
+`/recipe-front-design`は、該当するUI仕様と設計ドキュメントがレビュー・承認された時点で終了します。続けて実装する場合は`/recipe-front-plan`と`/recipe-front-build`を実行します。バックエンドや一般的な変更にも、同じ段階構成の`/recipe-design`、`/recipe-plan`、`/recipe-build`があります。
+
+### チームでのセットアップ
+
+Claude Codeはプロジェクト単位のマーケットプレイスとプラグインに対応しています。生成された`.claude/settings.json`をコミットすると、コントリビューターにも同じワークフロープラグインの利用を案内できます。
+
+```bash
+claude plugin marketplace add shinpr/claude-code-workflows --scope project
+claude plugin install dev-workflows-fullstack@claude-code-workflows --scope project
+```
+
+`dev-workflows-fullstack`は、リポジトリに合うプラグインへ置き換えてください。プロジェクト単位および管理対象のインストール方法については、[Claude Codeのプラグインドキュメント](https://code.claude.com/docs/en/discover-plugins#configure-team-marketplaces)を参照してください。
+
+---
+
+## 仕組み
+
+```mermaid
+flowchart LR
+    A[Request] --> B[Agree on outcome and exclusions]
+    B --> C{One evident implementation path?}
+    C -->|Yes| S[Direct task cycle]
+    S --> J[Complete]
+    C -->|No| D[Inspect, design, and review]
+    D --> E[Approve implementation scope]
+    E --> F[Per task: implement, verify, quality-check, commit]
+    F --> I[Independent implementation and security review]
+    I -->|Correction| F
+    I -->|Boundary changed| B
+    I -->|Passed| J[Complete]
+```
+
+ルートを決めるのはファイル数や実装量ではなく、必要なプロダクト判断と設計判断の数です。
+
+| 規模 | 変更に必要なもの | 実行内容 |
+|---|---|---|
+| Small | 1つの責務の中で既存パターンに沿って達成できる1つの成果 | タスクを直接実行 → タスクごとのチェックとリポジトリチェック → セキュリティレビュー |
+| Medium | 複数の責務にまたがる、または後続の実装にも影響する設計判断が必要な1つの成果 | レビュー済み設計ドキュメントと、必要に応じたUI仕様 / ADR → 選定した結合・E2E検証 → レビュー済み作業計画 → タスクサイクル → 最終レビュー |
+| Large | 個別の設計判断を必要とする複数の独立したプロダクト成果 | レビュー済みPRDと設計ドキュメント、および必要に応じたUI仕様 / ADR → 選定した結合・E2E検証 → レビュー済み作業計画 → タスクサイクル → 最終レビュー |
+
+UI仕様、ADR、結合テストやE2Eテストのスケルトンは、それぞれの判断または検証境界が必要な場合にだけ作成されます。
+
+成果物を生成しただけでは、ワークフローは次へ進みません。設計上の主張は承認前にリポジトリと照合されます。作業計画は、実装を許可する前に、範囲、依存順序、実行可能な検証方法についてレビューされます。各タスクはそのタスクに絞ったチェックと該当するリポジトリチェックを通過してからコミットされます。段階的な実装が完了すると、設計との整合性、観測可能な動作のカバレッジ、セキュリティを別々にレビューします。
+
+メインセッションは、どの発見が現在の成果に含まれるかを判断し、リポジトリを根拠に実装上の疑問を解決し、影響を受けない作業を止めずに進めます。レビューの提案が自動的に作業項目になることはありません。受け入れた修正は実装へ戻され、影響する検証ゲートを再度通過します。
+
+### 新しいコンテキストへ判断を引き継ぐ仕組み
+
+フェーズごとに新しいコンテキストを使うことで、前のフェーズの推論が、次のフェーズで暗黙の権限になることを防ぎます。同梱の[作業計画テンプレート](skills/documentation-criteria/references/plan-template.md)では、設計ドキュメントで承認されたすべての技術要件について、対応するタスクまたは明示的なギャップが必要です。ドキュメントの全セクションやレビュー提案を、無条件にタスクへ変換するものではありません。ギャップとは、承認済み要件に実装タスクまたは検証タスクがまだない状態を指します。
+
+```markdown
+| Design Doc | DD Section | DD Item | Category | Covered By Task(s) | Gap Status | Notes |
+|---|---|---|---|---|---|---|
+| docs/design/example.md | API contract | Preserve the error response shape | contract-change | Phase 2 Task 1 | covered | |
+| docs/design/example.md | Verification | Exercise cache invalidation | verification | | gap | Add a covering task before approval |
+```
+
+[タスクテンプレート](skills/documentation-criteria/references/task-template.md)は、実装を拘束する判断と外部から確認できる契約上の値を引き継ぎ、それぞれにYes/Noで判定できる準拠チェックを持たせます。実行後、コミット前にタスク全体の変更へ該当するリポジトリチェックを行います。最終レビュアーは実装時の会話ではなく、同じ承認済みソースと完成したコードを読みます。
+
+### 実際のワークフロー実行例
+
+[mcp-local-ragの増分同期機能](https://github.com/shinpr/mcp-local-rag/pull/171)は、ファイルシステムのスキャン、ストレージ、CLI、MCPの各インターフェースにまたがる42ファイルの変更でした。独立したセキュリティレビューによって実装は2回差し戻され、検証前のファイル読み取りと、シンボリックリンクされた親ディレクトリを経由してパス制限を回避できる問題が見つかりました。
+
+この実行は、参照先のADRと設計ドキュメントが存在しない作業計画から始まり、技術判断の根拠が不明確な状態でした。ユーザーは作業計画を正本として扱うことを選び、レシピはそれを13個のタスクに分割しました。最終実装には承認された動作を検証するために必要な変更が含まれ、監視モードと永続ジョブを対象外にした理由はPRに記録されています。
+
+### 初回実行後に確認すること
+
+- 合意したアプローチは既存の仕組みを拡張しているか。各追加には根拠があるか。
+- 各要件からタスクと観測可能な検証方法まで追跡できるか。
+- 完了したすべてのタスクが、コミット前にそのタスクに絞ったチェックとリポジトリの品質チェックを通過したか。
+- 最終レビューは実装全体を意図した動作とセキュリティ要件に照らしたか。
+- レビュアーが追加作業を提案した場合、適用または却下した理由が報告されているか。
+
+---
+
+## 代表的なワークフロー
+
+### バックエンドまたは一般的な変更を最初から最後まで実装する
+
+```bash
+/recipe-implement "Add rate limiting to the public API"
+```
+
+レシピは変更範囲を定め、現在の実装を調べ、判断に必要なドキュメントだけを作成します。判断が必要な箇所では承認を求め、作業計画に沿った実装と最終レビューまで進めます。
+
+### 先に設計し、実装は後で行う
+
+```bash
+# バックエンドまたは一般
+/recipe-design "Design rate limiting for the public API"
+/recipe-plan
+/recipe-build
+
+# Reactフロントエンド
+/recipe-front-design "Build a user profile dashboard"
+/recipe-front-plan
+/recipe-front-build
+```
+
+設計レシピは既存実装を確認し、範囲を確定し、必要なドキュメントを作成して、独立した整合性レビューを行った後に承認を待ちます。承認済みの成果物があれば、別のコンテキストや別の担当者が後から計画と実装を再開できます。
+
+フロントエンドでは、UIの構造や動作に設計の余地がある場合にUI分析とUI仕様を追加し、さらにコンポーネント設計、React Testing Library、TypeScriptのチェックを行います。
+
+たとえば2つのダッシュボードコンポーネントが個別にはローディングを正しく処理していても、一方がローディング中で他方が失敗したときの画面全体の動作が未定義な場合があります。UI仕様はその状態の組み合わせを記録し、結合前に設計とテスト作業へ対応付けます。
+
+### フルスタック開発
+
+```bash
+/recipe-fullstack-implement "Add user authentication with JWT + React login form"
+```
+
+変更に複数の独立したプロダクト成果がある場合は、1つのPRDで機能全体を扱います。バックエンドとフロントエンドの設計は分離したまま、`design-sync`が境界の整合性を確認し、作業計画は垂直スライスを使って早い段階から結合を検証します。
+
+既存のフルスタック作業計画から再開するには`/recipe-fullstack-build`を使います。フルスタックプラグインには、対応するバックエンドとフロントエンドのレシピも含まれます。
+
+<details>
+<summary>その他のワークフロー例</summary>
+
+#### 設計に照らして実装をレビューする
+
+```bash
+/recipe-review
+```
+
+レビューワークフローは実装を設計ドキュメントと比較し、独立したセキュリティレビューを行います。承認済みの判断を変える修正は、契約を暗黙に変更せず、関連するドキュメントへ戻されます。
+
+#### 修正を決める前に問題を調査する
+
+```bash
+/recipe-diagnose "API returns 500 on user login"
+```
+
+診断ワークフローは実行経路をマッピングし、疑わしい障害点を検証して、解決策のトレードオフを提示します。コードは変更しません。
+
+#### コードから既存システムを文書化する
+
+```bash
+/recipe-reverse-engineer "src/auth module"
+```
+
+コードからPRDと設計ドキュメントを作成し、実装と照合して内容を検証します。機能がバックエンドとフロントエンドにまたがる場合は、フルスタック版を使ってください。
+
+詳しい実行例は[How I Made Legacy Code AI-Friendly with Auto-Generated Docs](https://dev.to/shinpr/how-i-made-legacy-code-ai-friendly-with-auto-generated-docs-4353)を参照してください。
+
+#### 実装済みUIをデザインソースに合わせて調整する
+
+```bash
+/recipe-front-adjust "Align the card spacing and actions with the design source"
+```
+
+フロントエンドプラグインは外部デザインソースの参照方法を記録し、変更対象を確定し、調整がチェックに合格するまで視覚検証を繰り返します。
+
+</details>
+
+---
+
+## ワークフローレシピ一覧
+
+すべてのワークフローは`recipe-`で始まります。`/recipe-`まで入力してTabキーを押すと、インストール済みの候補を補完できます。
+
+<details>
+<summary>バックエンドおよび一般向けレシピをすべて表示</summary>
+
+| レシピ | 目的 | 使用場面 |
+|---|---|---|
+| `/recipe-implement` | 機能を最初から最後まで実装 | 新機能や一連のワークフロー |
+| `/recipe-design` | 設計ドキュメントを作成 | アーキテクチャ設計 |
+| `/recipe-plan` | 設計から作業計画を作成 | 計画フェーズ |
+| `/recipe-build` | 既存の作業計画を実行 | 実装の再開 |
+| `/recipe-review` | 設計ドキュメントに照らして実装を検証 | 実装後の確認 |
+| `/recipe-diagnose` | 問題を調査し、解決策を比較 | 根本原因の分析 |
+| `/recipe-reverse-engineer` | コードからPRDと設計ドキュメントを作成 | 既存システムの文書化 |
+| `/recipe-add-integration-tests` | 結合テストまたはE2Eテストを追加 | 既存コードのカバレッジ |
+| `/recipe-update-doc` | 既存ドキュメントを更新・レビュー | 要件または設計の変更 |
+| `/recipe-task` | ルールに従うタスクを直接実行 | 段階的な引き継ぎが不要な作業 |
+
+</details>
+
+<details>
+<summary>フロントエンド向けレシピをすべて表示</summary>
+
+フロントエンドプラグインはReact固有の分析、コンポーネント設計、React Testing Library、TypeScriptチェック、必要に応じたプロトタイプコードからのUI仕様作成を追加します。
+
+| レシピ | 目的 | 使用場面 |
+|---|---|---|
+| `/recipe-front-design` | 該当するUI仕様とフロントエンド設計ドキュメントを作成 | Reactコンポーネント設計 |
+| `/recipe-front-plan` | フロントエンド作業計画を作成 | コンポーネント計画 |
+| `/recipe-front-build` | フロントエンド作業計画を実行 | React実装の再開 |
+| `/recipe-front-adjust` | 外部検証を使って実装済みUIを調整 | 見た目の調整 |
+| `/recipe-front-review` | フロントエンド設計ドキュメントに照らして実装を検証 | 実装後の確認 |
+| `/recipe-diagnose` | 問題を調査し、解決策を比較 | 根本原因の分析 |
+| `/recipe-update-doc` | 既存ドキュメントを更新・レビュー | 要件または設計の変更 |
+| `/recipe-task` | ルールに従うタスクを直接実行 | 段階的な引き継ぎが不要な作業 |
+
+</details>
+
+---
+
+## プラグインに含まれるもの
+
+専門エージェントは分析と設計を実行・最終レビューから分離します。各プラグインには、そのワークフローが使う役割だけが含まれ、フルスタックプラグインはバックエンドとフロントエンドの役割を統合します。役割の全一覧は以下で確認できます。
+
+<details>
+<summary>専門エージェントの役割をすべて表示</summary>
+
+### 共通エージェント
+
+バックエンド、フロントエンド、フルスタックで共有されるエージェントです。
+
+| エージェント | 役割 |
+|---|---|
+| **requirement-analyzer** | オーケストレーターが要件とワークフローを判断するための簡潔な範囲・コスト情報を収集 |
+| **prd-creator** | 大規模な機能のプロダクト要件を定義 |
+| **codebase-analyzer** | 設計前に既存コードと依存関係を調査 |
+| **code-verifier** | ドキュメントを実装と比較 |
+| **work-planner** | 設計判断を実行可能な作業計画へ変換 |
+| **task-decomposer** | 作業計画をコミット単位のタスクに分割 |
+| **acceptance-test-generator** | 要件から結合・E2Eテストのスケルトンを作成 |
+| **integration-test-reviewer** | 結合・E2Eテストが意図した範囲を確認しているかレビュー |
+| **code-reviewer** | 実装を設計ドキュメントと照合 |
+| **document-reviewer** | ドキュメントの完全性とルール準拠を確認 |
+| **design-sync** | 複数の設計ドキュメント間の矛盾を検出 |
+| **investigator** | 実行経路をマッピングし、障害候補を特定 |
+| **verifier** | 障害候補を検証し、経路の網羅性を確認 |
+| **solver** | 解決策とトレードオフを比較 |
+| **security-reviewer** | 完成した実装のセキュリティ問題をレビュー |
+| **rule-advisor** | タスクに関連するコーディングルールを選定 |
+
+### バックエンド固有のエージェント
+
+| エージェント | 役割 |
+|---|---|
+| **technical-designer** | 技術アプローチとアーキテクチャを設計 |
+| **scope-discoverer** | 既存実装から機能境界を特定 |
+| **task-executor** | テストファーストの検証でバックエンドタスクを実装 |
+| **quality-fixer** | テスト、型チェック、lintなどの品質ゲートを実行 |
+
+### フロントエンド固有のエージェント
+
+| エージェント | 役割 |
+|---|---|
+| **ui-spec-designer** | 要件と任意のプロトタイプからUI仕様を作成 |
+| **ui-analyzer** | デザインソース、デザインシステム、ガイドラインを取得し、既存UIを調査 |
+| **technical-designer-frontend** | Reactコンポーネント設計と状態管理を設計 |
+| **task-executor-frontend** | React Testing Libraryのカバレッジを伴うReactコンポーネントを実装 |
+| **quality-fixer-frontend** | フロントエンドテスト、TypeScriptチェック、lint、ビルドを実行 |
+
+</details>
+
+<details>
+<summary>組み込みの開発ガイダンスを表示</summary>
+
+- **Coding Principles：** コード品質の基準。
+- **Testing Principles：** TDD、カバレッジ、テストパターン。
+- **Implementation Approach：** 実装判断とトレードオフ。
+- **Documentation Standards：** 明確で保守しやすいドキュメント。
+- **External Resource Context：** デザインソース、デザインシステム、APIスキーマ、インフラ定義など、リポジトリ外の情報を参照する方法を記録。
+- **LLM-Friendly Context：** 下流のエージェントが迷わず実行できるプロンプト、引き継ぎ、成果物、指示。
+
+エージェントは作業に応じてこれらのスキルを読み込みます。フロントエンドプラグインにはReactとTypeScript固有のルールも含まれます。
+
+</details>
+
+<details>
+<summary>ワークフローを使わずガイダンスだけを利用する（dev-skills）</summary>
+
+独自のプロンプトやCIですでにオーケストレーションしていて、ベストプラクティスのガイドだけが必要な場合は`dev-skills`を使います。計画、実行、検証をClaudeに一通り任せたい場合は、用途に合うワークフロープラグインをインストールしてください。
+
+- エージェントを含まない最小限のコンテキスト使用量
+- 手順を固定せず、コーディング、テスト、設計、ドキュメントのガイダンスを提供
+- 作業に応じて関連スキルを自動読み込み
+
+> **`dev-skills`をワークフロープラグインと同時にインストールしないでください。** 同じスキル説明が重複し、コンテキスト上限に達した後にClaude Codeがスキルを無視することがあります。
+
+```bash
+/plugin install dev-skills@claude-code-workflows
+```
+
+プラグイン種別を切り替えるには、次のように操作します。
+
+```bash
+# dev-skillsからdev-workflowsへ
+/plugin uninstall dev-skills@claude-code-workflows
+/plugin install dev-workflows@claude-code-workflows
+
+# dev-workflowsからdev-skillsへ
+/plugin uninstall dev-workflows@claude-code-workflows
+/plugin install dev-skills@claude-code-workflows
+```
+
+</details>
+
+<details>
+<summary>任意のアドオンを表示</summary>
+
+これらのプラグインは、コアワークフローを変更せずに関連機能を追加します。
+
+- [claude-code-discover](https://github.com/shinpr/claude-code-discover)：機能案を根拠のあるPRDへ変換。
+- [metronome](https://github.com/shinpr/metronome)：近道をした兆候を検出し、定義された手順に従うようClaudeへ求める。
+- [linear-prism](https://github.com/shinpr/linear-prism)：要件を検証し、構造化されたLinearタスクへ変換。
+- [pr-review](https://github.com/shinpr/pr-review-skill)：GitHub PRをリポジトリ固有の基準でレビューし、承認された指摘だけを投稿。
+
+```bash
+/plugin install discover@claude-code-workflows
+/plugin install metronome@claude-code-workflows
+/plugin install linear-prism@claude-code-workflows
+/plugin install pr-review@claude-code-workflows
+```
+
+</details>
+
+---
+
+## FAQ
+
+**Q：エラーが発生した場合はどうなりますか？**
+
+A：quality-fixerエージェントが、承認済みの成果の範囲内でテスト、型、lint、ビルドの失敗を修正します。同じ責務や契約に必要な周辺変更も対象です。
+
+次の場合にのみワークフローが停止します。
+
+- 修正によってプロダクト成果、承認済みの契約、重要な設計判断が変わる。
+- ユーザーだけが持つ権限が必要になる。
+- 既存の承認範囲に含まれない、元に戻せない外部操作を行う。
+
+**Q：OpenAI Codex CLI向けのバージョンはありますか？**
+
+A：はい。**[codex-workflows](https://github.com/shinpr/codex-workflows)**は同じワークフローモデルをCodex CLI向けに調整しています。
+
+**Q：`docs/plans/`の作業計画とタスクファイルはコミットすべきですか？**
+
+A：いいえ。レシピは`docs/plans/`を一時的な作業状態として扱います。処理済みのタスクファイルと中間修正ファイルは、正常終了後に削除されます。作業計画はレビューや後続のビルドのために残る場合がありますが、不要になれば削除できます。この作業状態がGit管理に入らないよう、プロジェクトの`.gitignore`へ次の行を追加してください。
+
+```
+docs/plans/
+```
+
+PRD、ADR、UI仕様、設計ドキュメントは、それぞれ`docs/prd/`、`docs/adr/`、`docs/ui-spec/`、`docs/design/`に配置され、コミット対象です。
+
+---
+
+## 外部プラグインのコントリビューション
+
+このマーケットプレイスは、プロダクト品質、発見、実装統制、検証まで、AIを使ったプロダクト開発のライフサイクル全体を支援します。AIコーディングエージェントによる開発を改善するプラグインをお持ちなら、ぜひお知らせください。
+
+提出方法と受け入れ基準は[CONTRIBUTING.md](CONTRIBUTING.md)を参照してください。
+
+<details>
+<summary>リポジトリ構成を表示</summary>
+
+```
+claude-code-workflows/
+├── .claude-plugin/
+│   └── marketplace.json        # Plugin definitions and per-plugin contents
+├── agents/                     # Specialized analysis, design, execution, and review roles
+├── skills/
+│   ├── recipe-*/               # Workflow entry points
+│   ├── documentation-criteria/ # Document rules and templates
+│   ├── coding-principles/
+│   ├── testing-principles/
+│   ├── external-resource-context/
+│   ├── llm-friendly-context/
+│   └── ...
+├── LICENSE
+└── README.md
+```
+
+</details>
+
+---
+
+## 設計上の背景
+
+<details>
+<summary>設計の背景資料</summary>
+
+- [Why LLMs Are Bad at 'First Try' and Great at Verification](https://www.norsica.jp/blog/llm-verification-over-generation)：同じセッションで生成と評価を行うより、外部フィードバックと新しいコンテキストを使う方が信頼できる理由。
+- [When Better Models Make Old Agent Workflows Worse](https://www.norsica.jp/blog/when-better-models-make-old-agent-workflows-worse)：経路を固定せず、境界と根拠を厳格に扱う理由。
+- [Reasoning Effort Is Not a Quality Setting](https://www.norsica.jp/blog/reasoning-effort-is-not-a-quality-setting)：探索を広げても、現在の成果に必要な作業へ収束させる必要がある理由。
+- [Stop Putting Everything in AGENTS.md](https://www.norsica.jp/blog/stop-putting-everything-in-agents-md)：常時読み込む指示を小さく保ち、必要に応じてスキル、設計判断、タスクガイダンスを読み込む理由。
+
+</details>
+
+---
+
+## ライセンス
+
+MIT License。自由に利用、変更、配布できます。
+
+詳細は[LICENSE](LICENSE)を参照してください。
+
+---
+
+[@shinpr](https://github.com/shinpr)が開発・メンテナンスしています。

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,466 @@
+# Claude Code 개발 워크플로
+
+[![Claude Code](https://img.shields.io/badge/Claude%20Code-Plugin-purple)](https://claude.ai/code)
+[![GitHub Stars](https://img.shields.io/github/stars/shinpr/claude-code-workflows?style=social)](https://github.com/shinpr/claude-code-workflows)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/shinpr/claude-code-workflows/pulls)
+
+[English](README.md) | [简体中文](README.zh-CN.md) | [日本語](README.ja.md) | [Español](README.es.md) | **한국어** | [Português (Brasil)](README.pt-BR.md)
+
+Claude Code는 코드베이스를 깊이 탐색할 수 있습니다. 하지만 복잡한 작업에서 더 어려운 문제는 탐색이 아니라 결론을 내는 일입니다. 예를 들어 계정 복구 흐름을 설계하다가 토큰 처리의 실제 불일치를 발견하면, Claude가 설계 대부분을 그 문제에 할애한 나머지 정작 요청받은 복구 동작을 모호하게 남길 수 있습니다.
+
+claude-code-workflows는 탐색이 합의된 결과를 향하도록 유지합니다. 설계 전에 목표와 제외 범위를 합의하고, 설계를 저장소와 대조하며, 커밋 전에 각 작업을 검증합니다. 규모가 큰 변경에서는 완성된 구현이 의도한 동작과 보안 요구 사항을 충족하는지도 독립적으로 검토합니다. 이 범위 안에서 Claude는 코드베이스를 바탕으로 구현 세부 사항을 결정합니다.
+
+목표와 안전한 구현 범위가 이미 명확하다면 Claude Code를 직접 사용하세요. 범위 합의, 오래 유지해야 하는 설계 결정, 컨텍스트 사이의 안정적인 인계 또는 독립적인 검증이 필요한 변경에는 이 워크플로를 사용하세요.
+
+---
+
+## 언제 유용한가요?
+
+이 워크플로는 Agent 호출과 산출물을 추가하므로 그만한 가치가 있을 때 사용해야 합니다. 관련 문제를 발견한 탓에 큰 변경이 원래 목표에서 벗어날 수 있거나, 설계 자체는 일관되지만 요청한 동작을 놓칠 수 있거나, 통과한 테스트가 검증한다고 주장한 내용을 실제로 관찰하지 못할 수 있을 때 유용합니다.
+
+구현 범위가 승인되면 Claude는 일상적인 구현 결정을 되묻지 않고 작업별 검증, 저장소 품질 검사, 커밋, 최종 검토까지 진행합니다. 제품 변경과 주요 설계 변경은 사용자에게 결정을 요청하고, 되돌릴 수 있는 구현 선택은 Claude가 처리합니다. Claude Code 플러그인으로 제공되므로 Claude의 구체적인 작업 순서를 고정하지 않고도 팀의 여러 저장소에 같은 통제 방식을 적용할 수 있습니다.
+
+---
+
+## 빠른 시작
+
+플러그인 마켓플레이스를 지원하는 버전의 Claude Code가 필요합니다.
+
+### 목적에 맞는 경로 선택
+
+| 필요한 작업 | 시작 명령 | 플러그인 |
+|---|---|---|
+| 백엔드, API, CLI 또는 일반 변경을 처음부터 끝까지 구현 | `/recipe-implement` | `dev-workflows` |
+| 구현 전에 백엔드 또는 일반 변경을 설계 | `/recipe-design` | `dev-workflows` |
+| React / TypeScript 프런트엔드를 설계하고 구현 | `/recipe-front-design` → `/recipe-front-plan` → `/recipe-front-build` | `dev-workflows-frontend` |
+| 백엔드와 React 프런트엔드를 함께 구현 | `/recipe-fullstack-implement` | `dev-workflows-fullstack` |
+| 설계를 기준으로 구현을 검토 | `/recipe-review` 또는 `/recipe-front-review` | `dev-workflows` 또는 `dev-workflows-frontend` |
+| 수정 방법을 정하기 전에 문제를 조사 | `/recipe-diagnose` | 모든 워크플로 플러그인 |
+| 코드에서 기존 시스템 문서를 생성 | `/recipe-reverse-engineer` | `dev-workflows` 또는 `dev-workflows-fullstack` |
+| 일회성 실험이나 프로토타입 | Claude Code를 직접 사용 | 없음 |
+
+### 공통 설정
+
+```bash
+# 1. Claude Code 실행
+claude
+
+# 2. 마켓플레이스 추가
+/plugin marketplace add shinpr/claude-code-workflows
+```
+
+### 워크플로 플러그인 하나 설치
+
+프로젝트에 맞는 플러그인을 설치하세요. 설치 후 `/reload-plugins` 실행 안내가 나오면 recipe를 호출하기 전에 실행하세요.
+
+```bash
+# 백엔드 또는 일반 변경
+/plugin install dev-workflows@claude-code-workflows
+/recipe-implement "Add rate limiting to the public API"
+
+# 프런트엔드
+/plugin install dev-workflows-frontend@claude-code-workflows
+/recipe-front-design "Add account recovery screens"
+
+# 풀스택
+/plugin install dev-workflows-fullstack@claude-code-workflows
+/recipe-fullstack-implement "Add user authentication with JWT + login form"
+```
+
+워크플로 플러그인은 하나만 설치하세요. `dev-workflows-fullstack`에는 백엔드와 프런트엔드 워크플로가 모두 포함되어 있습니다. 이전에 `dev-workflows`의 풀스택 recipe를 사용했다면 `dev-workflows-fullstack`으로 이전하세요.
+
+`/recipe-front-design`은 해당하는 UI Spec과 Design Doc이 검토 및 승인되면 종료됩니다. 계속 진행하려면 `/recipe-front-plan`과 `/recipe-front-build`를 실행하세요. 백엔드나 일반 변경에는 같은 단계로 구성된 `/recipe-design`, `/recipe-plan`, `/recipe-build`가 있습니다.
+
+### 팀 설정
+
+Claude Code는 프로젝트 범위의 마켓플레이스와 플러그인을 지원합니다. 생성된 `.claude/settings.json`을 커밋하면 기여자도 같은 워크플로 플러그인을 사용하도록 안내할 수 있습니다.
+
+```bash
+claude plugin marketplace add shinpr/claude-code-workflows --scope project
+claude plugin install dev-workflows-fullstack@claude-code-workflows --scope project
+```
+
+`dev-workflows-fullstack`은 저장소에 맞는 플러그인으로 바꾸세요. 프로젝트 범위 및 관리형 설치 방법은 [Claude Code 플러그인 문서](https://code.claude.com/docs/en/discover-plugins#configure-team-marketplaces)를 참고하세요.
+
+---
+
+## 동작 방식
+
+```mermaid
+flowchart LR
+    A[Request] --> B[Agree on outcome and exclusions]
+    B --> C{One evident implementation path?}
+    C -->|Yes| S[Direct task cycle]
+    S --> J[Complete]
+    C -->|No| D[Inspect, design, and review]
+    D --> E[Approve implementation scope]
+    E --> F[Per task: implement, verify, quality-check, commit]
+    F --> I[Independent implementation and security review]
+    I -->|Correction| F
+    I -->|Boundary changed| B
+    I -->|Passed| J[Complete]
+```
+
+경로는 파일 수나 구현 작업량이 아니라 필요한 제품 결정과 설계 결정의 수에 따라 달라집니다.
+
+| 규모 | 변경에 필요한 조건 | 진행 방식 |
+|---|---|---|
+| Small | 하나의 책임 안에서 기존 패턴을 따르는 단일 결과 | 작업을 직접 실행 → 작업별 검사 및 저장소 검사 → 보안 검토 |
+| Medium | 여러 책임에 걸치거나 장기적으로 유지할 설계 결정이 필요한 단일 결과 | 검토된 Design Doc과 필요시 UI Spec / ADR → 선택된 통합/E2E 검증 → 검토된 Work Plan → 작업 주기 → 최종 검토 |
+| Large | 각각 별도의 설계 결정이 필요한 여러 독립적인 제품 결과 | 검토된 PRD 및 Design Doc과 필요시 UI Spec / ADR → 선택된 통합/E2E 검증 → 검토된 Work Plan → 작업 주기 → 최종 검토 |
+
+UI Spec, ADR, 통합 또는 E2E 테스트 스켈레톤은 해당 결정이나 검증 경계가 필요할 때만 만들어집니다.
+
+산출물을 만들었다고 워크플로가 자동으로 다음 단계로 넘어가지는 않습니다. 설계의 주장은 승인 전에 저장소와 대조합니다. Work Plan은 구현을 승인하기 전에 범위, 의존성 순서, 실행 가능한 검증 방법을 검토합니다. 각 작업은 작업별 검사와 해당 저장소 검사를 통과한 뒤에만 커밋합니다. 단계별 구현이 끝나면 별도의 검토에서 설계 일관성, 관찰 가능한 동작의 검증 범위, 보안을 확인합니다.
+
+메인 세션은 어떤 발견이 현재 목표에 포함되는지 판단하고, 저장소를 근거로 구현 질문을 해결하며, 영향을 받지 않는 작업을 계속 진행합니다. 검토 제안이 자동으로 작업이 되지는 않습니다. 수락된 수정은 구현 단계로 돌아가 영향을 받는 검증 관문을 다시 거칩니다.
+
+### 새로운 컨텍스트에도 결정을 유지하는 방법
+
+단계마다 새로운 컨텍스트를 사용하면 한 단계의 추론이 다음 단계에서 암묵적인 권한으로 바뀌는 일을 막을 수 있습니다. 포함된 [Work Plan 템플릿](skills/documentation-criteria/references/plan-template.md)은 Design Doc에서 승인된 모든 기술 요구 사항에 대응 작업이나 명시적인 누락 표시가 있도록 요구합니다. 문서의 모든 절이나 검토 제안을 작업으로 바꾸지는 않습니다. 누락은 승인된 요구 사항에 아직 구현 또는 검증 작업이 없다는 뜻입니다.
+
+```markdown
+| Design Doc | DD Section | DD Item | Category | Covered By Task(s) | Gap Status | Notes |
+|---|---|---|---|---|---|---|
+| docs/design/example.md | API contract | Preserve the error response shape | contract-change | Phase 2 Task 1 | covered | |
+| docs/design/example.md | Verification | Exercise cache invalidation | verification | | gap | Add a covering task before approval |
+```
+
+[Task 템플릿](skills/documentation-criteria/references/task-template.md)은 구현을 구속하는 결정과 외부에서 확인할 수 있는 계약상의 값을 전달하며, 각 항목에 예/아니요로 답할 수 있는 준수 검사를 둡니다. 실행 후에는 커밋 전에 전체 작업 변경에 해당 저장소 검사를 적용합니다. 최종 검토자는 구현 대화에 의존하지 않고 같은 승인 자료와 완성된 코드를 읽습니다.
+
+### 실제 워크플로 실행 사례
+
+[mcp-local-rag의 증분 동기화 기능](https://github.com/shinpr/mcp-local-rag/pull/171)은 파일 시스템 스캔, 스토리지, CLI, MCP 인터페이스에 걸친 42개 파일 변경이었습니다. 독립적인 보안 검토가 구현을 두 번 돌려보냈습니다. 검증 전에 파일을 읽는 문제와 심볼릭 링크된 상위 디렉터리를 통해 경로 제한을 벗어나는 문제를 찾아냈습니다.
+
+실행은 존재하지 않는 ADR과 Design Doc을 참조하는 Work Plan에서 시작되어 기술 결정의 승인 근거가 불분명했습니다. 사용자는 Work Plan을 기준 자료로 삼기로 했고, recipe는 이를 계획된 13개 작업으로 나눴습니다. 최종 구현에는 승인된 동작을 검증하는 데 필요한 변경이 포함되었고, watch 모드와 영구 작업을 제외한 이유는 PR에 기록했습니다.
+
+### 첫 실행 후 확인할 사항
+
+- 합의한 접근 방식이 기존 구현을 확장하며 각 추가 사항에 근거를 제시했나요?
+- 각 요구 사항을 작업과 관찰 가능한 검증 방법까지 추적할 수 있나요?
+- 완료된 모든 작업이 커밋 전에 작업별 검사와 저장소 품질 검사를 통과했나요?
+- 최종 검토가 전체 변경을 의도한 동작 및 보안 요구 사항과 비교했나요?
+- 검토자가 추가 작업을 제안했을 때 적용하거나 거절한 이유가 보고서에 있나요?
+
+---
+
+## 주요 워크플로
+
+### 백엔드 또는 일반 개발을 처음부터 끝까지 진행
+
+```bash
+/recipe-implement "Add rate limiting to the public API"
+```
+
+recipe는 변경 범위를 정하고 현재 구현을 조사한 뒤, 결정에 필요한 문서만 만듭니다. 결정이 필요한 지점에서 승인을 요청하고, 이후 계획된 구현과 최종 검토까지 진행합니다.
+
+### 먼저 설계하고 나중에 구현
+
+```bash
+# 백엔드 또는 일반 변경
+/recipe-design "Design rate limiting for the public API"
+/recipe-plan
+/recipe-build
+
+# React 프런트엔드
+/recipe-front-design "Build a user profile dashboard"
+/recipe-front-plan
+/recipe-front-build
+```
+
+설계 recipe는 기존 구현을 조사하고 범위를 확인하며 필요한 문서를 만든 뒤, 독립적인 일관성 검토를 거쳐 승인을 기다립니다. 나중에 새 컨텍스트나 다른 담당자가 승인된 산출물을 바탕으로 계획과 구현을 이어갈 수 있습니다.
+
+프런트엔드 경로는 UI 구조나 동작을 더 설계해야 할 때 UI 분석과 UI Spec을 추가하고, 컴포넌트 아키텍처, React Testing Library, TypeScript 검사도 수행합니다.
+
+예를 들어 대시보드 컴포넌트 두 개가 각각 로딩 상태를 올바르게 처리해도, 하나는 로딩 중이고 다른 하나는 실패했을 때 전체 화면의 동작은 정의되지 않았을 수 있습니다. UI Spec은 이 상태 조합을 기록하고 통합 전에 설계 및 테스트 작업과 연결합니다.
+
+### 풀스택 개발
+
+```bash
+/recipe-fullstack-implement "Add user authentication with JWT + React login form"
+```
+
+변경에 여러 독립적인 제품 결과가 있으면 하나의 PRD가 전체 기능을 다룹니다. 백엔드와 프런트엔드 설계는 분리하고, `design-sync`가 그 경계를 확인하며, Work Plan은 수직 슬라이스를 사용해 통합을 일찍 검증합니다.
+
+기존 풀스택 Work Plan에서 계속하려면 `/recipe-fullstack-build`를 사용하세요. 풀스택 플러그인에는 필요한 백엔드와 프런트엔드 recipe도 포함되어 있습니다.
+
+<details>
+<summary>워크플로 예시 더 보기</summary>
+
+#### 설계를 기준으로 구현 검토
+
+```bash
+/recipe-review
+```
+
+검토 워크플로는 구현을 Design Doc과 비교하고 독립적인 보안 검토를 실행합니다. 승인된 결정을 바꾸는 수정은 계약을 조용히 변경하지 않고 관련 문서 단계로 되돌려 다시 검토합니다.
+
+#### 수정 방법을 정하기 전에 문제 조사
+
+```bash
+/recipe-diagnose "API returns 500 on user login"
+```
+
+진단 워크플로는 실행 경로를 정리하고 의심되는 실패 지점을 검증하며 해결책의 장단점을 제시합니다. 코드는 변경하지 않습니다.
+
+#### 코드에서 기존 시스템 문서화
+
+```bash
+/recipe-reverse-engineer "src/auth module"
+```
+
+코드에서 PRD와 Design Doc을 만들고 구현과 대조해 검증합니다. 기능이 백엔드와 프런트엔드에 걸쳐 있다면 풀스택 옵션을 사용하세요.
+
+전체 사례는 [How I Made Legacy Code AI-Friendly with Auto-Generated Docs](https://dev.to/shinpr/how-i-made-legacy-code-ai-friendly-with-auto-generated-docs-4353)를 참고하세요.
+
+#### 디자인 자료에 맞춰 구현된 UI 조정
+
+```bash
+/recipe-front-adjust "Align the card spacing and actions with the design source"
+```
+
+프런트엔드 플러그인은 외부 디자인 자료에 접근하는 방법을 기록하고 변경 대상 파일을 확인한 뒤, 조정이 검사를 통과할 때까지 시각 검증을 반복합니다.
+
+</details>
+
+---
+
+## Workflow Recipe 목록
+
+모든 워크플로 진입점은 `recipe-` 접두사를 사용합니다. `/recipe-`를 입력하고 Tab 키를 누르면 설치된 항목을 확인할 수 있습니다.
+
+<details>
+<summary>백엔드 및 일반 recipe 모두 보기</summary>
+
+| Recipe | 목적 | 사용 시점 |
+|---|---|---|
+| `/recipe-implement` | 기능을 처음부터 끝까지 구현 | 새 기능과 전체 워크플로 |
+| `/recipe-design` | 설계 문서 작성 | 아키텍처 계획 |
+| `/recipe-plan` | 설계에서 Work Plan 생성 | 계획 단계 |
+| `/recipe-build` | 기존 Work Plan 실행 | 구현 재개 |
+| `/recipe-review` | Design Doc을 기준으로 구현 검증 | 구현 후 확인 |
+| `/recipe-diagnose` | 문제를 조사하고 해결책 비교 | 근본 원인 분석 |
+| `/recipe-reverse-engineer` | 코드에서 PRD와 Design Doc 생성 | 기존 시스템 문서화 |
+| `/recipe-add-integration-tests` | 통합 또는 E2E 테스트 추가 | 기존 코드의 커버리지 확보 |
+| `/recipe-update-doc` | 기존 문서 업데이트 및 검토 | 요구 사항 또는 설계 변경 |
+| `/recipe-task` | 규칙을 따르는 작업을 직접 실행 | 단계별 인계가 필요 없는 작업 |
+
+</details>
+
+<details>
+<summary>프런트엔드 recipe 모두 보기</summary>
+
+프런트엔드 플러그인은 React 전용 분석, 컴포넌트 아키텍처, React Testing Library, TypeScript 검사와 필요시 프로토타입 코드에서 UI Spec을 만드는 기능을 추가합니다.
+
+| Recipe | 목적 | 사용 시점 |
+|---|---|---|
+| `/recipe-front-design` | 해당 UI Spec과 프런트엔드 Design Doc 작성 | React 컴포넌트 아키텍처 |
+| `/recipe-front-plan` | 프런트엔드 Work Plan 생성 | 컴포넌트 계획 |
+| `/recipe-front-build` | 프런트엔드 Work Plan 실행 | React 구현 재개 |
+| `/recipe-front-adjust` | 외부 검증으로 구현된 UI 조정 | 시각적 개선 |
+| `/recipe-front-review` | 프런트엔드 Design Doc을 기준으로 구현 검증 | 구현 후 확인 |
+| `/recipe-diagnose` | 문제를 조사하고 해결책 비교 | 근본 원인 분석 |
+| `/recipe-update-doc` | 기존 문서 업데이트 및 검토 | 요구 사항 또는 설계 변경 |
+| `/recipe-task` | 규칙을 따르는 작업을 직접 실행 | 단계별 인계가 필요 없는 작업 |
+
+</details>
+
+---
+
+## 플러그인 구성
+
+전문 Agent는 분석과 설계를 실행 및 최종 검토와 분리합니다. 각 플러그인은 해당 워크플로에 필요한 역할만 포함하고, 풀스택 플러그인은 백엔드와 프런트엔드 역할을 결합합니다. 전체 역할 목록은 아래에서 확인할 수 있습니다.
+
+<details>
+<summary>전문 Agent 역할 모두 보기</summary>
+
+### 공통 Agent
+
+백엔드, 프런트엔드, 풀스택 플러그인이 공유하는 Agent입니다.
+
+| Agent | 역할 |
+|---|---|
+| **requirement-analyzer** | 오케스트레이터가 요구 사항과 워크플로를 결정하는 데 필요한 간결한 범위 및 비용 근거 수집 |
+| **prd-creator** | 큰 기능의 제품 요구 사항 정의 |
+| **codebase-analyzer** | 설계 전에 기존 코드와 의존성 조사 |
+| **code-verifier** | 문서를 구현과 비교 |
+| **work-planner** | 설계 결정을 실행 가능한 Work Plan으로 변환 |
+| **task-decomposer** | Work Plan을 커밋 가능한 작업으로 분할 |
+| **acceptance-test-generator** | 요구 사항에서 통합 및 E2E 테스트 스켈레톤 생성 |
+| **integration-test-reviewer** | 통합 및 E2E 테스트가 의도한 범위를 검증하는지 검토 |
+| **code-reviewer** | 구현을 Design Doc과 대조 |
+| **document-reviewer** | 문서 완전성과 규칙 준수 여부 검토 |
+| **design-sync** | 여러 Design Doc 사이의 충돌 감지 |
+| **investigator** | 실행 경로를 정리하고 잠재적인 실패 지점 식별 |
+| **verifier** | 의심되는 실패 지점을 검증하고 경로 커버리지 확인 |
+| **solver** | 해결책과 장단점 비교 |
+| **security-reviewer** | 완성된 구현의 보안 문제 검토 |
+| **rule-advisor** | 작업에 관련된 개발 규칙 선택 |
+
+### 백엔드 전용 Agent
+
+| Agent | 역할 |
+|---|---|
+| **technical-designer** | 기술 접근 방식과 아키텍처 설계 |
+| **scope-discoverer** | 기존 구현에서 기능 경계 파악 |
+| **task-executor** | 테스트 우선 검증으로 백엔드 작업 구현 |
+| **quality-fixer** | 테스트, 타입 검사, lint 등 품질 관문 실행 |
+
+### 프런트엔드 전용 Agent
+
+| Agent | 역할 |
+|---|---|
+| **ui-spec-designer** | 요구 사항과 선택적 프로토타입에서 UI Spec 작성 |
+| **ui-analyzer** | 디자인 자료, 디자인 시스템, 가이드라인을 가져오고 기존 UI 조사 |
+| **technical-designer-frontend** | React 컴포넌트 아키텍처와 상태 관리 설계 |
+| **task-executor-frontend** | React Testing Library 커버리지를 포함한 React 컴포넌트 구현 |
+| **quality-fixer-frontend** | 프런트엔드 테스트, TypeScript 검사, lint, 빌드 실행 |
+
+</details>
+
+<details>
+<summary>내장 개발 가이드 보기</summary>
+
+- **Coding Principles.** 코드 품질 기준.
+- **Testing Principles.** TDD, 커버리지, 테스트 패턴.
+- **Implementation Approach.** 구현 결정과 장단점.
+- **Documentation Standards.** 명확하고 유지보수하기 쉬운 문서.
+- **External Resource Context.** 저장소 외부의 디자인 자료, 디자인 시스템, API 스키마, 인프라 정의 등에 접근하는 방법 기록.
+- **LLM-Friendly Context.** 후속 Agent가 추측 없이 실행할 수 있도록 명확한 프롬프트, 인계, 산출물, 지시 제공.
+
+Agent는 작업에 필요할 때 이 skill을 불러옵니다. 프런트엔드 플러그인에는 React와 TypeScript 전용 규칙도 포함됩니다.
+
+</details>
+
+<details>
+<summary>워크플로 없이 가이드만 사용하기(dev-skills)</summary>
+
+사용자 지정 프롬프트나 CI를 통해 이미 오케스트레이션하고 있고 모범 사례 가이드만 필요하다면 `dev-skills`를 사용하세요. Claude가 변경을 처음부터 끝까지 계획하고 실행하며 검증하게 하려면 용도에 맞는 워크플로 플러그인을 설치하세요.
+
+- Agent 없이 최소한의 컨텍스트만 사용
+- 정해진 절차를 강제하지 않고 개발, 테스트, 설계, 문서 가이드 제공
+- 작업에 맞는 skill 자동 로드
+
+> **`dev-skills`와 워크플로 플러그인을 함께 설치하지 마세요.** 두 플러그인은 같은 skill을 공유하므로 중복된 설명 때문에 컨텍스트 한도에 도달한 뒤 Claude Code가 skill을 무시할 수 있습니다.
+
+```bash
+/plugin install dev-skills@claude-code-workflows
+```
+
+플러그인 유형을 전환하려면 다음과 같이 실행하세요.
+
+```bash
+# dev-skills -> dev-workflows
+/plugin uninstall dev-skills@claude-code-workflows
+/plugin install dev-workflows@claude-code-workflows
+
+# dev-workflows -> dev-skills
+/plugin uninstall dev-workflows@claude-code-workflows
+/plugin install dev-skills@claude-code-workflows
+```
+
+</details>
+
+<details>
+<summary>선택적 추가 플러그인 보기</summary>
+
+다음 플러그인은 핵심 워크플로를 바꾸지 않고 관련 기능을 제공합니다.
+
+- [claude-code-discover](https://github.com/shinpr/claude-code-discover): 기능 아이디어를 근거가 있는 PRD로 변환합니다.
+- [metronome](https://github.com/shinpr/metronome): 지름길을 택한 징후를 감지하고 Claude가 정의된 절차를 따르도록 요청합니다.
+- [linear-prism](https://github.com/shinpr/linear-prism): 요구 사항을 검증하고 구조화된 Linear 작업으로 변환합니다.
+- [pr-review](https://github.com/shinpr/pr-review-skill): 저장소별 기준으로 GitHub PR을 검토하고 승인된 지적만 게시합니다.
+
+```bash
+/plugin install discover@claude-code-workflows
+/plugin install metronome@claude-code-workflows
+/plugin install linear-prism@claude-code-workflows
+/plugin install pr-review@claude-code-workflows
+```
+
+</details>
+
+---
+
+## 자주 묻는 질문
+
+**Q: 오류가 발생하면 어떻게 되나요?**
+
+A: quality-fixer Agent가 승인된 목표 안에서 테스트, 타입, lint, 빌드 실패를 처리합니다. 같은 책임이나 계약에 필요한 인접 변경도 포함됩니다.
+
+다음과 같은 경우에만 워크플로가 중단됩니다.
+
+- 수정이 제품 목표, 승인된 계약 또는 주요 설계 결정을 변경하는 경우
+- 사용자만 가진 권한이 필요한 경우
+- 기존 승인 범위에 포함되지 않은 되돌릴 수 없는 외부 작업을 수행해야 하는 경우
+
+**Q: OpenAI Codex CLI용 버전도 있나요?**
+
+A: 네. **[codex-workflows](https://github.com/shinpr/codex-workflows)**는 같은 워크플로 모델을 Codex CLI 환경에 맞게 조정한 버전입니다.
+
+**Q: `docs/plans/`의 Work Plan과 작업 파일을 커밋해야 하나요?**
+
+A: 아니요. recipe는 `docs/plans/`를 임시 작업 상태로 취급합니다. 사용이 끝난 작업 파일과 중간 수정 파일은 정상 완료 후 삭제됩니다. Work Plan은 검토나 나중 작업을 위해 남을 수 있으며 더 이상 필요하지 않을 때 삭제하면 됩니다. 이 작업 상태가 Git에 포함되지 않도록 프로젝트의 `.gitignore`에 다음 줄을 추가하세요.
+
+```
+docs/plans/
+```
+
+PRD, ADR, UI Spec, Design Doc은 각각 `docs/prd/`, `docs/adr/`, `docs/ui-spec/`, `docs/design/`에 있으며 커밋 대상입니다.
+
+---
+
+## 외부 플러그인 기여
+
+이 마켓플레이스는 제품 품질, 요구 사항 발견, 구현 통제, 검증까지 AI 제품 개발의 전체 수명 주기를 지원합니다. AI 코딩 Agent가 더 나은 제품을 만드는 데 도움이 되는 플러그인이 있다면 알려 주세요.
+
+제출 방법과 승인 기준은 [CONTRIBUTING.md](CONTRIBUTING.md)를 참고하세요.
+
+<details>
+<summary>저장소 구조 보기</summary>
+
+```
+claude-code-workflows/
+├── .claude-plugin/
+│   └── marketplace.json        # Plugin definitions and per-plugin contents
+├── agents/                     # Specialized analysis, design, execution, and review roles
+├── skills/
+│   ├── recipe-*/               # Workflow entry points
+│   ├── documentation-criteria/ # Document rules and templates
+│   ├── coding-principles/
+│   ├── testing-principles/
+│   ├── external-resource-context/
+│   ├── llm-friendly-context/
+│   └── ...
+├── LICENSE
+└── README.md
+```
+
+</details>
+
+---
+
+## 설계 배경
+
+<details>
+<summary>관련 자료</summary>
+
+- [Why LLMs Are Bad at 'First Try' and Great at Verification](https://www.norsica.jp/blog/llm-verification-over-generation): 한 세션이 생성과 평가를 모두 맡는 것보다 외부 피드백과 새 컨텍스트가 더 신뢰할 수 있는 이유.
+- [When Better Models Make Old Agent Workflows Worse](https://www.norsica.jp/blog/when-better-models-make-old-agent-workflows-worse): 구체적인 경로를 강제하지 않으면서 경계와 근거를 엄격하게 다루는 이유.
+- [Reasoning Effort Is Not a Quality Setting](https://www.norsica.jp/blog/reasoning-effort-is-not-a-quality-setting): 탐색 범위가 넓더라도 현재 목표에 필요한 작업으로 수렴해야 하는 이유.
+- [Stop Putting Everything in AGENTS.md](https://www.norsica.jp/blog/stop-putting-everything-in-agents-md): 항상 읽는 지시는 짧게 유지하고 skill, 설계 결정, 작업 가이드는 필요할 때 불러와야 하는 이유.
+
+</details>
+
+---
+
+## 라이선스
+
+MIT License. 자유롭게 사용, 수정, 배포할 수 있습니다.
+
+자세한 내용은 [LICENSE](LICENSE)를 참고하세요.
+
+---
+
+[@shinpr](https://github.com/shinpr)이 개발하고 유지보수합니다.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/shinpr/claude-code-workflows/pulls)
 
+**English** | [简体中文](README.zh-CN.md) | [日本語](README.ja.md) | [Español](README.es.md) | [한국어](README.ko.md) | [Português (Brasil)](README.pt-BR.md)
+
 Claude Code can explore a codebase deeply. On non-trivial work, the harder problem is convergence. While designing an account-recovery flow, Claude may find a real inconsistency in token handling and spend most of the design on it, leaving the requested recovery behavior vague.
 
 claude-code-workflows keeps that exploration pointed at an agreed result. It agrees on the outcome and exclusions before design, checks designs against the repository, verifies each task before commit, and, on larger changes, independently reviews the finished implementation for intended behavior and security. Within that scope, Claude chooses the implementation details from the codebase.

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -1,0 +1,466 @@
+# Fluxos de desenvolvimento para Claude Code
+
+[![Claude Code](https://img.shields.io/badge/Claude%20Code-Plugin-purple)](https://claude.ai/code)
+[![GitHub Stars](https://img.shields.io/github/stars/shinpr/claude-code-workflows?style=social)](https://github.com/shinpr/claude-code-workflows)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/shinpr/claude-code-workflows/pulls)
+
+[English](README.md) | [简体中文](README.zh-CN.md) | [日本語](README.ja.md) | [Español](README.es.md) | [한국어](README.ko.md) | **Português (Brasil)**
+
+O Claude Code consegue explorar uma base de código em profundidade. Em trabalhos mais complexos, porém, o desafio maior não é explorar: é chegar a uma conclusão. Ao projetar um fluxo de recuperação de conta, por exemplo, o Claude pode encontrar uma inconsistência real no tratamento de tokens e dedicar quase todo o design a ela, deixando vago o comportamento de recuperação que havia sido solicitado.
+
+O claude-code-workflows mantém essa exploração direcionada a um resultado combinado. Antes do design, ele define o objetivo e o que fica fora do escopo; confronta o design com o repositório; verifica cada tarefa antes do commit e, em mudanças maiores, submete a implementação concluída a revisões independentes de comportamento e segurança. Dentro desses limites, o Claude decide os detalhes da implementação com base no código existente.
+
+Use o Claude Code diretamente quando o resultado e os limites seguros da implementação já estiverem claros. Use estes fluxos quando uma mudança exigir acordo de escopo, decisões de design duradouras, uma passagem de contexto confiável ou verificação independente.
+
+---
+
+## Quando vale a pena usar o fluxo?
+
+O fluxo adiciona chamadas de agentes e documentos, então precisa compensar esse custo. Ele é útil quando uma descoberta paralela real pode desviar uma mudança grande do objetivo, quando um design coerente pode deixar de fora o comportamento solicitado ou quando um teste que passa não observa de fato aquilo que diz verificar.
+
+Depois que o escopo de implementação é aprovado, o Claude conduz as tarefas pelas verificações específicas, pelos controles de qualidade do repositório, pelos commits e pela revisão final, sem pedir confirmação para decisões rotineiras. Mudanças de produto e decisões importantes de design voltam para o usuário; escolhas reversíveis de implementação ficam com o Claude. Como o processo é distribuído na forma de plugin do Claude Code, a equipe pode aplicar os mesmos controles em vários repositórios sem prescrever os passos do Claude.
+
+---
+
+## Início rápido
+
+Requer uma versão do Claude Code com suporte ao marketplace de plugins.
+
+### Escolha um caminho
+
+| O que você precisa? | Comece com | Plugin |
+|---|---|---|
+| Entregar de ponta a ponta uma mudança de backend, API, CLI ou de uso geral | `/recipe-implement` | `dev-workflows` |
+| Projetar uma mudança de backend ou de uso geral antes da implementação | `/recipe-design` | `dev-workflows` |
+| Projetar e implementar um frontend React / TypeScript | `/recipe-front-design` → `/recipe-front-plan` → `/recipe-front-build` | `dev-workflows-frontend` |
+| Entregar backend e frontend React juntos | `/recipe-fullstack-implement` | `dev-workflows-fullstack` |
+| Revisar uma implementação em relação ao design | `/recipe-review` ou `/recipe-front-review` | `dev-workflows` ou `dev-workflows-frontend` |
+| Investigar um problema antes de escolher a correção | `/recipe-diagnose` | Qualquer plugin de fluxo |
+| Documentar um sistema existente a partir do código | `/recipe-reverse-engineer` | `dev-workflows` ou `dev-workflows-fullstack` |
+| Fazer um experimento descartável ou protótipo | Use o Claude Code diretamente | Nenhum |
+
+### Configuração comum
+
+```bash
+# 1. Inicie o Claude Code
+claude
+
+# 2. Adicione o marketplace
+/plugin marketplace add shinpr/claude-code-workflows
+```
+
+### Instale um único plugin de fluxo
+
+Instale o plugin adequado ao projeto. Se a instalação pedir para executar `/reload-plugins`, faça isso antes de chamar uma recipe.
+
+```bash
+# Backend ou uso geral
+/plugin install dev-workflows@claude-code-workflows
+/recipe-implement "Add rate limiting to the public API"
+
+# Frontend
+/plugin install dev-workflows-frontend@claude-code-workflows
+/recipe-front-design "Add account recovery screens"
+
+# Full stack
+/plugin install dev-workflows-fullstack@claude-code-workflows
+/recipe-fullstack-implement "Add user authentication with JWT + login form"
+```
+
+Instale apenas um plugin de fluxo. O `dev-workflows-fullstack` já inclui os fluxos de backend e frontend. Se você usava as recipes full stack do `dev-workflows`, migre para o `dev-workflows-fullstack`.
+
+O `/recipe-front-design` termina depois que a UI Spec e o Design Doc aplicáveis forem revisados e aprovados. Execute `/recipe-front-plan` e `/recipe-front-build` quando quiser continuar. Para backend ou mudanças de uso geral, `/recipe-design`, `/recipe-plan` e `/recipe-build` oferecem as mesmas etapas.
+
+### Configuração para equipes
+
+O Claude Code aceita marketplaces e plugins com escopo de projeto. Inclua o arquivo `.claude/settings.json` gerado no repositório para que os colaboradores usem o mesmo plugin.
+
+```bash
+claude plugin marketplace add shinpr/claude-code-workflows --scope project
+claude plugin install dev-workflows-fullstack@claude-code-workflows --scope project
+```
+
+Substitua `dev-workflows-fullstack` pelo plugin adequado ao repositório. Consulte a [documentação de plugins do Claude Code](https://code.claude.com/docs/en/discover-plugins#configure-team-marketplaces) para conhecer as opções de instalação com escopo de projeto e de instalação gerenciada.
+
+---
+
+## Como funciona
+
+```mermaid
+flowchart LR
+    A[Request] --> B[Agree on outcome and exclusions]
+    B --> C{One evident implementation path?}
+    C -->|Yes| S[Direct task cycle]
+    S --> J[Complete]
+    C -->|No| D[Inspect, design, and review]
+    D --> E[Approve implementation scope]
+    E --> F[Per task: implement, verify, quality-check, commit]
+    F --> I[Independent implementation and security review]
+    I -->|Correction| F
+    I -->|Boundary changed| B
+    I -->|Passed| J[Complete]
+```
+
+O caminho é determinado pelo número de decisões de produto e design, não pela quantidade de arquivos nem pelo volume da implementação.
+
+| Escala | O que a mudança exige | O que acontece |
+|---|---|---|
+| Small | Um resultado que segue um padrão existente dentro de uma única responsabilidade | Ciclo direto de tarefas → verificações específicas e do repositório → revisão de segurança |
+| Medium | Um resultado que atravessa responsabilidades ou requer uma decisão duradoura de design | Design Doc revisado, mais UI Spec / ADR quando necessário → prova de integração/E2E selecionada → Work Plan revisado → ciclos de tarefas → revisão final |
+| Large | Vários resultados independentes de produto que exigem decisões separadas de design | PRD e Design Docs revisados, mais UI Spec / ADR quando necessário → prova de integração/E2E selecionada → Work Plan revisado → ciclos de tarefas → revisão final |
+
+UI Specs, ADRs e esqueletos de testes de integração ou E2E só aparecem quando as respectivas decisões ou fronteiras de verificação se aplicam.
+
+Gerar um documento, por si só, não faz o fluxo avançar. As afirmações do design são verificadas contra o repositório antes da aprovação. O Work Plan é revisado quanto à cobertura, à ordem das dependências e à viabilidade das verificações antes de autorizar a implementação. Cada tarefa só entra em um commit depois de passar pelas verificações específicas e pelos controles aplicáveis do repositório. Ao fim da implementação em etapas, revisões separadas examinam a consistência com o design, a cobertura observável e a segurança.
+
+A sessão principal decide quais descobertas pertencem ao resultado atual, resolve dúvidas de implementação com base no repositório e mantém em andamento o trabalho que não foi afetado. Sugestões de revisão não viram tarefas automaticamente. Correções aceitas retornam à implementação e passam novamente pelos controles afetados.
+
+### Como as decisões sobrevivem a novos contextos
+
+Um novo contexto em cada fase evita que o raciocínio de uma fase vire, silenciosamente, a autoridade da seguinte. O [modelo de Work Plan](skills/documentation-criteria/references/plan-template.md) incluído exige que todo requisito técnico aprovado em um Design Doc tenha uma tarefa correspondente ou uma lacuna explícita. Ele não transforma cada seção do documento nem cada sugestão de revisão em tarefa. Uma lacuna significa que um requisito aprovado ainda não tem uma tarefa de implementação ou verificação.
+
+```markdown
+| Design Doc | DD Section | DD Item | Category | Covered By Task(s) | Gap Status | Notes |
+|---|---|---|---|---|---|---|
+| docs/design/example.md | API contract | Preserve the error response shape | contract-change | Phase 2 Task 1 | covered | |
+| docs/design/example.md | Verification | Exercise cache invalidation | verification | | gap | Add a covering task before approval |
+```
+
+O [modelo de Task](skills/documentation-criteria/references/task-template.md) leva para a implementação as decisões obrigatórias e os valores observáveis dos contratos, cada um com uma verificação de conformidade que pode ser respondida com sim ou não. Depois da execução, os controles aplicáveis do repositório rodam sobre a mudança completa antes do commit. Os revisores finais leem as mesmas fontes aprovadas e o código concluído, em vez de depender da conversa de implementação.
+
+### Uma execução real
+
+O [recurso de sincronização incremental do mcp-local-rag](https://github.com/shinpr/mcp-local-rag/pull/171) foi uma mudança de 42 arquivos que atravessou a leitura do sistema de arquivos, o armazenamento, a CLI e as interfaces MCP. Uma revisão independente de segurança devolveu a implementação duas vezes. Ela encontrou leituras de arquivos antes da validação e uma forma de contornar a restrição de caminhos por meio de um diretório pai com link simbólico.
+
+A execução começou com um Work Plan que fazia referência a um ADR e a um Design Doc inexistentes, deixando incerta a fonte aprovada para as decisões técnicas. O usuário optou por tratar o Work Plan como referência principal, e a recipe o dividiu em 13 tarefas planejadas. A implementação final incluiu as mudanças necessárias para verificar o comportamento aprovado, enquanto o PR registrou por que o modo watch e os jobs persistentes ficaram fora do escopo.
+
+### O que verificar após a primeira execução
+
+- A abordagem combinada ampliou o que já existia e apresentou evidências para cada adição?
+- É possível seguir cada requisito até uma tarefa e um método de verificação observável?
+- Toda tarefa concluída passou pelas verificações específicas e do repositório antes do commit?
+- A revisão final comparou toda a mudança com o comportamento esperado e os requisitos de segurança?
+- Quando um revisor propôs mais trabalho, o relatório explicou por que a sugestão foi aplicada ou recusada?
+
+---
+
+## Fluxos mais comuns
+
+### Desenvolvimento completo de backend ou uso geral
+
+```bash
+/recipe-implement "Add rate limiting to the public API"
+```
+
+A recipe delimita a mudança, examina a implementação atual, cria somente os documentos necessários para as decisões e pausa quando precisa de uma aprovação. Em seguida, conclui a implementação planejada e a revisão final.
+
+### Projetar primeiro e implementar depois
+
+```bash
+# Backend ou uso geral
+/recipe-design "Design rate limiting for the public API"
+/recipe-plan
+/recipe-build
+
+# Frontend React
+/recipe-front-design "Build a user profile dashboard"
+/recipe-front-plan
+/recipe-front-build
+```
+
+As recipes de design examinam a implementação existente, confirmam o escopo, criam os documentos necessários, executam uma revisão independente de consistência e param para aprovação. O planejamento e a implementação podem continuar mais tarde, em outro contexto ou por outra pessoa, a partir dos documentos aprovados.
+
+O caminho de frontend acrescenta análise e uma UI Spec quando a estrutura ou o comportamento da interface ainda precisa ser definido, além de arquitetura de componentes, React Testing Library e verificações de TypeScript.
+
+Por exemplo, dois componentes de um dashboard podem tratar corretamente seus estados de carregamento isoladamente, mas a tela combinada pode não definir o que acontece quando um ainda carrega e o outro falha. A UI Spec registra essa combinação de estados e a relaciona ao trabalho de design e teste antes da integração.
+
+### Desenvolvimento full stack
+
+```bash
+/recipe-fullstack-implement "Add user authentication with JWT + React login form"
+```
+
+Quando a mudança contém vários resultados independentes de produto, um único PRD cobre toda a funcionalidade. Os designs de backend e frontend permanecem separados, o `design-sync` verifica a fronteira entre eles e o Work Plan usa slices verticais para testar a integração desde cedo.
+
+Use `/recipe-fullstack-build` para continuar a partir de um Work Plan full stack existente. O plugin full stack também inclui as recipes de backend e frontend aplicáveis.
+
+<details>
+<summary>Mais exemplos de fluxo</summary>
+
+#### Revisar uma implementação em relação ao design
+
+```bash
+/recipe-review
+```
+
+O fluxo de revisão compara a implementação com os Design Docs e executa uma revisão independente de segurança. Uma correção que altera uma decisão aprovada volta ao documento correspondente em vez de mudar o contrato silenciosamente.
+
+#### Investigar antes de escolher uma correção
+
+```bash
+/recipe-diagnose "API returns 500 on user login"
+```
+
+O fluxo de diagnóstico mapeia os caminhos de execução, verifica possíveis pontos de falha e apresenta os prós e contras das soluções. Ele não altera o código.
+
+#### Documentar um sistema existente a partir do código
+
+```bash
+/recipe-reverse-engineer "src/auth module"
+```
+
+Esse fluxo deriva PRDs e Design Docs do código e os verifica em relação à implementação. Use a opção full stack quando a funcionalidade atravessar backend e frontend.
+
+Veja [How I Made Legacy Code AI-Friendly with Auto-Generated Docs](https://dev.to/shinpr/how-i-made-legacy-code-ai-friendly-with-auto-generated-docs-4353) para acompanhar um exemplo completo.
+
+#### Ajustar uma UI implementada a partir de uma fonte de design
+
+```bash
+/recipe-front-adjust "Align the card spacing and actions with the design source"
+```
+
+O plugin de frontend registra como acessar a fonte externa de design, confirma o conjunto de arquivos a alterar e repete a verificação visual até o ajuste passar pelos controles.
+
+</details>
+
+---
+
+## Referência das recipes
+
+Todos os pontos de entrada usam o prefixo `recipe-`. Digite `/recipe-` e use Tab para ver as opções instaladas.
+
+<details>
+<summary>Ver todas as recipes de backend e uso geral</summary>
+
+| Recipe | Objetivo | Quando usar |
+|---|---|---|
+| `/recipe-implement` | Implementar uma funcionalidade de ponta a ponta | Novas funcionalidades e fluxos completos |
+| `/recipe-design` | Criar documentação de design | Planejamento de arquitetura |
+| `/recipe-plan` | Gerar um Work Plan a partir do design | Etapa de planejamento |
+| `/recipe-build` | Executar um Work Plan existente | Retomar uma implementação |
+| `/recipe-review` | Verificar a implementação em relação aos Design Docs | Verificação após a implementação |
+| `/recipe-diagnose` | Investigar um problema e comparar soluções | Análise de causa raiz |
+| `/recipe-reverse-engineer` | Derivar PRDs e Design Docs do código | Documentação de sistemas existentes |
+| `/recipe-add-integration-tests` | Adicionar testes de integração ou E2E | Cobertura para código existente |
+| `/recipe-update-doc` | Atualizar e revisar documentos existentes | Mudanças de requisitos ou design |
+| `/recipe-task` | Executar diretamente uma tarefa guiada por regras | Trabalho que não precisa de passagem de contexto entre etapas |
+
+</details>
+
+<details>
+<summary>Ver todas as recipes de frontend</summary>
+
+O plugin de frontend acrescenta análise específica de React, arquitetura de componentes, React Testing Library, verificações de TypeScript e, quando necessário, a geração de uma UI Spec a partir de um protótipo.
+
+| Recipe | Objetivo | Quando usar |
+|---|---|---|
+| `/recipe-front-design` | Criar a UI Spec e o Design Doc de frontend aplicáveis | Arquitetura de componentes React |
+| `/recipe-front-plan` | Gerar um Work Plan de frontend | Planejamento de componentes |
+| `/recipe-front-build` | Executar o Work Plan de frontend | Retomar a implementação React |
+| `/recipe-front-adjust` | Ajustar uma UI implementada com verificação externa | Refinamentos visuais |
+| `/recipe-front-review` | Verificar a implementação em relação aos Design Docs de frontend | Verificação após a implementação |
+| `/recipe-diagnose` | Investigar um problema e comparar soluções | Análise de causa raiz |
+| `/recipe-update-doc` | Atualizar e revisar documentos existentes | Mudanças de requisitos ou design |
+| `/recipe-task` | Executar diretamente uma tarefa guiada por regras | Trabalho que não precisa de passagem de contexto entre etapas |
+
+</details>
+
+---
+
+## O que os plugins incluem
+
+Agentes especializados mantêm a análise e o design separados da execução e da revisão final. Cada plugin inclui somente os papéis usados por seus fluxos; o plugin full stack combina os papéis de backend e frontend. A lista completa está abaixo.
+
+<details>
+<summary>Ver todos os papéis de agentes especializados</summary>
+
+### Agentes compartilhados
+
+Estes agentes são compartilhados pelos plugins de backend, frontend e full stack:
+
+| Agente | Função |
+|---|---|
+| **requirement-analyzer** | Reúne evidências objetivas de escopo e custo para as decisões de requisitos e fluxo do orquestrador |
+| **prd-creator** | Define requisitos de produto para funcionalidades maiores |
+| **codebase-analyzer** | Examina o código e as dependências existentes antes do design |
+| **code-verifier** | Compara os documentos com a implementação |
+| **work-planner** | Transforma decisões de design em um Work Plan executável |
+| **task-decomposer** | Divide um Work Plan em tarefas prontas para commit |
+| **acceptance-test-generator** | Cria esqueletos de testes de integração e E2E a partir dos requisitos |
+| **integration-test-reviewer** | Revisa testes de integração e E2E em relação à cobertura pretendida |
+| **code-reviewer** | Verifica a implementação em relação aos Design Docs |
+| **document-reviewer** | Verifica a integridade do documento e a conformidade com as regras |
+| **design-sync** | Detecta conflitos entre vários Design Docs |
+| **investigator** | Mapeia caminhos de execução e identifica possíveis pontos de falha |
+| **verifier** | Questiona possíveis pontos de falha e verifica a cobertura dos caminhos |
+| **solver** | Compara soluções e seus trade-offs |
+| **security-reviewer** | Revisa a implementação concluída em busca de problemas de segurança |
+| **rule-advisor** | Seleciona as regras de desenvolvimento relevantes para a tarefa |
+
+### Agentes específicos de backend
+
+| Agente | Função |
+|---|---|
+| **technical-designer** | Projeta a abordagem técnica e a arquitetura |
+| **scope-discoverer** | Encontra limites funcionais na implementação existente |
+| **task-executor** | Implementa tarefas de backend com verificação orientada por testes |
+| **quality-fixer** | Executa testes, verificações de tipos, lint e outros controles de qualidade |
+
+### Agentes específicos de frontend
+
+| Agente | Função |
+|---|---|
+| **ui-spec-designer** | Cria uma UI Spec a partir dos requisitos e de um protótipo opcional |
+| **ui-analyzer** | Obtém fontes e sistemas de design, consulta diretrizes e examina a UI existente |
+| **technical-designer-frontend** | Projeta a arquitetura de componentes React e o gerenciamento de estado |
+| **task-executor-frontend** | Implementa componentes React com cobertura baseada em React Testing Library |
+| **quality-fixer-frontend** | Executa testes de frontend, verificações de TypeScript, lint e builds |
+
+</details>
+
+<details>
+<summary>Ver as orientações de desenvolvimento incluídas</summary>
+
+- **Coding Principles.** Padrões de qualidade de código.
+- **Testing Principles.** TDD, cobertura e padrões de teste.
+- **Implementation Approach.** Decisões de implementação e seus trade-offs.
+- **Documentation Standards.** Documentação clara e fácil de manter.
+- **External Resource Context.** Registra como chegar a fontes e sistemas de design, esquemas de API, definições de infraestrutura e outros recursos externos.
+- **LLM-Friendly Context.** Prompts, passagens de contexto, documentos e instruções claros para que os próximos agentes executem sem precisar adivinhar.
+
+Os agentes carregam essas skills conforme a necessidade do trabalho. O plugin de frontend também inclui regras específicas de React e TypeScript.
+
+</details>
+
+<details>
+<summary>Usar as orientações sem o fluxo (dev-skills)</summary>
+
+Se você já tem orquestração por meio de prompts próprios ou CI e precisa apenas das orientações de boas práticas, use `dev-skills`. Se quiser que o Claude planeje, execute e verifique uma mudança de ponta a ponta, instale o plugin de fluxo adequado.
+
+- Uso mínimo de contexto, sem agentes
+- Orientações de desenvolvimento, testes, design e documentação sem impor um processo
+- Carregamento automático das skills relevantes para cada tarefa
+
+> **Não instale `dev-skills` junto com um plugin de fluxo.** Eles compartilham as mesmas skills, e descrições duplicadas podem fazer com que o Claude Code ignore skills depois de atingir o limite de contexto.
+
+```bash
+/plugin install dev-skills@claude-code-workflows
+```
+
+Para alternar entre os tipos de plugin:
+
+```bash
+# dev-skills -> dev-workflows
+/plugin uninstall dev-skills@claude-code-workflows
+/plugin install dev-workflows@claude-code-workflows
+
+# dev-workflows -> dev-skills
+/plugin uninstall dev-workflows@claude-code-workflows
+/plugin install dev-skills@claude-code-workflows
+```
+
+</details>
+
+<details>
+<summary>Ver complementos opcionais</summary>
+
+Estes plugins cobrem funções relacionadas sem alterar o fluxo principal:
+
+- [claude-code-discover](https://github.com/shinpr/claude-code-discover): transforma ideias de funcionalidades em PRDs sustentados por evidências.
+- [metronome](https://github.com/shinpr/metronome): detecta atalhos e pede que o Claude siga o procedimento definido.
+- [linear-prism](https://github.com/shinpr/linear-prism): valida requisitos e os transforma em tarefas estruturadas do Linear.
+- [pr-review](https://github.com/shinpr/pr-review-skill): revisa PRs do GitHub segundo os critérios do repositório e publica apenas os achados aprovados.
+
+```bash
+/plugin install discover@claude-code-workflows
+/plugin install metronome@claude-code-workflows
+/plugin install linear-prism@claude-code-workflows
+/plugin install pr-review@claude-code-workflows
+```
+
+</details>
+
+---
+
+## Perguntas frequentes
+
+**P: O que acontece se houver erros?**
+
+R: Os agentes quality-fixer resolvem falhas de testes, tipos, lint e build dentro do resultado aprovado, inclusive mudanças adjacentes exigidas pela mesma responsabilidade ou contrato.
+
+O fluxo só para quando uma correção:
+
+- altera o resultado do produto, um contrato aprovado ou uma decisão importante de design;
+- exige uma autorização que pertence ao usuário;
+- executa uma ação externa irreversível que não está coberta pela autorização existente.
+
+**P: Existe uma versão para o OpenAI Codex CLI?**
+
+R: Sim. O **[codex-workflows](https://github.com/shinpr/codex-workflows)** usa o mesmo modelo de fluxo, adaptado ao ambiente do Codex CLI.
+
+**P: Devo incluir no commit o Work Plan e os arquivos de tarefas em `docs/plans/`?**
+
+R: Não. As recipes tratam `docs/plans/` como estado temporário de trabalho. Arquivos de tarefas já usados e arquivos intermediários de correção são removidos após a conclusão bem-sucedida. O Work Plan pode permanecer para revisão ou para uma execução futura e pode ser excluído quando não for mais necessário. Adicione a linha abaixo ao `.gitignore` do projeto para manter esse estado fora do controle de versão:
+
+```
+docs/plans/
+```
+
+PRDs, ADRs, UI Specs e Design Docs ficam em `docs/prd/`, `docs/adr/`, `docs/ui-spec/` e `docs/design/`, respectivamente, e devem ser incluídos no repositório.
+
+---
+
+## Contribuindo com plugins externos
+
+Este marketplace cobre todo o ciclo de desenvolvimento de produtos com IA: qualidade do produto, descoberta, controle da implementação e verificação. Se o seu plugin ajuda agentes de programação a entregar produtos melhores, queremos conhecê-lo.
+
+Consulte [CONTRIBUTING.md](CONTRIBUTING.md) para ver as instruções e os critérios de aceitação.
+
+<details>
+<summary>Ver a estrutura do repositório</summary>
+
+```
+claude-code-workflows/
+├── .claude-plugin/
+│   └── marketplace.json        # Plugin definitions and per-plugin contents
+├── agents/                     # Specialized analysis, design, execution, and review roles
+├── skills/
+│   ├── recipe-*/               # Workflow entry points
+│   ├── documentation-criteria/ # Document rules and templates
+│   ├── coding-principles/
+│   ├── testing-principles/
+│   ├── external-resource-context/
+│   ├── llm-friendly-context/
+│   └── ...
+├── LICENSE
+└── README.md
+```
+
+</details>
+
+---
+
+## Fundamentos do design
+
+<details>
+<summary>Leituras relacionadas</summary>
+
+- [Why LLMs Are Bad at 'First Try' and Great at Verification](https://www.norsica.jp/blog/llm-verification-over-generation): por que feedback externo e novos contextos são mais confiáveis do que pedir à mesma sessão para gerar e avaliar o próprio trabalho.
+- [When Better Models Make Old Agent Workflows Worse](https://www.norsica.jp/blog/when-better-models-make-old-agent-workflows-worse): por que o fluxo é rigoroso com limites e evidências sem impor um caminho específico.
+- [Reasoning Effort Is Not a Quality Setting](https://www.norsica.jp/blog/reasoning-effort-is-not-a-quality-setting): por que uma exploração mais ampla ainda precisa convergir para o trabalho que o resultado atual justifica.
+- [Stop Putting Everything in AGENTS.md](https://www.norsica.jp/blog/stop-putting-everything-in-agents-md): por que instruções permanentes devem permanecer pequenas e skills, decisões de design e orientações de tarefas devem ser carregadas conforme a necessidade.
+
+</details>
+
+---
+
+## Licença
+
+Licença MIT. Você pode usar, modificar e distribuir livremente.
+
+Consulte [LICENSE](LICENSE) para saber mais.
+
+---
+
+Desenvolvido e mantido por [@shinpr](https://github.com/shinpr).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,466 @@
+# Claude Code 开发工作流
+
+[![Claude Code](https://img.shields.io/badge/Claude%20Code-Plugin-purple)](https://claude.ai/code)
+[![GitHub Stars](https://img.shields.io/github/stars/shinpr/claude-code-workflows?style=social)](https://github.com/shinpr/claude-code-workflows)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/shinpr/claude-code-workflows/pulls)
+
+[English](README.md) | **简体中文** | [日本語](README.ja.md) | [Español](README.es.md) | [한국어](README.ko.md) | [Português (Brasil)](README.pt-BR.md)
+
+Claude Code能够深入探索代码库。但面对复杂任务时，真正困难的往往不是探索，而是让探索最终收敛。比如在设计账户恢复流程时，Claude可能发现令牌处理存在真实的不一致，并把大部分精力投入其中，结果反而没有说清用户真正需要的恢复行为。
+
+claude-code-workflows让探索始终围绕已经约定的结果展开。它在设计前确认目标和排除项，对照代码库检查设计，在提交前验证每个任务；对于较大的变更，还会独立审查最终实现是否符合预期行为和安全要求。在这个边界内，Claude根据代码库自行决定实现细节。
+
+如果目标和安全的实现边界已经清楚，直接使用Claude Code即可。如果变更需要先对范围达成一致、保留可追溯的设计决策、在不同上下文之间可靠交接，或进行独立验证，请使用这些工作流。
+
+---
+
+## 什么时候适合使用？
+
+工作流会增加Agent调用和文档产物，因此应该只在收益足以覆盖成本时使用。当一个实际发现的次要问题可能让大型变更偏离原目标、设计看似自洽却可能漏掉所需行为，或者通过的测试并未真正观察到它声称验证的内容时，这套工作流最有价值。
+
+实现范围获批后，Claude会完成每个任务的针对性验证、仓库质量检查、提交和最终审查，不会为常规实现决策反复询问。产品变更和重大设计变更会交回用户决定；可逆的实现选择由Claude处理。由于它以Claude Code插件形式提供，团队可以在不规定Claude具体步骤的前提下，在不同仓库中应用同一套控制机制。
+
+---
+
+## 快速开始
+
+需要使用支持插件市场的Claude Code版本。
+
+### 选择合适的路径
+
+| 你需要什么？ | 从这里开始 | 插件 |
+|---|---|---|
+| 端到端交付后端、API、CLI或通用变更 | `/recipe-implement` | `dev-workflows` |
+| 在实现前设计后端或通用变更 | `/recipe-design` | `dev-workflows` |
+| 设计并实现React / TypeScript前端 | `/recipe-front-design` → `/recipe-front-plan` → `/recipe-front-build` | `dev-workflows-frontend` |
+| 同时交付后端和React前端 | `/recipe-fullstack-implement` | `dev-workflows-fullstack` |
+| 按照设计审查实现 | `/recipe-review` 或 `/recipe-front-review` | `dev-workflows` 或 `dev-workflows-frontend` |
+| 在选择修复方案前调查问题 | `/recipe-diagnose` | 任意工作流插件 |
+| 根据代码记录现有系统 | `/recipe-reverse-engineer` | `dev-workflows` 或 `dev-workflows-fullstack` |
+| 一次性实验或原型 | 直接使用Claude Code | 无 |
+
+### 通用设置
+
+```bash
+# 1. 启动Claude Code
+claude
+
+# 2. 添加插件市场
+/plugin marketplace add shinpr/claude-code-workflows
+```
+
+### 安装一个工作流插件
+
+安装与项目相匹配的插件。如果安装后提示运行`/reload-plugins`，请先执行它，再调用recipe。
+
+```bash
+# 后端或通用变更
+/plugin install dev-workflows@claude-code-workflows
+/recipe-implement "Add rate limiting to the public API"
+
+# 前端
+/plugin install dev-workflows-frontend@claude-code-workflows
+/recipe-front-design "Add account recovery screens"
+
+# 全栈
+/plugin install dev-workflows-fullstack@claude-code-workflows
+/recipe-fullstack-implement "Add user authentication with JWT + login form"
+```
+
+只安装一个工作流插件。`dev-workflows-fullstack`已经包含后端和前端工作流。如果你之前使用`dev-workflows`中的全栈recipe，请迁移到`dev-workflows-fullstack`。
+
+`/recipe-front-design`会在适用的UI Spec和Design Doc完成审查并获批后停止。准备继续时，运行`/recipe-front-plan`和`/recipe-front-build`。后端或通用变更也提供同样分阶段的`/recipe-design`、`/recipe-plan`和`/recipe-build`。
+
+### 团队设置
+
+Claude Code支持项目级插件市场和插件。提交生成的`.claude/settings.json`，让贡献者也使用同一个工作流插件。
+
+```bash
+claude plugin marketplace add shinpr/claude-code-workflows --scope project
+claude plugin install dev-workflows-fullstack@claude-code-workflows --scope project
+```
+
+请将`dev-workflows-fullstack`替换为适合当前仓库的插件。项目级和受管安装方式请参见[Claude Code插件文档](https://code.claude.com/docs/en/discover-plugins#configure-team-marketplaces)。
+
+---
+
+## 工作原理
+
+```mermaid
+flowchart LR
+    A[Request] --> B[Agree on outcome and exclusions]
+    B --> C{One evident implementation path?}
+    C -->|Yes| S[Direct task cycle]
+    S --> J[Complete]
+    C -->|No| D[Inspect, design, and review]
+    D --> E[Approve implementation scope]
+    E --> F[Per task: implement, verify, quality-check, commit]
+    F --> I[Independent implementation and security review]
+    I -->|Correction| F
+    I -->|Boundary changed| B
+    I -->|Passed| J[Complete]
+```
+
+路径由产品决策和设计决策的数量决定，而不是文件数量或实现工作量。
+
+| 规模 | 变更需要什么 | 执行内容 |
+|---|---|---|
+| Small | 一个沿用现有模式、且限定在单一职责内的结果 | 直接执行任务 → 针对当前任务的检查和仓库检查 → 安全审查 |
+| Medium | 一个跨越多个职责或需要长期设计决策的结果 | 经审查的Design Doc，以及按需添加的UI Spec / ADR → 选定的集成/E2E验证 → 经审查的Work Plan → 任务周期 → 最终审查 |
+| Large | 多个需要分别做设计决策的独立产品结果 | 经审查的PRD和Design Doc，以及按需添加的UI Spec / ADR → 选定的集成/E2E验证 → 经审查的Work Plan → 任务周期 → 最终审查 |
+
+只有确实存在相应决策或验证边界时，才会创建UI Spec、ADR以及集成或E2E测试骨架。
+
+仅仅生成文档并不会推动工作流继续。设计中的主张必须在批准前与仓库核对。Work Plan必须经过范围覆盖、依赖顺序和可执行验证方面的审查，才能授权实现。每项任务只有通过针对当前任务的检查和适用的仓库检查后才会提交。分阶段实现完成后，独立审查会分别检查设计一致性、可观测行为的覆盖和安全性。
+
+主会话负责判断哪些发现属于当前目标，根据仓库解决实现问题，并让不受影响的工作继续进行。审查建议不会自动变成新任务。被接受的修正会返回实现阶段，并重新经过受影响的验证环节。
+
+### 如何在新上下文中保留决策
+
+每个阶段使用新的上下文，避免上一阶段的推理在下一阶段悄悄变成权威。内置的[Work Plan模板](skills/documentation-criteria/references/plan-template.md)要求Design Doc中每条已批准的技术需求都有对应任务，或被明确标记为缺口。它不会把文档的每个章节或每条审查建议都转成任务。缺口表示某项已批准需求还没有实现或验证任务。
+
+```markdown
+| Design Doc | DD Section | DD Item | Category | Covered By Task(s) | Gap Status | Notes |
+|---|---|---|---|---|---|---|
+| docs/design/example.md | API contract | Preserve the error response shape | contract-change | Phase 2 Task 1 | covered | |
+| docs/design/example.md | Verification | Exercise cache invalidation | verification | | gap | Add a covering task before approval |
+```
+
+[Task模板](skills/documentation-criteria/references/task-template.md)会把具有约束力的决策和对外可验证的契约内容带入实现，并为每一项提供可用“是/否”判断的合规检查。执行完成后，在提交前对整个任务变更运行适用的仓库检查。最终审查者读取同一套已批准来源和完成的代码，而不是依赖实现过程中的对话。
+
+### 一次真实的工作流执行
+
+[mcp-local-rag的增量同步功能](https://github.com/shinpr/mcp-local-rag/pull/171)是一项涉及文件系统扫描、存储、CLI和MCP接口的42文件变更。独立安全审查两次将实现退回修改，发现了验证前读取文件，以及通过符号链接父目录绕过路径边界的问题。
+
+执行开始时，现有Work Plan引用的ADR和Design Doc并不存在，因此技术决策的批准来源并不明确。用户选择把Work Plan作为权威来源，recipe将其拆分成13项计划任务。最终实现包含验证已批准行为所需的变更，同时PR记录了为何不包含watch模式和持久化任务。
+
+### 首次运行后应该检查什么
+
+- 约定的方法是否扩展了现有实现，并为每项新增内容提供依据？
+- 能否从每项需求追踪到任务和可观察的验证方法？
+- 每项已完成任务是否在提交前通过针对性检查和仓库质量检查？
+- 最终审查是否将整个变更与预期行为和安全要求进行了比较？
+- 审查者建议增加工作时，报告是否说明了采纳或拒绝的原因？
+
+---
+
+## 常用工作流
+
+### 端到端完成后端或通用开发
+
+```bash
+/recipe-implement "Add rate limiting to the public API"
+```
+
+recipe会确定变更范围、检查当前实现，只创建决策所需的文档；需要用户决定时暂停，然后继续按照计划完成实现和最终审查。
+
+### 先设计，后实现
+
+```bash
+# 后端或通用变更
+/recipe-design "Design rate limiting for the public API"
+/recipe-plan
+/recipe-build
+
+# React前端
+/recipe-front-design "Build a user profile dashboard"
+/recipe-front-plan
+/recipe-front-build
+```
+
+设计recipe会检查现有实现、确认范围、创建必要文档并进行独立一致性审查，然后等待批准。之后可以在新的上下文中，或由其他贡献者依据已批准的产物继续规划和实现。
+
+当需要进一步设计前端UI结构或行为时，前端路径会增加UI分析和UI Spec，并包含组件架构、React Testing Library与TypeScript检查。
+
+例如，两个仪表盘组件可能各自正确处理加载状态，但当一个仍在加载、另一个已经失败时，整个页面的行为却没有定义。UI Spec会记录这种状态组合，并在集成前将它追踪到设计与测试工作。
+
+### 全栈开发
+
+```bash
+/recipe-fullstack-implement "Add user authentication with JWT + React login form"
+```
+
+当变更包含多个独立产品结果时，一个PRD覆盖整个功能。前后端设计保持分离，`design-sync`检查两者边界，Work Plan采用纵向切片，以便尽早验证集成。
+
+使用`/recipe-fullstack-build`可从现有的全栈Work Plan继续执行。全栈插件也包含适用的后端和前端recipe。
+
+<details>
+<summary>更多工作流示例</summary>
+
+#### 按照设计审查实现
+
+```bash
+/recipe-review
+```
+
+审查工作流会将实现与Design Doc比较，并运行独立安全审查。如果修正会改变已批准的决策，它会返回相应文档，而不会悄悄修改契约。
+
+#### 选择修复方案前先调查问题
+
+```bash
+/recipe-diagnose "API returns 500 on user login"
+```
+
+诊断工作流会绘制执行路径、验证疑似故障点，并给出不同解决方案的取舍。它不会修改代码。
+
+#### 根据代码记录现有系统
+
+```bash
+/recipe-reverse-engineer "src/auth module"
+```
+
+该流程从代码生成PRD和Design Doc，并对照实现进行验证。功能同时涉及前后端时，请使用全栈版本。
+
+完整示例参见[How I Made Legacy Code AI-Friendly with Auto-Generated Docs](https://dev.to/shinpr/how-i-made-legacy-code-ai-friendly-with-auto-generated-docs-4353)。
+
+#### 根据设计来源调整已经实现的UI
+
+```bash
+/recipe-front-adjust "Align the card spacing and actions with the design source"
+```
+
+前端插件会记录如何访问外部设计来源，确认写入范围，并反复进行视觉验证，直到调整通过检查。
+
+</details>
+
+---
+
+## Workflow Recipe参考
+
+所有工作流入口都以`recipe-`开头。输入`/recipe-`并按Tab键即可查看已安装的候选项。
+
+<details>
+<summary>查看全部后端和通用recipe</summary>
+
+| Recipe | 用途 | 适用场景 |
+|---|---|---|
+| `/recipe-implement` | 端到端实现功能 | 新功能、完整工作流 |
+| `/recipe-design` | 创建设计文档 | 架构规划 |
+| `/recipe-plan` | 根据设计生成Work Plan | 规划阶段 |
+| `/recipe-build` | 执行已有Work Plan | 继续实现 |
+| `/recipe-review` | 按照Design Doc验证实现 | 实现后检查 |
+| `/recipe-diagnose` | 调查问题并比较解决方案 | 根因分析 |
+| `/recipe-reverse-engineer` | 根据代码生成PRD和Design Doc | 现有系统文档化 |
+| `/recipe-add-integration-tests` | 添加集成或E2E测试 | 为现有代码补充覆盖 |
+| `/recipe-update-doc` | 更新并审查现有文档 | 需求或设计变更 |
+| `/recipe-task` | 直接运行遵循规则的任务 | 不需要分阶段交接的工作 |
+
+</details>
+
+<details>
+<summary>查看全部前端recipe</summary>
+
+前端插件增加React专项分析、组件架构、React Testing Library、TypeScript检查，并可按需根据原型代码生成UI Spec。
+
+| Recipe | 用途 | 适用场景 |
+|---|---|---|
+| `/recipe-front-design` | 创建适用的UI Spec和前端Design Doc | React组件架构 |
+| `/recipe-front-plan` | 生成前端Work Plan | 组件规划 |
+| `/recipe-front-build` | 执行前端Work Plan | 恢复React实现 |
+| `/recipe-front-adjust` | 借助外部验证调整已实现UI | 视觉细节调整 |
+| `/recipe-front-review` | 按照前端Design Doc验证实现 | 实现后检查 |
+| `/recipe-diagnose` | 调查问题并比较解决方案 | 根因分析 |
+| `/recipe-update-doc` | 更新并审查现有文档 | 需求或设计变更 |
+| `/recipe-task` | 直接运行遵循规则的任务 | 不需要分阶段交接的工作 |
+
+</details>
+
+---
+
+## 插件包含的内容
+
+专用Agent将分析和设计与执行及最终审查分开。每个插件只包含自身工作流使用的角色；全栈插件则组合后端和前端角色。完整角色列表如下。
+
+<details>
+<summary>查看全部专用Agent角色</summary>
+
+### 共享Agent
+
+这些Agent由后端、前端和全栈工作流共享：
+
+| Agent | 职责 |
+|---|---|
+| **requirement-analyzer** | 收集精简的范围和成本证据，供编排器判断需求与工作流 |
+| **prd-creator** | 为大型功能定义产品需求 |
+| **codebase-analyzer** | 在设计前检查现有代码和依赖 |
+| **code-verifier** | 对照实现检查文档 |
+| **work-planner** | 将设计决策转为可执行的Work Plan |
+| **task-decomposer** | 将Work Plan拆分为可提交的任务 |
+| **acceptance-test-generator** | 根据需求创建集成和E2E测试骨架 |
+| **integration-test-reviewer** | 检查集成和E2E测试是否覆盖预期边界 |
+| **code-reviewer** | 对照Design Doc检查实现 |
+| **document-reviewer** | 检查文档完整性和规则合规性 |
+| **design-sync** | 发现多个Design Doc之间的冲突 |
+| **investigator** | 绘制执行路径并识别潜在故障点 |
+| **verifier** | 质疑疑似故障点并检查路径覆盖 |
+| **solver** | 比较解决方案及其取舍 |
+| **security-reviewer** | 审查已完成实现中的安全问题 |
+| **rule-advisor** | 选择与任务相关的编码规则 |
+
+### 后端专用Agent
+
+| Agent | 职责 |
+|---|---|
+| **technical-designer** | 设计技术方案和架构 |
+| **scope-discoverer** | 从现有实现中识别功能边界 |
+| **task-executor** | 通过测试优先验证实现后端任务 |
+| **quality-fixer** | 运行测试、类型检查、lint等质量检查 |
+
+### 前端专用Agent
+
+| Agent | 职责 |
+|---|---|
+| **ui-spec-designer** | 根据需求和可选原型创建UI Spec |
+| **ui-analyzer** | 获取设计来源、设计系统和规范，并检查现有UI |
+| **technical-designer-frontend** | 设计React组件架构和状态管理 |
+| **task-executor-frontend** | 实现React组件，并使用React Testing Library提供行为覆盖 |
+| **quality-fixer-frontend** | 运行前端测试、TypeScript检查、lint和构建 |
+
+</details>
+
+<details>
+<summary>查看内置开发指南</summary>
+
+- **Coding Principles：** 代码质量标准。
+- **Testing Principles：** TDD、覆盖率和测试模式。
+- **Implementation Approach：** 实现决策及其取舍。
+- **Documentation Standards：** 清晰、易维护的文档。
+- **External Resource Context：** 记录如何访问仓库外的设计来源、设计系统、API Schema、基础设施定义等资源。
+- **LLM-Friendly Context：** 让下游Agent无需猜测即可执行的提示、交接、产物和说明。
+
+Agent会在任务需要时加载这些skill。前端插件还包含React和TypeScript专项规则。
+
+</details>
+
+<details>
+<summary>不使用工作流，只使用指南（dev-skills）</summary>
+
+如果你已经通过自定义提示或CI完成编排，只需要最佳实践指南，请使用`dev-skills`。如果希望Claude端到端完成规划、执行和验证，请安装合适的工作流插件。
+
+- 最小上下文占用，不包含Agent
+- 提供编码、测试、设计和文档指南，但不规定固定流程
+- 根据任务自动加载相关skill
+
+> **不要同时安装`dev-skills`和工作流插件。** 它们包含相同的skill，重复描述可能导致Claude Code在达到上下文限制后忽略skill。
+
+```bash
+/plugin install dev-skills@claude-code-workflows
+```
+
+切换插件类型：
+
+```bash
+# dev-skills -> dev-workflows
+/plugin uninstall dev-skills@claude-code-workflows
+/plugin install dev-workflows@claude-code-workflows
+
+# dev-workflows -> dev-skills
+/plugin uninstall dev-workflows@claude-code-workflows
+/plugin install dev-skills@claude-code-workflows
+```
+
+</details>
+
+<details>
+<summary>查看可选扩展</summary>
+
+这些插件在不改变核心工作流的情况下提供相关能力：
+
+- [claude-code-discover](https://github.com/shinpr/claude-code-discover)：将功能想法转为有证据支持的PRD。
+- [metronome](https://github.com/shinpr/metronome)：发现走捷径的迹象，并要求Claude遵循既定流程。
+- [linear-prism](https://github.com/shinpr/linear-prism)：验证需求并转换为结构化Linear任务。
+- [pr-review](https://github.com/shinpr/pr-review-skill)：按照仓库标准审查GitHub PR，只发布获准的问题。
+
+```bash
+/plugin install discover@claude-code-workflows
+/plugin install metronome@claude-code-workflows
+/plugin install linear-prism@claude-code-workflows
+/plugin install pr-review@claude-code-workflows
+```
+
+</details>
+
+---
+
+## 常见问题
+
+**问：如果发生错误怎么办？**
+
+答：quality-fixer Agent会在已批准目标的范围内处理测试、类型检查、lint和构建失败，包括同一职责或契约连带需要的改动。
+
+只有在以下情况下，工作流才会停止：
+
+- 修复会改变产品目标、已批准契约或重大设计决策；
+- 需要只有用户拥有的权限；
+- 必须执行现有授权不包含、且不可逆的外部操作。
+
+**问：有适用于OpenAI Codex CLI的版本吗？**
+
+答：有。**[codex-workflows](https://github.com/shinpr/codex-workflows)**采用相同的工作流模型，并针对Codex CLI进行了调整。
+
+**问：应该提交`docs/plans/`中的Work Plan和Task文件吗？**
+
+答：不应该。recipe将`docs/plans/`视为临时工作状态。已使用的Task文件和中间修复文件会在成功完成后清理。Work Plan可能会保留用于审查或稍后继续构建，不再需要时可以删除。请在项目的`.gitignore`中加入以下内容，避免这些工作状态进入版本控制：
+
+```
+docs/plans/
+```
+
+PRD、ADR、UI Spec和Design Doc分别位于`docs/prd/`、`docs/adr/`、`docs/ui-spec/`和`docs/design/`，它们应当提交到仓库。
+
+---
+
+## 贡献外部插件
+
+这个插件市场覆盖使用AI构建产品的完整生命周期：产品质量、需求发现、实现控制和验证。如果你的插件能帮助AI编程Agent交付更好的产品，欢迎告诉我们。
+
+提交指南和验收标准请参见[CONTRIBUTING.md](CONTRIBUTING.md)。
+
+<details>
+<summary>查看仓库结构</summary>
+
+```
+claude-code-workflows/
+├── .claude-plugin/
+│   └── marketplace.json        # Plugin definitions and per-plugin contents
+├── agents/                     # Specialized analysis, design, execution, and review roles
+├── skills/
+│   ├── recipe-*/               # Workflow entry points
+│   ├── documentation-criteria/ # Document rules and templates
+│   ├── coding-principles/
+│   ├── testing-principles/
+│   ├── external-resource-context/
+│   ├── llm-friendly-context/
+│   └── ...
+├── LICENSE
+└── README.md
+```
+
+</details>
+
+---
+
+## 设计背景
+
+<details>
+<summary>相关背景文章</summary>
+
+- [Why LLMs Are Bad at 'First Try' and Great at Verification](https://www.norsica.jp/blog/llm-verification-over-generation)：为什么外部反馈和新的上下文，比让同一会话同时负责生成与评判更可靠。
+- [When Better Models Make Old Agent Workflows Worse](https://www.norsica.jp/blog/when-better-models-make-old-agent-workflows-worse)：为什么工作流严格控制边界与证据，却不规定实现路径。
+- [Reasoning Effort Is Not a Quality Setting](https://www.norsica.jp/blog/reasoning-effort-is-not-a-quality-setting)：为什么扩大探索范围后，仍然必须收敛到当前目标真正需要的工作。
+- [Stop Putting Everything in AGENTS.md](https://www.norsica.jp/blog/stop-putting-everything-in-agents-md)：为什么常驻指令应保持精简，而skill、设计决策和任务指南应按需加载。
+
+</details>
+
+---
+
+## 许可证
+
+MIT License。可自由使用、修改和分发。
+
+详情参见[LICENSE](LICENSE)。
+
+---
+
+由[@shinpr](https://github.com/shinpr)开发并维护。


### PR DESCRIPTION
## Summary

- add Simplified Chinese, Japanese, Spanish, Korean, and Brazilian Portuguese README translations
- add a language selector to every README variant
- refine localized technical terminology based on language review while preserving the English source meaning

## Verification

- confirmed matching heading, code fence, details block, and table structure across all README variants
- verified recipe names, plugin names, agent names, and external URLs against the English README
- validated every local Markdown target
- ran git diff --cached --check

This is a documentation-only change, so no runtime tests were required. The local commit hook reported that lefthook was not installed; the documentation checks above were run directly.