### PR TITLE
fix: keep document updates within the active workflow

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "dev-workflows",
       "source": "./dev-workflows",
       "strict": true,
-      "version": "0.24.8",
+      "version": "0.24.9",
       "description": "Skills + Subagents for backend development - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
       "author": {
         "name": "Shinsuke Kagawa",
@@ -82,7 +82,7 @@
       "name": "dev-workflows-frontend",
       "source": "./dev-workflows-frontend",
       "strict": true,
-      "version": "0.24.8",
+      "version": "0.24.9",
       "description": "Skills + Subagents for React/TypeScript - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
       "author": {
         "name": "Shinsuke Kagawa",
@@ -155,7 +155,7 @@
       "name": "dev-workflows-fullstack",
       "source": "./dev-workflows-fullstack",
       "strict": true,
-      "version": "0.24.8",
+      "version": "0.24.9",
       "description": "Skills + Subagents for fullstack development (backend + React/TypeScript) - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
       "author": {
         "name": "Shinsuke Kagawa",
@@ -244,7 +244,7 @@
       "name": "dev-skills",
       "source": "./dev-skills",
       "strict": true,
-      "version": "0.24.8",
+      "version": "0.24.9",
       "description": "Lightweight skills for users with existing workflows - coding best practices, testing principles, and design guidelines without recipe workflows or agents",
       "author": {
         "name": "Shinsuke Kagawa",

--- a/dev-skills/.claude-plugin/plugin.json
+++ b/dev-skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-skills",
   "description": "Lightweight skills for users with existing workflows - coding best practices, testing principles, and design guidelines without recipe workflows or agents",
-  "version": "0.24.8",
+  "version": "0.24.9",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows-frontend/.claude-plugin/plugin.json
+++ b/dev-workflows-frontend/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflows-frontend",
   "description": "Skills + Subagents for React/TypeScript - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
-  "version": "0.24.8",
+  "version": "0.24.9",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows-frontend/skills/subagents-orchestration-guide/SKILL.md
+++ b/dev-workflows-frontend/skills/subagents-orchestration-guide/SKILL.md
@@ -29,7 +29,7 @@ Classify Small when `scopeEvidence.executionRoute.status` is `evident`, that rou
 
 ### Requirement Change Detection During Flow
 
-Treat new or changed behaviors, constraints, or technical requirements as requirement changes. Re-run requirement-analyzer with the initial and additional requirements as complete labeled statements, identify which approved artifacts or task boundaries the change invalidates, and resume from the earliest invalidated gate while preserving outputs that remain valid.
+Treat new or changed behaviors, constraints, or technical requirements as requirement changes. Update the orchestrator-owned convergence record with the requirement change, identify which approved artifacts or task boundaries it invalidates, and resume from the earliest invalidated gate while preserving outputs that remain valid.
 
 ## Orchestration Principles
 
@@ -208,7 +208,7 @@ For Small, execute one direct-scope 4-step cycle. Complete after `approved`, or 
 | Required implementation remains incomplete | Continue while repository evidence supplies an advancing action; otherwise finish with an incomplete report and the observed evidence. |
 | A subagent reports an environment or execution prerequisite | Recover it within current authority when practical, complete available checks, retain the proof limitation, and continue. Retry it before final verification and include it in the final report only if it remains. |
 | Review Resolution returns `user_decision_required` | Stop at the current gate and request that decision. |
-| A requirement changes | Apply Requirement Change Detection above. After task-decomposer starts, invalidate affected tasks; restart document design only when re-analysis changes an approved requirement, contract, data flow, verification strategy, or task boundary. |
+| A requirement changes | Apply Requirement Change Detection above. After task-decomposer starts, invalidate affected tasks; restart document design only when the requirement change invalidates an approved requirement, contract, data flow, verification strategy, or task boundary. |
 | The user stops or interrupts | Stop autonomous execution. |
 
 ### Task Execution Cycle

--- a/dev-workflows-fullstack/.claude-plugin/plugin.json
+++ b/dev-workflows-fullstack/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflows-fullstack",
   "description": "Skills + Subagents for fullstack development (backend + React/TypeScript) - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
-  "version": "0.24.8",
+  "version": "0.24.9",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows-fullstack/skills/subagents-orchestration-guide/SKILL.md
+++ b/dev-workflows-fullstack/skills/subagents-orchestration-guide/SKILL.md
@@ -29,7 +29,7 @@ Classify Small when `scopeEvidence.executionRoute.status` is `evident`, that rou
 
 ### Requirement Change Detection During Flow
 
-Treat new or changed behaviors, constraints, or technical requirements as requirement changes. Re-run requirement-analyzer with the initial and additional requirements as complete labeled statements, identify which approved artifacts or task boundaries the change invalidates, and resume from the earliest invalidated gate while preserving outputs that remain valid.
+Treat new or changed behaviors, constraints, or technical requirements as requirement changes. Update the orchestrator-owned convergence record with the requirement change, identify which approved artifacts or task boundaries it invalidates, and resume from the earliest invalidated gate while preserving outputs that remain valid.
 
 ## Orchestration Principles
 
@@ -208,7 +208,7 @@ For Small, execute one direct-scope 4-step cycle. Complete after `approved`, or 
 | Required implementation remains incomplete | Continue while repository evidence supplies an advancing action; otherwise finish with an incomplete report and the observed evidence. |
 | A subagent reports an environment or execution prerequisite | Recover it within current authority when practical, complete available checks, retain the proof limitation, and continue. Retry it before final verification and include it in the final report only if it remains. |
 | Review Resolution returns `user_decision_required` | Stop at the current gate and request that decision. |
-| A requirement changes | Apply Requirement Change Detection above. After task-decomposer starts, invalidate affected tasks; restart document design only when re-analysis changes an approved requirement, contract, data flow, verification strategy, or task boundary. |
+| A requirement changes | Apply Requirement Change Detection above. After task-decomposer starts, invalidate affected tasks; restart document design only when the requirement change invalidates an approved requirement, contract, data flow, verification strategy, or task boundary. |
 | The user stops or interrupts | Stop autonomous execution. |
 
 ### Task Execution Cycle

--- a/dev-workflows/.claude-plugin/plugin.json
+++ b/dev-workflows/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflows",
   "description": "Skills + Subagents for backend development - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
-  "version": "0.24.8",
+  "version": "0.24.9",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows/skills/subagents-orchestration-guide/SKILL.md
+++ b/dev-workflows/skills/subagents-orchestration-guide/SKILL.md
@@ -29,7 +29,7 @@ Classify Small when `scopeEvidence.executionRoute.status` is `evident`, that rou
 
 ### Requirement Change Detection During Flow
 
-Treat new or changed behaviors, constraints, or technical requirements as requirement changes. Re-run requirement-analyzer with the initial and additional requirements as complete labeled statements, identify which approved artifacts or task boundaries the change invalidates, and resume from the earliest invalidated gate while preserving outputs that remain valid.
+Treat new or changed behaviors, constraints, or technical requirements as requirement changes. Update the orchestrator-owned convergence record with the requirement change, identify which approved artifacts or task boundaries it invalidates, and resume from the earliest invalidated gate while preserving outputs that remain valid.
 
 ## Orchestration Principles
 
@@ -208,7 +208,7 @@ For Small, execute one direct-scope 4-step cycle. Complete after `approved`, or 
 | Required implementation remains incomplete | Continue while repository evidence supplies an advancing action; otherwise finish with an incomplete report and the observed evidence. |
 | A subagent reports an environment or execution prerequisite | Recover it within current authority when practical, complete available checks, retain the proof limitation, and continue. Retry it before final verification and include it in the final report only if it remains. |
 | Review Resolution returns `user_decision_required` | Stop at the current gate and request that decision. |
-| A requirement changes | Apply Requirement Change Detection above. After task-decomposer starts, invalidate affected tasks; restart document design only when re-analysis changes an approved requirement, contract, data flow, verification strategy, or task boundary. |
+| A requirement changes | Apply Requirement Change Detection above. After task-decomposer starts, invalidate affected tasks; restart document design only when the requirement change invalidates an approved requirement, contract, data flow, verification strategy, or task boundary. |
 | The user stops or interrupts | Stop autonomous execution. |
 
 ### Task Execution Cycle

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-workflows",
-  "version": "0.24.8",
+  "version": "0.24.9",
   "private": true,
   "type": "module",
   "engines": {

--- a/skills/subagents-orchestration-guide/SKILL.md
+++ b/skills/subagents-orchestration-guide/SKILL.md
@@ -29,7 +29,7 @@ Classify Small when `scopeEvidence.executionRoute.status` is `evident`, that rou
 
 ### Requirement Change Detection During Flow
 
-Treat new or changed behaviors, constraints, or technical requirements as requirement changes. Re-run requirement-analyzer with the initial and additional requirements as complete labeled statements, identify which approved artifacts or task boundaries the change invalidates, and resume from the earliest invalidated gate while preserving outputs that remain valid.
+Treat new or changed behaviors, constraints, or technical requirements as requirement changes. Update the orchestrator-owned convergence record with the requirement change, identify which approved artifacts or task boundaries it invalidates, and resume from the earliest invalidated gate while preserving outputs that remain valid.
 
 ## Orchestration Principles
 
@@ -208,7 +208,7 @@ For Small, execute one direct-scope 4-step cycle. Complete after `approved`, or 
 | Required implementation remains incomplete | Continue while repository evidence supplies an advancing action; otherwise finish with an incomplete report and the observed evidence. |
 | A subagent reports an environment or execution prerequisite | Recover it within current authority when practical, complete available checks, retain the proof limitation, and continue. Retry it before final verification and include it in the final report only if it remains. |
 | Review Resolution returns `user_decision_required` | Stop at the current gate and request that decision. |
-| A requirement changes | Apply Requirement Change Detection above. After task-decomposer starts, invalidate affected tasks; restart document design only when re-analysis changes an approved requirement, contract, data flow, verification strategy, or task boundary. |
+| A requirement changes | Apply Requirement Change Detection above. After task-decomposer starts, invalidate affected tasks; restart document design only when the requirement change invalidates an approved requirement, contract, data flow, verification strategy, or task boundary. |
 | The user stops or interrupts | Stop autonomous execution. |
 
 ### Task Execution Cycle


### PR DESCRIPTION
## Summary

- Keep in-flow requirement changes in the orchestrator-owned convergence record instead of forcing a requirement-analyzer rerun.
- Resume from the earliest invalidated gate while preserving outputs that remain valid.
- Restart document design only when the requirement change invalidates an approved requirement, contract, data flow, verification strategy, or task boundary.
- Bump the bundled plugin version to 0.24.9.

## Why

Document updates already have an authorized target and requested outcome. Forcing them through fresh requirement analysis introduces unrelated scope and cost evaluation before applying the requested change.

## Verification

- pnpm sync:check
- pnpm check:skills-index
- git diff --check
- claude plugin validate .claude-plugin/marketplace.json
- claude plugin validate dev-workflows
- claude plugin validate dev-workflows-frontend
- claude plugin validate dev-workflows-fullstack
- claude plugin validate dev-skills