### PR TITLE
Converge final verifier reruns

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "dev-workflows",
       "source": "./dev-workflows",
       "strict": true,
-      "version": "0.24.9",
+      "version": "0.24.10",
       "description": "Skills + Subagents for backend development - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
       "author": {
         "name": "Shinsuke Kagawa",
@@ -82,7 +82,7 @@
       "name": "dev-workflows-frontend",
       "source": "./dev-workflows-frontend",
       "strict": true,
-      "version": "0.24.9",
+      "version": "0.24.10",
       "description": "Skills + Subagents for React/TypeScript - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
       "author": {
         "name": "Shinsuke Kagawa",
@@ -155,7 +155,7 @@
       "name": "dev-workflows-fullstack",
       "source": "./dev-workflows-fullstack",
       "strict": true,
-      "version": "0.24.9",
+      "version": "0.24.10",
       "description": "Skills + Subagents for fullstack development (backend + React/TypeScript) - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
       "author": {
         "name": "Shinsuke Kagawa",
@@ -244,7 +244,7 @@
       "name": "dev-skills",
       "source": "./dev-skills",
       "strict": true,
-      "version": "0.24.9",
+      "version": "0.24.10",
       "description": "Lightweight skills for users with existing workflows - coding best practices, testing principles, and design guidelines without recipe workflows or agents",
       "author": {
         "name": "Shinsuke Kagawa",

--- a/dev-skills/.claude-plugin/plugin.json
+++ b/dev-skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-skills",
   "description": "Lightweight skills for users with existing workflows - coding best practices, testing principles, and design guidelines without recipe workflows or agents",
-  "version": "0.24.9",
+  "version": "0.24.10",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows-frontend/.claude-plugin/plugin.json
+++ b/dev-workflows-frontend/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflows-frontend",
   "description": "Skills + Subagents for React/TypeScript - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
-  "version": "0.24.9",
+  "version": "0.24.10",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows-frontend/skills/subagents-orchestration-guide/SKILL.md
+++ b/dev-workflows-frontend/skills/subagents-orchestration-guide/SKILL.md
@@ -175,7 +175,7 @@ graph TD
     START[Batch approval] --> TD[task-decomposer]
     TD --> CYCLE[Per-task 4-step cycle, including commit]
     CYCLE -->|remaining tasks| CYCLE
-    CYCLE -->|all tasks complete| VERIFY[code-verifier + security-reviewer]
+    CYCLE -->|all tasks complete| VERIFY[Initial verifier set or evidence-required reruns]
     CYCLE -->|recoverable or structurally incomplete result| CYCLE
     CYCLE -->|user-owned block or requirement change| USER[Escalate or re-analyze]
     VERIFY -->|passed| REPORT[Completion report]
@@ -197,7 +197,7 @@ For Small, execute one direct-scope 4-step cycle. Complete after `approved`, or 
 
 **Fix-cycle handoff**: Apply Review Resolution, then invoke each required executor with its original `task_file` or direct-scope fields plus `correction_findings` as the complete `apply` finding objects verbatim with only their dispositions added. Carry `prior_feedback` only to reconciliation reviewers.
 
-**Re-run rule**: After any applied post-implementation correction, re-run both code-verifier and security-reviewer. Review Resolution convergence governs acceptance and preserves resolved declines.
+**Re-run rule**: After any applied post-implementation correction, re-run each verifier run with at least one correction applied from its latest result. Retain any other verifier result completed by Post-Implementation Verification Status Routing or Review Resolution only when repository evidence establishes that the correction preserved its verification boundary; otherwise re-run that verifier. After Specialist Result Acceptance recovers a blocked verifier's prerequisite, re-run that verifier. Review Resolution convergence governs acceptance and preserves resolved declines.
 
 ### Conditions for Stopping Autonomous Execution
 

--- a/dev-workflows-frontend/skills/subagents-orchestration-guide/references/review-resolution.md
+++ b/dev-workflows-frontend/skills/subagents-orchestration-guide/references/review-resolution.md
@@ -19,7 +19,7 @@ For verifier, design-sync, code-reviewer, security-reviewer, and integration-tes
 Use the result producer's declared verification mode:
 
 - **Reconciliation reviewer**: document-reviewer, code-reviewer, security-reviewer, and integration-test-reviewer accept `prior_feedback` and return `prior_feedback_reconciliation` after correction.
-- **Fresh verifier**: code-verifier and design-sync independently report the current state from their original inputs. After an applied correction, rerun them and adjudicate the current result; a decline-only result is complete.
+- **Fresh verifier**: code-verifier and design-sync independently report the current state from their original inputs. After a correction is applied from a fresh verifier's result, rerun that verifier and adjudicate the current result; a decline-only result is complete.
 
 ## 1. Assess Every Finding
 
@@ -62,7 +62,7 @@ The correction assessment covers exactly every received item. The reviewer compl
 
 Derive the correction re-review status or verdict only from these reconciliation entries. An independent factual verifier may repeat an observed discrepancy; the orchestrator assigns its disposition from governing evidence.
 
-For a fresh verifier, rerun only after at least one applied correction. The latest result replaces the prior current-state result for corrected items. Retain a prior decline when the latest result reports the materially same claim or conflict with unchanged governing evidence; adjudicate new or materially changed findings before routing. Match materially identical findings by their claim/conflict and cited source/target evidence rather than relying only on a regenerated positional ID.
+For a fresh verifier, rerun after at least one correction is applied from its latest result or when the caller's re-run rule requires a current-state result. The latest result replaces the prior current-state result for corrected items. Retain a prior decline when the latest result reports the materially same claim or conflict with unchanged governing evidence; adjudicate new or materially changed findings before routing. Match materially identical findings by their claim/conflict and cited source/target evidence rather than relying only on a regenerated positional ID.
 
 ## 3. Converge or Report
 

--- a/dev-workflows-fullstack/.claude-plugin/plugin.json
+++ b/dev-workflows-fullstack/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflows-fullstack",
   "description": "Skills + Subagents for fullstack development (backend + React/TypeScript) - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
-  "version": "0.24.9",
+  "version": "0.24.10",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows-fullstack/skills/subagents-orchestration-guide/SKILL.md
+++ b/dev-workflows-fullstack/skills/subagents-orchestration-guide/SKILL.md
@@ -175,7 +175,7 @@ graph TD
     START[Batch approval] --> TD[task-decomposer]
     TD --> CYCLE[Per-task 4-step cycle, including commit]
     CYCLE -->|remaining tasks| CYCLE
-    CYCLE -->|all tasks complete| VERIFY[code-verifier + security-reviewer]
+    CYCLE -->|all tasks complete| VERIFY[Initial verifier set or evidence-required reruns]
     CYCLE -->|recoverable or structurally incomplete result| CYCLE
     CYCLE -->|user-owned block or requirement change| USER[Escalate or re-analyze]
     VERIFY -->|passed| REPORT[Completion report]
@@ -197,7 +197,7 @@ For Small, execute one direct-scope 4-step cycle. Complete after `approved`, or 
 
 **Fix-cycle handoff**: Apply Review Resolution, then invoke each required executor with its original `task_file` or direct-scope fields plus `correction_findings` as the complete `apply` finding objects verbatim with only their dispositions added. Carry `prior_feedback` only to reconciliation reviewers.
 
-**Re-run rule**: After any applied post-implementation correction, re-run both code-verifier and security-reviewer. Review Resolution convergence governs acceptance and preserves resolved declines.
+**Re-run rule**: After any applied post-implementation correction, re-run each verifier run with at least one correction applied from its latest result. Retain any other verifier result completed by Post-Implementation Verification Status Routing or Review Resolution only when repository evidence establishes that the correction preserved its verification boundary; otherwise re-run that verifier. After Specialist Result Acceptance recovers a blocked verifier's prerequisite, re-run that verifier. Review Resolution convergence governs acceptance and preserves resolved declines.
 
 ### Conditions for Stopping Autonomous Execution
 

--- a/dev-workflows-fullstack/skills/subagents-orchestration-guide/references/review-resolution.md
+++ b/dev-workflows-fullstack/skills/subagents-orchestration-guide/references/review-resolution.md
@@ -19,7 +19,7 @@ For verifier, design-sync, code-reviewer, security-reviewer, and integration-tes
 Use the result producer's declared verification mode:
 
 - **Reconciliation reviewer**: document-reviewer, code-reviewer, security-reviewer, and integration-test-reviewer accept `prior_feedback` and return `prior_feedback_reconciliation` after correction.
-- **Fresh verifier**: code-verifier and design-sync independently report the current state from their original inputs. After an applied correction, rerun them and adjudicate the current result; a decline-only result is complete.
+- **Fresh verifier**: code-verifier and design-sync independently report the current state from their original inputs. After a correction is applied from a fresh verifier's result, rerun that verifier and adjudicate the current result; a decline-only result is complete.
 
 ## 1. Assess Every Finding
 
@@ -62,7 +62,7 @@ The correction assessment covers exactly every received item. The reviewer compl
 
 Derive the correction re-review status or verdict only from these reconciliation entries. An independent factual verifier may repeat an observed discrepancy; the orchestrator assigns its disposition from governing evidence.
 
-For a fresh verifier, rerun only after at least one applied correction. The latest result replaces the prior current-state result for corrected items. Retain a prior decline when the latest result reports the materially same claim or conflict with unchanged governing evidence; adjudicate new or materially changed findings before routing. Match materially identical findings by their claim/conflict and cited source/target evidence rather than relying only on a regenerated positional ID.
+For a fresh verifier, rerun after at least one correction is applied from its latest result or when the caller's re-run rule requires a current-state result. The latest result replaces the prior current-state result for corrected items. Retain a prior decline when the latest result reports the materially same claim or conflict with unchanged governing evidence; adjudicate new or materially changed findings before routing. Match materially identical findings by their claim/conflict and cited source/target evidence rather than relying only on a regenerated positional ID.
 
 ## 3. Converge or Report
 

--- a/dev-workflows/.claude-plugin/plugin.json
+++ b/dev-workflows/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflows",
   "description": "Skills + Subagents for backend development - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
-  "version": "0.24.9",
+  "version": "0.24.10",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows/skills/subagents-orchestration-guide/SKILL.md
+++ b/dev-workflows/skills/subagents-orchestration-guide/SKILL.md
@@ -175,7 +175,7 @@ graph TD
     START[Batch approval] --> TD[task-decomposer]
     TD --> CYCLE[Per-task 4-step cycle, including commit]
     CYCLE -->|remaining tasks| CYCLE
-    CYCLE -->|all tasks complete| VERIFY[code-verifier + security-reviewer]
+    CYCLE -->|all tasks complete| VERIFY[Initial verifier set or evidence-required reruns]
     CYCLE -->|recoverable or structurally incomplete result| CYCLE
     CYCLE -->|user-owned block or requirement change| USER[Escalate or re-analyze]
     VERIFY -->|passed| REPORT[Completion report]
@@ -197,7 +197,7 @@ For Small, execute one direct-scope 4-step cycle. Complete after `approved`, or 
 
 **Fix-cycle handoff**: Apply Review Resolution, then invoke each required executor with its original `task_file` or direct-scope fields plus `correction_findings` as the complete `apply` finding objects verbatim with only their dispositions added. Carry `prior_feedback` only to reconciliation reviewers.
 
-**Re-run rule**: After any applied post-implementation correction, re-run both code-verifier and security-reviewer. Review Resolution convergence governs acceptance and preserves resolved declines.
+**Re-run rule**: After any applied post-implementation correction, re-run each verifier run with at least one correction applied from its latest result. Retain any other verifier result completed by Post-Implementation Verification Status Routing or Review Resolution only when repository evidence establishes that the correction preserved its verification boundary; otherwise re-run that verifier. After Specialist Result Acceptance recovers a blocked verifier's prerequisite, re-run that verifier. Review Resolution convergence governs acceptance and preserves resolved declines.
 
 ### Conditions for Stopping Autonomous Execution
 

--- a/dev-workflows/skills/subagents-orchestration-guide/references/review-resolution.md
+++ b/dev-workflows/skills/subagents-orchestration-guide/references/review-resolution.md
@@ -19,7 +19,7 @@ For verifier, design-sync, code-reviewer, security-reviewer, and integration-tes
 Use the result producer's declared verification mode:
 
 - **Reconciliation reviewer**: document-reviewer, code-reviewer, security-reviewer, and integration-test-reviewer accept `prior_feedback` and return `prior_feedback_reconciliation` after correction.
-- **Fresh verifier**: code-verifier and design-sync independently report the current state from their original inputs. After an applied correction, rerun them and adjudicate the current result; a decline-only result is complete.
+- **Fresh verifier**: code-verifier and design-sync independently report the current state from their original inputs. After a correction is applied from a fresh verifier's result, rerun that verifier and adjudicate the current result; a decline-only result is complete.
 
 ## 1. Assess Every Finding
 
@@ -62,7 +62,7 @@ The correction assessment covers exactly every received item. The reviewer compl
 
 Derive the correction re-review status or verdict only from these reconciliation entries. An independent factual verifier may repeat an observed discrepancy; the orchestrator assigns its disposition from governing evidence.
 
-For a fresh verifier, rerun only after at least one applied correction. The latest result replaces the prior current-state result for corrected items. Retain a prior decline when the latest result reports the materially same claim or conflict with unchanged governing evidence; adjudicate new or materially changed findings before routing. Match materially identical findings by their claim/conflict and cited source/target evidence rather than relying only on a regenerated positional ID.
+For a fresh verifier, rerun after at least one correction is applied from its latest result or when the caller's re-run rule requires a current-state result. The latest result replaces the prior current-state result for corrected items. Retain a prior decline when the latest result reports the materially same claim or conflict with unchanged governing evidence; adjudicate new or materially changed findings before routing. Match materially identical findings by their claim/conflict and cited source/target evidence rather than relying only on a regenerated positional ID.
 
 ## 3. Converge or Report
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-workflows",
-  "version": "0.24.9",
+  "version": "0.24.10",
   "private": true,
   "type": "module",
   "engines": {

--- a/skills/subagents-orchestration-guide/SKILL.md
+++ b/skills/subagents-orchestration-guide/SKILL.md
@@ -175,7 +175,7 @@ graph TD
     START[Batch approval] --> TD[task-decomposer]
     TD --> CYCLE[Per-task 4-step cycle, including commit]
     CYCLE -->|remaining tasks| CYCLE
-    CYCLE -->|all tasks complete| VERIFY[code-verifier + security-reviewer]
+    CYCLE -->|all tasks complete| VERIFY[Initial verifier set or evidence-required reruns]
     CYCLE -->|recoverable or structurally incomplete result| CYCLE
     CYCLE -->|user-owned block or requirement change| USER[Escalate or re-analyze]
     VERIFY -->|passed| REPORT[Completion report]
@@ -197,7 +197,7 @@ For Small, execute one direct-scope 4-step cycle. Complete after `approved`, or 
 
 **Fix-cycle handoff**: Apply Review Resolution, then invoke each required executor with its original `task_file` or direct-scope fields plus `correction_findings` as the complete `apply` finding objects verbatim with only their dispositions added. Carry `prior_feedback` only to reconciliation reviewers.
 
-**Re-run rule**: After any applied post-implementation correction, re-run both code-verifier and security-reviewer. Review Resolution convergence governs acceptance and preserves resolved declines.
+**Re-run rule**: After any applied post-implementation correction, re-run each verifier run with at least one correction applied from its latest result. Retain any other verifier result completed by Post-Implementation Verification Status Routing or Review Resolution only when repository evidence establishes that the correction preserved its verification boundary; otherwise re-run that verifier. After Specialist Result Acceptance recovers a blocked verifier's prerequisite, re-run that verifier. Review Resolution convergence governs acceptance and preserves resolved declines.
 
 ### Conditions for Stopping Autonomous Execution
 

--- a/skills/subagents-orchestration-guide/references/review-resolution.md
+++ b/skills/subagents-orchestration-guide/references/review-resolution.md
@@ -19,7 +19,7 @@ For verifier, design-sync, code-reviewer, security-reviewer, and integration-tes
 Use the result producer's declared verification mode:
 
 - **Reconciliation reviewer**: document-reviewer, code-reviewer, security-reviewer, and integration-test-reviewer accept `prior_feedback` and return `prior_feedback_reconciliation` after correction.
-- **Fresh verifier**: code-verifier and design-sync independently report the current state from their original inputs. After an applied correction, rerun them and adjudicate the current result; a decline-only result is complete.
+- **Fresh verifier**: code-verifier and design-sync independently report the current state from their original inputs. After a correction is applied from a fresh verifier's result, rerun that verifier and adjudicate the current result; a decline-only result is complete.
 
 ## 1. Assess Every Finding
 
@@ -62,7 +62,7 @@ The correction assessment covers exactly every received item. The reviewer compl
 
 Derive the correction re-review status or verdict only from these reconciliation entries. An independent factual verifier may repeat an observed discrepancy; the orchestrator assigns its disposition from governing evidence.
 
-For a fresh verifier, rerun only after at least one applied correction. The latest result replaces the prior current-state result for corrected items. Retain a prior decline when the latest result reports the materially same claim or conflict with unchanged governing evidence; adjudicate new or materially changed findings before routing. Match materially identical findings by their claim/conflict and cited source/target evidence rather than relying only on a regenerated positional ID.
+For a fresh verifier, rerun after at least one correction is applied from its latest result or when the caller's re-run rule requires a current-state result. The latest result replaces the prior current-state result for corrected items. Retain a prior decline when the latest result reports the materially same claim or conflict with unchanged governing evidence; adjudicate new or materially changed findings before routing. Match materially identical findings by their claim/conflict and cited source/target evidence rather than relying only on a regenerated positional ID.
 
 ## 3. Converge or Report
 


### PR DESCRIPTION
## Summary

- rerun corrected verifier runs while preserving completed results whose evidence remains valid
- rerun recovered blocked verifiers and align fresh-verifier reruns with caller requirements
- sync generated plugin bundles and bump the patch version to 0.24.10

## Validation

- `pnpm sync:check`
- `pnpm check:skills-index`
- `claude plugin validate .claude-plugin/marketplace.json`
- `claude plugin validate dev-workflows`
- `claude plugin validate dev-workflows-frontend`
- `claude plugin validate dev-workflows-fullstack`
- `claude plugin validate dev-skills`
- `git diff --check`
