### PR TITLE
Use repository quality profiles during implementation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "dev-workflows",
       "source": "./dev-workflows",
       "strict": true,
-      "version": "0.25.0",
+      "version": "0.25.1",
       "description": "Skills + Subagents for backend development - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
       "author": {
         "name": "Shinsuke Kagawa",
@@ -83,7 +83,7 @@
       "name": "dev-workflows-frontend",
       "source": "./dev-workflows-frontend",
       "strict": true,
-      "version": "0.25.0",
+      "version": "0.25.1",
       "description": "Skills + Subagents for React/TypeScript - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
       "author": {
         "name": "Shinsuke Kagawa",
@@ -157,7 +157,7 @@
       "name": "dev-workflows-fullstack",
       "source": "./dev-workflows-fullstack",
       "strict": true,
-      "version": "0.25.0",
+      "version": "0.25.1",
       "description": "Skills + Subagents for fullstack development (backend + React/TypeScript) - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
       "author": {
         "name": "Shinsuke Kagawa",
@@ -247,7 +247,7 @@
       "name": "dev-skills",
       "source": "./dev-skills",
       "strict": true,
-      "version": "0.25.0",
+      "version": "0.25.1",
       "description": "Lightweight skills for users with existing workflows - coding best practices, testing principles, and design guidelines without recipe workflows or agents",
       "author": {
         "name": "Shinsuke Kagawa",

--- a/README.es.md
+++ b/README.es.md
@@ -36,7 +36,7 @@ Requiere una versión de Claude Code compatible con el marketplace de plugins.
 | Diseñar e implementar un frontend en React / TypeScript | `/recipe-front-design` → `/recipe-front-plan` → `/recipe-front-build` | `dev-workflows-frontend` |
 | Entregar juntos un backend y un frontend React | `/recipe-fullstack-implement` | `dev-workflows-fullstack` |
 | Revisar una implementación terminada frente al resultado acordado | `/recipe-review` o `/recipe-front-review` | `dev-workflows` o `dev-workflows-frontend` |
-| Definir criterios de revisión propios del repositorio | `/recipe-quality-profile` | Cualquier plugin de flujos |
+| Definir reglas de calidad propias del repositorio | `/recipe-quality-profile` | Cualquier plugin de flujos |
 | Investigar un problema antes de elegir una solución | `/recipe-diagnose` | Cualquier plugin de flujos |
 | Documentar un sistema existente a partir del código | `/recipe-reverse-engineer` | `dev-workflows` o `dev-workflows-fullstack` |
 | Hacer un experimento descartable o un prototipo | Usa Claude Code directamente | Ninguno |
@@ -130,7 +130,7 @@ Usar un contexto nuevo para cada fase evita que el razonamiento de una fase se c
 | docs/design/example.md | Verification | Exercise cache invalidation | verification | | gap | Add a covering task before approval |
 ```
 
-La [plantilla de Task](skills/documentation-criteria/references/task-template.md) lleva a implementación las decisiones obligatorias y los valores observables de los contratos, cada uno con una comprobación de cumplimiento que se responde con sí o no. Después de ejecutar la tarea, los controles aplicables del repositorio se ejecutan sobre el cambio completo antes del commit. Los revisores finales leen las mismas fuentes aprobadas y el código terminado, en lugar de depender de la conversación de implementación. `/recipe-quality-profile` permite registrar criterios de revisión propios del repositorio y sus fuentes en `docs/project-context/quality.yaml`; los revisores finales usan el perfil confirmado junto con las fuentes aprobadas.
+La [plantilla de Task](skills/documentation-criteria/references/task-template.md) lleva a implementación las decisiones obligatorias y los valores observables de los contratos, cada uno con una comprobación de cumplimiento que se responde con sí o no. Después de ejecutar la tarea, los controles aplicables del repositorio se ejecutan sobre el cambio completo antes del commit. Los revisores finales leen las mismas fuentes aprobadas y el código terminado, en lugar de depender de la conversación de implementación. `/recipe-quality-profile` permite registrar reglas de calidad propias del repositorio y sus fuentes en `docs/project-context/quality.yaml`; los ejecutores de implementación y los revisores finales usan el perfil confirmado junto con las fuentes aprobadas.
 
 ### Una ejecución real
 
@@ -243,7 +243,7 @@ Todos los puntos de entrada usan el prefijo `recipe-`. Escribe `/recipe-` y usa 
 | `/recipe-plan` | Generar un Work Plan a partir del diseño | Fase de planificación |
 | `/recipe-build` | Ejecutar un Work Plan existente | Retomar una implementación |
 | `/recipe-review` | Revisar una implementación terminada frente al resultado acordado | Comprobación posterior a la implementación |
-| `/recipe-quality-profile` | Definir criterios de revisión propios del repositorio | Criterios del repositorio |
+| `/recipe-quality-profile` | Definir reglas de calidad propias del repositorio | Reglas de calidad |
 | `/recipe-diagnose` | Investigar un problema y comparar soluciones | Análisis de causa raíz |
 | `/recipe-reverse-engineer` | Derivar PRD y Design Docs del código | Documentación de sistemas existentes |
 | `/recipe-add-integration-tests` | Añadir pruebas de integración o E2E | Cobertura de código existente |
@@ -264,7 +264,7 @@ El plugin de frontend añade análisis específico de React, arquitectura de com
 | `/recipe-front-build` | Ejecutar el Work Plan de frontend | Retomar una implementación React |
 | `/recipe-front-adjust` | Ajustar una UI implementada con verificación externa | Mejoras visuales |
 | `/recipe-front-review` | Revisar un frontend terminado frente al resultado acordado | Comprobación posterior a la implementación |
-| `/recipe-quality-profile` | Definir criterios de revisión propios del repositorio | Criterios del repositorio |
+| `/recipe-quality-profile` | Definir reglas de calidad propias del repositorio | Reglas de calidad |
 | `/recipe-diagnose` | Investigar un problema y comparar soluciones | Análisis de causa raíz |
 | `/recipe-update-doc` | Actualizar y revisar documentos existentes | Cambios de requisitos o diseño |
 | `/recipe-task` | Ejecutar directamente una tarea guiada por reglas | Trabajo que no requiere traspasos entre etapas |

--- a/README.ja.md
+++ b/README.ja.md
@@ -36,7 +36,7 @@ claude-code-workflowsは、探索を合意済みの成果へ向け続けるた�
 | React / TypeScriptフロントエンドを設計・実装する | `/recipe-front-design` → `/recipe-front-plan` → `/recipe-front-build` | `dev-workflows-frontend` |
 | バックエンドとReactフロントエンドをまとめて実装する | `/recipe-fullstack-implement` | `dev-workflows-fullstack` |
 | 完成した実装を合意した成果に照らしてレビューする | `/recipe-review` または `/recipe-front-review` | `dev-workflows` または `dev-workflows-frontend` |
-| リポジトリ固有のレビュー基準を定める | `/recipe-quality-profile` | 任意のワークフロープラグイン |
+| リポジトリ固有の品質ルールを定める | `/recipe-quality-profile` | 任意のワークフロープラグイン |
 | 修正を決める前に問題を調査する | `/recipe-diagnose` | 任意のワークフロープラグイン |
 | コードから既存システムを文書化する | `/recipe-reverse-engineer` | `dev-workflows` または `dev-workflows-fullstack` |
 | 使い捨ての実験やプロトタイプを作る | Claude Codeを直接使う | なし |
@@ -130,7 +130,7 @@ UI仕様、ADR、結合テストやE2Eテストのスケルトンは、それぞ
 | docs/design/example.md | Verification | Exercise cache invalidation | verification | | gap | Add a covering task before approval |
 ```
 
-[タスクテンプレート](skills/documentation-criteria/references/task-template.md)は、実装を拘束する判断と外部から確認できる契約上の値を引き継ぎ、それぞれにYes/Noで判定できる準拠チェックを持たせます。実行後、コミット前にタスク全体の変更へ該当するリポジトリチェックを行います。最終レビュアーは実装時の会話ではなく、同じ承認済みソースと完成したコードを読みます。`/recipe-quality-profile`を使うと、リポジトリ固有のレビュー基準とその根拠を`docs/project-context/quality.yaml`に記録でき、最終レビューでは確認済みの設定を承認済みソースとあわせて使います。
+[タスクテンプレート](skills/documentation-criteria/references/task-template.md)は、実装を拘束する判断と外部から確認できる契約上の値を引き継ぎ、それぞれにYes/Noで判定できる準拠チェックを持たせます。実行後、コミット前にタスク全体の変更へ該当するリポジトリチェックを行います。最終レビュアーは実装時の会話ではなく、同じ承認済みソースと完成したコードを読みます。`/recipe-quality-profile`を使うと、リポジトリ固有の品質ルールとその根拠を`docs/project-context/quality.yaml`に記録でき、実装担当と最終レビュアーは確認済みの設定を承認済みソースとあわせて使います。
 
 ### 実際のワークフロー実行例
 
@@ -243,7 +243,7 @@ UI仕様、ADR、結合テストやE2Eテストのスケルトンは、それぞ
 | `/recipe-plan` | 設計から作業計画を作成 | 計画フェーズ |
 | `/recipe-build` | 既存の作業計画を実行 | 実装の再開 |
 | `/recipe-review` | 完成した実装を合意した成果に照らしてレビュー | 実装後の確認 |
-| `/recipe-quality-profile` | リポジトリ固有のレビュー基準を設定 | リポジトリ基準の設定 |
+| `/recipe-quality-profile` | リポジトリ固有の品質ルールを設定 | 品質ルールの設定 |
 | `/recipe-diagnose` | 問題を調査し、解決策を比較 | 根本原因の分析 |
 | `/recipe-reverse-engineer` | コードからPRDと設計ドキュメントを作成 | 既存システムの文書化 |
 | `/recipe-add-integration-tests` | 結合テストまたはE2Eテストを追加 | 既存コードのカバレッジ |
@@ -264,7 +264,7 @@ UI仕様、ADR、結合テストやE2Eテストのスケルトンは、それぞ
 | `/recipe-front-build` | フロントエンド作業計画を実行 | React実装の再開 |
 | `/recipe-front-adjust` | 外部検証を使って実装済みUIを調整 | 見た目の調整 |
 | `/recipe-front-review` | 完成したフロントエンドを合意した成果に照らしてレビュー | 実装後の確認 |
-| `/recipe-quality-profile` | リポジトリ固有のレビュー基準を設定 | リポジトリ基準の設定 |
+| `/recipe-quality-profile` | リポジトリ固有の品質ルールを設定 | 品質ルールの設定 |
 | `/recipe-diagnose` | 問題を調査し、解決策を比較 | 根本原因の分析 |
 | `/recipe-update-doc` | 既存ドキュメントを更新・レビュー | 要件または設計の変更 |
 | `/recipe-task` | ルールに従うタスクを直接実行 | 段階的な引き継ぎが不要な作業 |

--- a/README.ko.md
+++ b/README.ko.md
@@ -36,7 +36,7 @@ claude-code-workflows는 탐색이 합의된 결과를 향하도록 유지합니
 | React / TypeScript 프런트엔드를 설계하고 구현 | `/recipe-front-design` → `/recipe-front-plan` → `/recipe-front-build` | `dev-workflows-frontend` |
 | 백엔드와 React 프런트엔드를 함께 구현 | `/recipe-fullstack-implement` | `dev-workflows-fullstack` |
 | 완성된 구현이 합의한 결과에 맞는지 검토 | `/recipe-review` 또는 `/recipe-front-review` | `dev-workflows` 또는 `dev-workflows-frontend` |
-| 저장소별 검토 기준 설정 | `/recipe-quality-profile` | 모든 워크플로 플러그인 |
+| 저장소별 품질 규칙 설정 | `/recipe-quality-profile` | 모든 워크플로 플러그인 |
 | 수정 방법을 정하기 전에 문제를 조사 | `/recipe-diagnose` | 모든 워크플로 플러그인 |
 | 코드에서 기존 시스템 문서를 생성 | `/recipe-reverse-engineer` | `dev-workflows` 또는 `dev-workflows-fullstack` |
 | 일회성 실험이나 프로토타입 | Claude Code를 직접 사용 | 없음 |
@@ -130,7 +130,7 @@ Work Plan은 구현을 승인하기 전에 범위, 의존성 순서, 실행 가�
 | docs/design/example.md | Verification | Exercise cache invalidation | verification | | gap | Add a covering task before approval |
 ```
 
-[Task 템플릿](skills/documentation-criteria/references/task-template.md)은 구현을 구속하는 결정과 외부에서 확인할 수 있는 계약상의 값을 전달하며, 각 항목에 예/아니요로 답할 수 있는 준수 검사를 둡니다. 실행 후에는 커밋 전에 전체 작업 변경에 해당 저장소 검사를 적용합니다. 최종 검토자는 구현 대화에 의존하지 않고 같은 승인 자료와 완성된 코드를 읽습니다. `/recipe-quality-profile`을 사용하면 저장소별 검토 기준과 근거를 `docs/project-context/quality.yaml`에 기록할 수 있습니다. 최종 검토자는 확인된 프로필을 승인 자료와 함께 사용합니다.
+[Task 템플릿](skills/documentation-criteria/references/task-template.md)은 구현을 구속하는 결정과 외부에서 확인할 수 있는 계약상의 값을 전달하며, 각 항목에 예/아니요로 답할 수 있는 준수 검사를 둡니다. 실행 후에는 커밋 전에 전체 작업 변경에 해당 저장소 검사를 적용합니다. 최종 검토자는 구현 대화에 의존하지 않고 같은 승인 자료와 완성된 코드를 읽습니다. `/recipe-quality-profile`을 사용하면 저장소별 품질 규칙과 근거를 `docs/project-context/quality.yaml`에 기록할 수 있습니다. 구현 실행자와 최종 검토자는 확인된 프로필을 승인 자료와 함께 사용합니다.
 
 ### 실제 워크플로 실행 사례
 
@@ -243,7 +243,7 @@ recipe는 변경 범위를 정하고 현재 구현을 조사한 뒤, 결정에 �
 | `/recipe-plan` | 설계에서 Work Plan 생성 | 계획 단계 |
 | `/recipe-build` | 기존 Work Plan 실행 | 구현 재개 |
 | `/recipe-review` | 완성된 구현이 합의한 결과에 맞는지 검토 | 구현 후 확인 |
-| `/recipe-quality-profile` | 저장소별 검토 기준 설정 | 저장소 기준 설정 |
+| `/recipe-quality-profile` | 저장소별 품질 규칙 설정 | 품질 규칙 설정 |
 | `/recipe-diagnose` | 문제를 조사하고 해결책 비교 | 근본 원인 분석 |
 | `/recipe-reverse-engineer` | 코드에서 PRD와 Design Doc 생성 | 기존 시스템 문서화 |
 | `/recipe-add-integration-tests` | 통합 또는 E2E 테스트 추가 | 기존 코드의 커버리지 확보 |
@@ -264,7 +264,7 @@ recipe는 변경 범위를 정하고 현재 구현을 조사한 뒤, 결정에 �
 | `/recipe-front-build` | 프런트엔드 Work Plan 실행 | React 구현 재개 |
 | `/recipe-front-adjust` | 외부 검증으로 구현된 UI 조정 | 시각적 개선 |
 | `/recipe-front-review` | 완성된 프런트엔드가 합의한 결과에 맞는지 검토 | 구현 후 확인 |
-| `/recipe-quality-profile` | 저장소별 검토 기준 설정 | 저장소 기준 설정 |
+| `/recipe-quality-profile` | 저장소별 품질 규칙 설정 | 품질 규칙 설정 |
 | `/recipe-diagnose` | 문제를 조사하고 해결책 비교 | 근본 원인 분석 |
 | `/recipe-update-doc` | 기존 문서 업데이트 및 검토 | 요구 사항 또는 설계 변경 |
 | `/recipe-task` | 규칙을 따르는 작업을 직접 실행 | 단계별 인계가 필요 없는 작업 |

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Requires a Claude Code release with plugin marketplace support.
 | Design and build a React / TypeScript frontend | `/recipe-front-design` → `/recipe-front-plan` → `/recipe-front-build` | `dev-workflows-frontend` |
 | Deliver a backend and React frontend change together | `/recipe-fullstack-implement` | `dev-workflows-fullstack` |
 | Review a completed implementation against the agreed outcome | `/recipe-review` or `/recipe-front-review` | `dev-workflows` or `dev-workflows-frontend` |
-| Set repository-specific review standards | `/recipe-quality-profile` | Any workflow plugin |
+| Set repository-specific quality rules | `/recipe-quality-profile` | Any workflow plugin |
 | Investigate a problem before choosing a fix | `/recipe-diagnose` | Any workflow plugin |
 | Document an existing system from its code | `/recipe-reverse-engineer` | `dev-workflows` or `dev-workflows-fullstack` |
 | A throwaway experiment or prototype | Use Claude Code directly | None |
@@ -130,7 +130,7 @@ Fresh contexts keep one phase's reasoning from silently becoming the next phase'
 | docs/design/example.md | Verification | Exercise cache invalidation | verification | | gap | Add a covering task before approval |
 ```
 
-The [Task template](skills/documentation-criteria/references/task-template.md) carries binding decisions and observable contract values into implementation, each with a yes-or-no compliance check. After execution, the applicable repository checks run against the complete task change before commit. The final reviewers read the same approved sources and the completed code instead of relying on the implementation conversation. `/recipe-quality-profile` can record repository-specific review standards and their sources in `docs/project-context/quality.yaml`; final reviewers use a confirmed profile alongside the approved sources.
+The [Task template](skills/documentation-criteria/references/task-template.md) carries binding decisions and observable contract values into implementation, each with a yes-or-no compliance check. After execution, the applicable repository checks run against the complete task change before commit. The final reviewers read the same approved sources and the completed code instead of relying on the implementation conversation. `/recipe-quality-profile` can record repository-specific quality rules and their sources in `docs/project-context/quality.yaml`; implementation executors and final reviewers use a confirmed profile alongside the approved sources.
 
 ### A real workflow run
 
@@ -245,7 +245,7 @@ All workflow entry points use the `recipe-` prefix. Type `/recipe-` and use tab 
 | `/recipe-plan` | Generate a work plan from design | Planning phase |
 | `/recipe-build` | Execute an existing work plan | Resume implementation |
 | `/recipe-review` | Review a completed implementation against the agreed outcome | Post-implementation check |
-| `/recipe-quality-profile` | Set repository-specific review standards | Repository standards |
+| `/recipe-quality-profile` | Set repository-specific quality rules | Repository quality rules |
 | `/recipe-diagnose` | Investigate a problem and compare solutions | Root cause analysis |
 | `/recipe-reverse-engineer` | Derive PRDs and Design Docs from code | Existing-system documentation |
 | `/recipe-add-integration-tests` | Add integration or E2E tests | Coverage for existing code |
@@ -266,7 +266,7 @@ The frontend plugin adds React-specific analysis, component architecture, React 
 | `/recipe-front-build` | Execute a frontend work plan | Resume React implementation |
 | `/recipe-front-adjust` | Adjust an implemented UI with external verification | Visual refinements |
 | `/recipe-front-review` | Review a completed frontend against the agreed outcome | Post-implementation check |
-| `/recipe-quality-profile` | Set repository-specific review standards | Repository standards |
+| `/recipe-quality-profile` | Set repository-specific quality rules | Repository quality rules |
 | `/recipe-diagnose` | Investigate a problem and compare solutions | Root cause analysis |
 | `/recipe-update-doc` | Update and review existing documents | Requirement or design changes |
 | `/recipe-task` | Run a rule-guided task directly | Work that does not need staged workflow handoffs |

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -36,7 +36,7 @@ Requer uma versão do Claude Code com suporte ao marketplace de plugins.
 | Projetar e implementar um frontend React / TypeScript | `/recipe-front-design` → `/recipe-front-plan` → `/recipe-front-build` | `dev-workflows-frontend` |
 | Entregar backend e frontend React juntos | `/recipe-fullstack-implement` | `dev-workflows-fullstack` |
 | Revisar uma implementação concluída em relação ao resultado combinado | `/recipe-review` ou `/recipe-front-review` | `dev-workflows` ou `dev-workflows-frontend` |
-| Definir critérios de revisão específicos do repositório | `/recipe-quality-profile` | Qualquer plugin de fluxo |
+| Definir regras de qualidade específicas do repositório | `/recipe-quality-profile` | Qualquer plugin de fluxo |
 | Investigar um problema antes de escolher a correção | `/recipe-diagnose` | Qualquer plugin de fluxo |
 | Documentar um sistema existente a partir do código | `/recipe-reverse-engineer` | `dev-workflows` ou `dev-workflows-fullstack` |
 | Fazer um experimento descartável ou protótipo | Use o Claude Code diretamente | Nenhum |
@@ -130,7 +130,7 @@ Um novo contexto em cada fase evita que o raciocínio de uma fase vire, silencio
 | docs/design/example.md | Verification | Exercise cache invalidation | verification | | gap | Add a covering task before approval |
 ```
 
-O [modelo de Task](skills/documentation-criteria/references/task-template.md) leva para a implementação as decisões obrigatórias e os valores observáveis dos contratos, cada um com uma verificação de conformidade que pode ser respondida com sim ou não. Depois da execução, os controles aplicáveis do repositório rodam sobre a mudança completa antes do commit. Os revisores finais leem as mesmas fontes aprovadas e o código concluído, em vez de depender da conversa de implementação. `/recipe-quality-profile` permite registrar critérios de revisão específicos do repositório e suas fontes em `docs/project-context/quality.yaml`; os revisores finais usam o perfil confirmado junto com as fontes aprovadas.
+O [modelo de Task](skills/documentation-criteria/references/task-template.md) leva para a implementação as decisões obrigatórias e os valores observáveis dos contratos, cada um com uma verificação de conformidade que pode ser respondida com sim ou não. Depois da execução, os controles aplicáveis do repositório rodam sobre a mudança completa antes do commit. Os revisores finais leem as mesmas fontes aprovadas e o código concluído, em vez de depender da conversa de implementação. `/recipe-quality-profile` permite registrar regras de qualidade específicas do repositório e suas fontes em `docs/project-context/quality.yaml`; os executores de implementação e os revisores finais usam o perfil confirmado junto com as fontes aprovadas.
 
 ### Uma execução real
 
@@ -243,7 +243,7 @@ Todos os pontos de entrada usam o prefixo `recipe-`. Digite `/recipe-` e use Tab
 | `/recipe-plan` | Gerar um Work Plan a partir do design | Etapa de planejamento |
 | `/recipe-build` | Executar um Work Plan existente | Retomar uma implementação |
 | `/recipe-review` | Revisar uma implementação concluída em relação ao resultado combinado | Verificação após a implementação |
-| `/recipe-quality-profile` | Definir critérios de revisão específicos do repositório | Critérios do repositório |
+| `/recipe-quality-profile` | Definir regras de qualidade específicas do repositório | Regras de qualidade |
 | `/recipe-diagnose` | Investigar um problema e comparar soluções | Análise de causa raiz |
 | `/recipe-reverse-engineer` | Derivar PRDs e Design Docs do código | Documentação de sistemas existentes |
 | `/recipe-add-integration-tests` | Adicionar testes de integração ou E2E | Cobertura para código existente |
@@ -264,7 +264,7 @@ O plugin de frontend acrescenta análise específica de React, arquitetura de co
 | `/recipe-front-build` | Executar o Work Plan de frontend | Retomar a implementação React |
 | `/recipe-front-adjust` | Ajustar uma UI implementada com verificação externa | Refinamentos visuais |
 | `/recipe-front-review` | Revisar um frontend concluído em relação ao resultado combinado | Verificação após a implementação |
-| `/recipe-quality-profile` | Definir critérios de revisão específicos do repositório | Critérios do repositório |
+| `/recipe-quality-profile` | Definir regras de qualidade específicas do repositório | Regras de qualidade |
 | `/recipe-diagnose` | Investigar um problema e comparar soluções | Análise de causa raiz |
 | `/recipe-update-doc` | Atualizar e revisar documentos existentes | Mudanças de requisitos ou design |
 | `/recipe-task` | Executar diretamente uma tarefa guiada por regras | Trabalho que não precisa de passagem de contexto entre etapas |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -36,7 +36,7 @@ claude-code-workflows让探索始终围绕已经约定的结果展开。它在�
 | 设计并实现React / TypeScript前端 | `/recipe-front-design` → `/recipe-front-plan` → `/recipe-front-build` | `dev-workflows-frontend` |
 | 同时交付后端和React前端 | `/recipe-fullstack-implement` | `dev-workflows-fullstack` |
 | 对照约定结果审查已完成的实现 | `/recipe-review` 或 `/recipe-front-review` | `dev-workflows` 或 `dev-workflows-frontend` |
-| 设置仓库特有的审查标准 | `/recipe-quality-profile` | 任意工作流插件 |
+| 设置仓库特有的质量规则 | `/recipe-quality-profile` | 任意工作流插件 |
 | 在选择修复方案前调查问题 | `/recipe-diagnose` | 任意工作流插件 |
 | 根据代码记录现有系统 | `/recipe-reverse-engineer` | `dev-workflows` 或 `dev-workflows-fullstack` |
 | 一次性实验或原型 | 直接使用Claude Code | 无 |
@@ -130,7 +130,7 @@ Work Plan必须经过范围覆盖、依赖顺序和可执行验证方面的审�
 | docs/design/example.md | Verification | Exercise cache invalidation | verification | | gap | Add a covering task before approval |
 ```
 
-[Task模板](skills/documentation-criteria/references/task-template.md)会把具有约束力的决策和对外可验证的契约内容带入实现，并为每一项提供可用“是/否”判断的合规检查。执行完成后，在提交前对整个任务变更运行适用的仓库检查。最终审查者读取同一套已批准来源和完成的代码，而不是依赖实现过程中的对话。`/recipe-quality-profile`可以把仓库特有的审查标准及其依据记录到`docs/project-context/quality.yaml`中；最终审查会将确认后的配置与已批准资料一同使用。
+[Task模板](skills/documentation-criteria/references/task-template.md)会把具有约束力的决策和对外可验证的契约内容带入实现，并为每一项提供可用“是/否”判断的合规检查。执行完成后，在提交前对整个任务变更运行适用的仓库检查。最终审查者读取同一套已批准来源和完成的代码，而不是依赖实现过程中的对话。`/recipe-quality-profile`可以把仓库特有的质量规则及其依据记录到`docs/project-context/quality.yaml`中；实现执行者和最终审查者会将确认后的配置与已批准资料一同使用。
 
 ### 一次真实的工作流执行
 
@@ -243,7 +243,7 @@ recipe会确定变更范围、检查当前实现，只创建决策所需的文�
 | `/recipe-plan` | 根据设计生成Work Plan | 规划阶段 |
 | `/recipe-build` | 执行已有Work Plan | 继续实现 |
 | `/recipe-review` | 对照约定结果审查已完成的实现 | 实现后检查 |
-| `/recipe-quality-profile` | 设置仓库特有的审查标准 | 仓库标准设置 |
+| `/recipe-quality-profile` | 设置仓库特有的质量规则 | 质量规则设置 |
 | `/recipe-diagnose` | 调查问题并比较解决方案 | 根因分析 |
 | `/recipe-reverse-engineer` | 根据代码生成PRD和Design Doc | 现有系统文档化 |
 | `/recipe-add-integration-tests` | 添加集成或E2E测试 | 为现有代码补充覆盖 |
@@ -264,7 +264,7 @@ recipe会确定变更范围、检查当前实现，只创建决策所需的文�
 | `/recipe-front-build` | 执行前端Work Plan | 恢复React实现 |
 | `/recipe-front-adjust` | 借助外部验证调整已实现UI | 视觉细节调整 |
 | `/recipe-front-review` | 对照约定结果审查已完成的前端 | 实现后检查 |
-| `/recipe-quality-profile` | 设置仓库特有的审查标准 | 仓库标准设置 |
+| `/recipe-quality-profile` | 设置仓库特有的质量规则 | 质量规则设置 |
 | `/recipe-diagnose` | 调查问题并比较解决方案 | 根因分析 |
 | `/recipe-update-doc` | 更新并审查现有文档 | 需求或设计变更 |
 | `/recipe-task` | 直接运行遵循规则的任务 | 不需要分阶段交接的工作 |

--- a/agents/task-executor-frontend.md
+++ b/agents/task-executor-frontend.md
@@ -44,6 +44,8 @@ Use the appropriate run command based on the `packageManager` field in package.j
 ### Applying to Implementation
 Apply loaded TypeScript / React / test-implement / frontend-ai-guide rules during implementation. Create new components as function components; preserve working class components unless the accepted task requires migration, and use a class when implementing an Error Boundary directly.
 
+When `docs/project-context/quality.yaml` exists, use it as implementation guidance.
+
 Deliver the outcome with types satisfied at their boundaries, errors propagated or handled explicitly, and tests asserting the behavior the task delivers. Downstream quality assurance re-checks these properties.
 
 ## Design Surface Check (Before Mandatory Judgment)

--- a/agents/task-executor.md
+++ b/agents/task-executor.md
@@ -39,6 +39,8 @@ Before acting, map the preloaded skills to concrete rules for this task. Follow 
 ### Applying to Implementation
 Apply loaded architecture/coding/testing rules during implementation, including the selected test-first or behavior-preserving refactor flow. Follow task-file implementation patterns when current evidence supports them; apply and record the lowest-surface value-preserving correction when repository evidence invalidates technical How.
 
+When `docs/project-context/quality.yaml` exists, use it as implementation guidance.
+
 Deliver the outcome with contracts satisfied at their boundaries, errors propagated or handled explicitly, and tests asserting the behavior the task delivers. Downstream quality assurance re-checks these properties.
 
 ## Design Surface Check (Before Mandatory Judgment)

--- a/dev-skills/.claude-plugin/plugin.json
+++ b/dev-skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-skills",
   "description": "Lightweight skills for users with existing workflows - coding best practices, testing principles, and design guidelines without recipe workflows or agents",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows-frontend/.claude-plugin/plugin.json
+++ b/dev-workflows-frontend/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflows-frontend",
   "description": "Skills + Subagents for React/TypeScript - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows-frontend/agents/task-executor-frontend.md
+++ b/dev-workflows-frontend/agents/task-executor-frontend.md
@@ -44,6 +44,8 @@ Use the appropriate run command based on the `packageManager` field in package.j
 ### Applying to Implementation
 Apply loaded TypeScript / React / test-implement / frontend-ai-guide rules during implementation. Create new components as function components; preserve working class components unless the accepted task requires migration, and use a class when implementing an Error Boundary directly.
 
+When `docs/project-context/quality.yaml` exists, use it as implementation guidance.
+
 Deliver the outcome with types satisfied at their boundaries, errors propagated or handled explicitly, and tests asserting the behavior the task delivers. Downstream quality assurance re-checks these properties.
 
 ## Design Surface Check (Before Mandatory Judgment)

--- a/dev-workflows-frontend/skills/recipe-quality-profile/SKILL.md
+++ b/dev-workflows-frontend/skills/recipe-quality-profile/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: recipe-quality-profile
-description: Proposes repository-specific review policy and, after confirmation, creates or updates docs/project-context/quality.yaml. Use when asked to create or update a repository quality profile.
+description: Proposes repository-specific quality policy for implementation and review and, after confirmation, creates or updates docs/project-context/quality.yaml. Use when asked to create or update a repository quality profile.
 disable-model-invocation: true
 ---
 
@@ -9,7 +9,7 @@ Execute Skill: coding-principles to distinguish repository-owned policy from gen
 
 ## Purpose
 
-Establish repository-specific code-review acceptance conditions with the user, then create or update `docs/project-context/quality.yaml`.
+Establish repository-specific implementation and code-review acceptance conditions with the user, then create or update `docs/project-context/quality.yaml`.
 
 Requested policy change: $ARGUMENTS
 
@@ -25,7 +25,7 @@ review_dimensions:
       - "repository/path: section, identifier, or contract"
 ```
 
-Each dimension owns one repository-specific review decision. `applies_when` limits its review surface, `pass` defines the accepted state, and `evidence` identifies why the repository owns the rule.
+Each dimension owns one repository-specific quality decision. `applies_when` limits its implementation and review surface, `pass` defines the accepted state, and `evidence` identifies why the repository owns the rule.
 
 ## Authoring Flow
 
@@ -33,7 +33,7 @@ Each dimension owns one repository-specific review decision. `applies_when` limi
 2. Build candidates from acceptance conditions expressed or enforced by repository instructions, contributor documentation, CI, manifests and scripts, schemas and public contracts, tests, or representative implementation patterns. For an update, derive candidates only from the requested policy change and preserve unrelated dimensions.
 3. For each candidate, inspect supporting and contradicting evidence wherever it can change the candidate's applicability, accepted state, or repository ownership. Separate observed repository facts from policy choices that require user confirmation.
 4. Retain a candidate only when failing its `pass` condition would change implementation acceptance and every repository fact it depends on has cited evidence. Give it the narrowest useful `applies_when`, one positive observable `pass` condition, and consolidate candidates that would produce the same finding and correction. Omit a candidate when required repository evidence is unavailable and report the exact evidence needed.
-5. Present proposed additions, changes, and removals, confirm that other dimensions remain unchanged, show the supporting and contradicting evidence, and state unresolved policy choices with their effect on review acceptance. Obtain explicit user confirmation of a proposal with no unresolved choices before writing.
+5. Present proposed additions, changes, and removals, confirm that other dimensions remain unchanged, show the supporting and contradicting evidence, and state unresolved policy choices with their effect on implementation and review acceptance. Obtain explicit user confirmation of a proposal with no unresolved choices before writing.
 6. Write only the confirmed profile content. Read the result and verify version `1`, unique IDs, all required fields, observable conditions, readable evidence references, and consistency with the confirmed proposal.
 
 When no repository-specific dimension remains and no profile exists, report that repository evidence supports no profile content and leave the repository unchanged.
@@ -45,7 +45,7 @@ Before confirmation, report:
 - proposed additions, changes, and removals, plus the unchanged remainder;
 - supporting and contradicting evidence for each modification;
 - omitted candidates and the exact missing evidence;
-- policy choices requiring the user's decision and their effect on review acceptance.
+- policy choices requiring the user's decision and their effect on implementation and review acceptance.
 
 After confirmation, report:
 
@@ -56,7 +56,7 @@ After confirmation, report:
 
 ## Completion Check
 
-- [ ] Every retained dimension changes a review decision and cites repository or user-confirmed policy evidence
+- [ ] Every retained dimension changes an implementation or review decision and cites repository or user-confirmed policy evidence
 - [ ] Conditions are positive, observable, and limited by `applies_when`
 - [ ] The profile contains repository-specific acceptance conditions only
 - [ ] Supporting and contradicting evidence were compared where they could change the proposal

--- a/dev-workflows-fullstack/.claude-plugin/plugin.json
+++ b/dev-workflows-fullstack/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflows-fullstack",
   "description": "Skills + Subagents for fullstack development (backend + React/TypeScript) - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows-fullstack/agents/task-executor-frontend.md
+++ b/dev-workflows-fullstack/agents/task-executor-frontend.md
@@ -44,6 +44,8 @@ Use the appropriate run command based on the `packageManager` field in package.j
 ### Applying to Implementation
 Apply loaded TypeScript / React / test-implement / frontend-ai-guide rules during implementation. Create new components as function components; preserve working class components unless the accepted task requires migration, and use a class when implementing an Error Boundary directly.
 
+When `docs/project-context/quality.yaml` exists, use it as implementation guidance.
+
 Deliver the outcome with types satisfied at their boundaries, errors propagated or handled explicitly, and tests asserting the behavior the task delivers. Downstream quality assurance re-checks these properties.
 
 ## Design Surface Check (Before Mandatory Judgment)

--- a/dev-workflows-fullstack/agents/task-executor.md
+++ b/dev-workflows-fullstack/agents/task-executor.md
@@ -39,6 +39,8 @@ Before acting, map the preloaded skills to concrete rules for this task. Follow 
 ### Applying to Implementation
 Apply loaded architecture/coding/testing rules during implementation, including the selected test-first or behavior-preserving refactor flow. Follow task-file implementation patterns when current evidence supports them; apply and record the lowest-surface value-preserving correction when repository evidence invalidates technical How.
 
+When `docs/project-context/quality.yaml` exists, use it as implementation guidance.
+
 Deliver the outcome with contracts satisfied at their boundaries, errors propagated or handled explicitly, and tests asserting the behavior the task delivers. Downstream quality assurance re-checks these properties.
 
 ## Design Surface Check (Before Mandatory Judgment)

--- a/dev-workflows-fullstack/skills/recipe-quality-profile/SKILL.md
+++ b/dev-workflows-fullstack/skills/recipe-quality-profile/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: recipe-quality-profile
-description: Proposes repository-specific review policy and, after confirmation, creates or updates docs/project-context/quality.yaml. Use when asked to create or update a repository quality profile.
+description: Proposes repository-specific quality policy for implementation and review and, after confirmation, creates or updates docs/project-context/quality.yaml. Use when asked to create or update a repository quality profile.
 disable-model-invocation: true
 ---
 
@@ -9,7 +9,7 @@ Execute Skill: coding-principles to distinguish repository-owned policy from gen
 
 ## Purpose
 
-Establish repository-specific code-review acceptance conditions with the user, then create or update `docs/project-context/quality.yaml`.
+Establish repository-specific implementation and code-review acceptance conditions with the user, then create or update `docs/project-context/quality.yaml`.
 
 Requested policy change: $ARGUMENTS
 
@@ -25,7 +25,7 @@ review_dimensions:
       - "repository/path: section, identifier, or contract"
 ```
 
-Each dimension owns one repository-specific review decision. `applies_when` limits its review surface, `pass` defines the accepted state, and `evidence` identifies why the repository owns the rule.
+Each dimension owns one repository-specific quality decision. `applies_when` limits its implementation and review surface, `pass` defines the accepted state, and `evidence` identifies why the repository owns the rule.
 
 ## Authoring Flow
 
@@ -33,7 +33,7 @@ Each dimension owns one repository-specific review decision. `applies_when` limi
 2. Build candidates from acceptance conditions expressed or enforced by repository instructions, contributor documentation, CI, manifests and scripts, schemas and public contracts, tests, or representative implementation patterns. For an update, derive candidates only from the requested policy change and preserve unrelated dimensions.
 3. For each candidate, inspect supporting and contradicting evidence wherever it can change the candidate's applicability, accepted state, or repository ownership. Separate observed repository facts from policy choices that require user confirmation.
 4. Retain a candidate only when failing its `pass` condition would change implementation acceptance and every repository fact it depends on has cited evidence. Give it the narrowest useful `applies_when`, one positive observable `pass` condition, and consolidate candidates that would produce the same finding and correction. Omit a candidate when required repository evidence is unavailable and report the exact evidence needed.
-5. Present proposed additions, changes, and removals, confirm that other dimensions remain unchanged, show the supporting and contradicting evidence, and state unresolved policy choices with their effect on review acceptance. Obtain explicit user confirmation of a proposal with no unresolved choices before writing.
+5. Present proposed additions, changes, and removals, confirm that other dimensions remain unchanged, show the supporting and contradicting evidence, and state unresolved policy choices with their effect on implementation and review acceptance. Obtain explicit user confirmation of a proposal with no unresolved choices before writing.
 6. Write only the confirmed profile content. Read the result and verify version `1`, unique IDs, all required fields, observable conditions, readable evidence references, and consistency with the confirmed proposal.
 
 When no repository-specific dimension remains and no profile exists, report that repository evidence supports no profile content and leave the repository unchanged.
@@ -45,7 +45,7 @@ Before confirmation, report:
 - proposed additions, changes, and removals, plus the unchanged remainder;
 - supporting and contradicting evidence for each modification;
 - omitted candidates and the exact missing evidence;
-- policy choices requiring the user's decision and their effect on review acceptance.
+- policy choices requiring the user's decision and their effect on implementation and review acceptance.
 
 After confirmation, report:
 
@@ -56,7 +56,7 @@ After confirmation, report:
 
 ## Completion Check
 
-- [ ] Every retained dimension changes a review decision and cites repository or user-confirmed policy evidence
+- [ ] Every retained dimension changes an implementation or review decision and cites repository or user-confirmed policy evidence
 - [ ] Conditions are positive, observable, and limited by `applies_when`
 - [ ] The profile contains repository-specific acceptance conditions only
 - [ ] Supporting and contradicting evidence were compared where they could change the proposal

--- a/dev-workflows/.claude-plugin/plugin.json
+++ b/dev-workflows/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflows",
   "description": "Skills + Subagents for backend development - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows/agents/task-executor.md
+++ b/dev-workflows/agents/task-executor.md
@@ -39,6 +39,8 @@ Before acting, map the preloaded skills to concrete rules for this task. Follow 
 ### Applying to Implementation
 Apply loaded architecture/coding/testing rules during implementation, including the selected test-first or behavior-preserving refactor flow. Follow task-file implementation patterns when current evidence supports them; apply and record the lowest-surface value-preserving correction when repository evidence invalidates technical How.
 
+When `docs/project-context/quality.yaml` exists, use it as implementation guidance.
+
 Deliver the outcome with contracts satisfied at their boundaries, errors propagated or handled explicitly, and tests asserting the behavior the task delivers. Downstream quality assurance re-checks these properties.
 
 ## Design Surface Check (Before Mandatory Judgment)

--- a/dev-workflows/skills/recipe-quality-profile/SKILL.md
+++ b/dev-workflows/skills/recipe-quality-profile/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: recipe-quality-profile
-description: Proposes repository-specific review policy and, after confirmation, creates or updates docs/project-context/quality.yaml. Use when asked to create or update a repository quality profile.
+description: Proposes repository-specific quality policy for implementation and review and, after confirmation, creates or updates docs/project-context/quality.yaml. Use when asked to create or update a repository quality profile.
 disable-model-invocation: true
 ---
 
@@ -9,7 +9,7 @@ Execute Skill: coding-principles to distinguish repository-owned policy from gen
 
 ## Purpose
 
-Establish repository-specific code-review acceptance conditions with the user, then create or update `docs/project-context/quality.yaml`.
+Establish repository-specific implementation and code-review acceptance conditions with the user, then create or update `docs/project-context/quality.yaml`.
 
 Requested policy change: $ARGUMENTS
 
@@ -25,7 +25,7 @@ review_dimensions:
       - "repository/path: section, identifier, or contract"
 ```
 
-Each dimension owns one repository-specific review decision. `applies_when` limits its review surface, `pass` defines the accepted state, and `evidence` identifies why the repository owns the rule.
+Each dimension owns one repository-specific quality decision. `applies_when` limits its implementation and review surface, `pass` defines the accepted state, and `evidence` identifies why the repository owns the rule.
 
 ## Authoring Flow
 
@@ -33,7 +33,7 @@ Each dimension owns one repository-specific review decision. `applies_when` limi
 2. Build candidates from acceptance conditions expressed or enforced by repository instructions, contributor documentation, CI, manifests and scripts, schemas and public contracts, tests, or representative implementation patterns. For an update, derive candidates only from the requested policy change and preserve unrelated dimensions.
 3. For each candidate, inspect supporting and contradicting evidence wherever it can change the candidate's applicability, accepted state, or repository ownership. Separate observed repository facts from policy choices that require user confirmation.
 4. Retain a candidate only when failing its `pass` condition would change implementation acceptance and every repository fact it depends on has cited evidence. Give it the narrowest useful `applies_when`, one positive observable `pass` condition, and consolidate candidates that would produce the same finding and correction. Omit a candidate when required repository evidence is unavailable and report the exact evidence needed.
-5. Present proposed additions, changes, and removals, confirm that other dimensions remain unchanged, show the supporting and contradicting evidence, and state unresolved policy choices with their effect on review acceptance. Obtain explicit user confirmation of a proposal with no unresolved choices before writing.
+5. Present proposed additions, changes, and removals, confirm that other dimensions remain unchanged, show the supporting and contradicting evidence, and state unresolved policy choices with their effect on implementation and review acceptance. Obtain explicit user confirmation of a proposal with no unresolved choices before writing.
 6. Write only the confirmed profile content. Read the result and verify version `1`, unique IDs, all required fields, observable conditions, readable evidence references, and consistency with the confirmed proposal.
 
 When no repository-specific dimension remains and no profile exists, report that repository evidence supports no profile content and leave the repository unchanged.
@@ -45,7 +45,7 @@ Before confirmation, report:
 - proposed additions, changes, and removals, plus the unchanged remainder;
 - supporting and contradicting evidence for each modification;
 - omitted candidates and the exact missing evidence;
-- policy choices requiring the user's decision and their effect on review acceptance.
+- policy choices requiring the user's decision and their effect on implementation and review acceptance.
 
 After confirmation, report:
 
@@ -56,7 +56,7 @@ After confirmation, report:
 
 ## Completion Check
 
-- [ ] Every retained dimension changes a review decision and cites repository or user-confirmed policy evidence
+- [ ] Every retained dimension changes an implementation or review decision and cites repository or user-confirmed policy evidence
 - [ ] Conditions are positive, observable, and limited by `applies_when`
 - [ ] The profile contains repository-specific acceptance conditions only
 - [ ] Supporting and contradicting evidence were compared where they could change the proposal

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-workflows",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "private": true,
   "type": "module",
   "engines": {

--- a/skills/recipe-quality-profile/SKILL.md
+++ b/skills/recipe-quality-profile/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: recipe-quality-profile
-description: Proposes repository-specific review policy and, after confirmation, creates or updates docs/project-context/quality.yaml. Use when asked to create or update a repository quality profile.
+description: Proposes repository-specific quality policy for implementation and review and, after confirmation, creates or updates docs/project-context/quality.yaml. Use when asked to create or update a repository quality profile.
 disable-model-invocation: true
 ---
 
@@ -9,7 +9,7 @@ Execute Skill: coding-principles to distinguish repository-owned policy from gen
 
 ## Purpose
 
-Establish repository-specific code-review acceptance conditions with the user, then create or update `docs/project-context/quality.yaml`.
+Establish repository-specific implementation and code-review acceptance conditions with the user, then create or update `docs/project-context/quality.yaml`.
 
 Requested policy change: $ARGUMENTS
 
@@ -25,7 +25,7 @@ review_dimensions:
       - "repository/path: section, identifier, or contract"
 ```
 
-Each dimension owns one repository-specific review decision. `applies_when` limits its review surface, `pass` defines the accepted state, and `evidence` identifies why the repository owns the rule.
+Each dimension owns one repository-specific quality decision. `applies_when` limits its implementation and review surface, `pass` defines the accepted state, and `evidence` identifies why the repository owns the rule.
 
 ## Authoring Flow
 
@@ -33,7 +33,7 @@ Each dimension owns one repository-specific review decision. `applies_when` limi
 2. Build candidates from acceptance conditions expressed or enforced by repository instructions, contributor documentation, CI, manifests and scripts, schemas and public contracts, tests, or representative implementation patterns. For an update, derive candidates only from the requested policy change and preserve unrelated dimensions.
 3. For each candidate, inspect supporting and contradicting evidence wherever it can change the candidate's applicability, accepted state, or repository ownership. Separate observed repository facts from policy choices that require user confirmation.
 4. Retain a candidate only when failing its `pass` condition would change implementation acceptance and every repository fact it depends on has cited evidence. Give it the narrowest useful `applies_when`, one positive observable `pass` condition, and consolidate candidates that would produce the same finding and correction. Omit a candidate when required repository evidence is unavailable and report the exact evidence needed.
-5. Present proposed additions, changes, and removals, confirm that other dimensions remain unchanged, show the supporting and contradicting evidence, and state unresolved policy choices with their effect on review acceptance. Obtain explicit user confirmation of a proposal with no unresolved choices before writing.
+5. Present proposed additions, changes, and removals, confirm that other dimensions remain unchanged, show the supporting and contradicting evidence, and state unresolved policy choices with their effect on implementation and review acceptance. Obtain explicit user confirmation of a proposal with no unresolved choices before writing.
 6. Write only the confirmed profile content. Read the result and verify version `1`, unique IDs, all required fields, observable conditions, readable evidence references, and consistency with the confirmed proposal.
 
 When no repository-specific dimension remains and no profile exists, report that repository evidence supports no profile content and leave the repository unchanged.
@@ -45,7 +45,7 @@ Before confirmation, report:
 - proposed additions, changes, and removals, plus the unchanged remainder;
 - supporting and contradicting evidence for each modification;
 - omitted candidates and the exact missing evidence;
-- policy choices requiring the user's decision and their effect on review acceptance.
+- policy choices requiring the user's decision and their effect on implementation and review acceptance.
 
 After confirmation, report:
 
@@ -56,7 +56,7 @@ After confirmation, report:
 
 ## Completion Check
 
-- [ ] Every retained dimension changes a review decision and cites repository or user-confirmed policy evidence
+- [ ] Every retained dimension changes an implementation or review decision and cites repository or user-confirmed policy evidence
 - [ ] Conditions are positive, observable, and limited by `applies_when`
 - [ ] The profile contains repository-specific acceptance conditions only
 - [ ] Supporting and contradicting evidence were compared where they could change the proposal


### PR DESCRIPTION
## Summary

- use repository quality profiles as implementation guidance for backend and frontend executors
- describe quality profiles as shared implementation and review policy across documentation and localized READMEs
- bump package and plugin versions to 0.25.1

## Testing

- `pnpm sync:check`
- `pnpm check:skills-index`
- `claude plugin validate .claude-plugin/marketplace.json`
- `claude plugin validate dev-workflows`
- `claude plugin validate dev-workflows-frontend`
- `claude plugin validate dev-workflows-fullstack`
- `claude plugin validate dev-skills`