### PR TITLE
Resolve frontend type-safety guidance by guarantee, not by a fixed route

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "dev-workflows",
       "source": "./dev-workflows",
       "strict": true,
-      "version": "0.25.3",
+      "version": "0.25.4",
       "description": "Skills + Subagents for backend development - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
       "author": {
         "name": "Shinsuke Kagawa",
@@ -83,7 +83,7 @@
       "name": "dev-workflows-frontend",
       "source": "./dev-workflows-frontend",
       "strict": true,
-      "version": "0.25.3",
+      "version": "0.25.4",
       "description": "Skills + Subagents for React/TypeScript - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
       "author": {
         "name": "Shinsuke Kagawa",
@@ -157,7 +157,7 @@
       "name": "dev-workflows-fullstack",
       "source": "./dev-workflows-fullstack",
       "strict": true,
-      "version": "0.25.3",
+      "version": "0.25.4",
       "description": "Skills + Subagents for fullstack development (backend + React/TypeScript) - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
       "author": {
         "name": "Shinsuke Kagawa",
@@ -247,7 +247,7 @@
       "name": "dev-skills",
       "source": "./dev-skills",
       "strict": true,
-      "version": "0.25.3",
+      "version": "0.25.4",
       "description": "Lightweight skills for users with existing workflows - coding best practices, testing principles, and design guidelines without recipe workflows or agents",
       "author": {
         "name": "Shinsuke Kagawa",

--- a/agents/quality-fixer-frontend.md
+++ b/agents/quality-fixer-frontend.md
@@ -253,7 +253,7 @@ Between tool calls, briefly report: which phase is running, the command executed
   - Split components when independent rendering, state, data, or test responsibilities create material coupling or verification cost; retain a cohesive component when splitting would add avoidable prop/state synchronization
   - Refactor deeply nested conditionals
 - **Type Error Fixes**
-  - Handle external API responses with unknown type and type guards
+  - Resolve external API response types by the typescript-rules boundary validation policy
   - Add necessary Props type definitions
   - Flexibly handle with generics or union types
 
@@ -261,7 +261,6 @@ Between tool calls, briefly report: which phase is running, the command executed
 
 ### TypeScript Errors
 - **Props type definition**: Add explicit type definitions for all component Props
-- **Unknown API responses**: Use `unknown` type with type guards for external data
 - **Event handlers**: Use proper React event types (`React.ChangeEvent`, `React.MouseEvent`)
 - **Refs**: Use `React.RefObject<T>` or `React.MutableRefObject<T>`
 

--- a/dev-skills/.claude-plugin/plugin.json
+++ b/dev-skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-skills",
   "description": "Lightweight skills for users with existing workflows - coding best practices, testing principles, and design guidelines without recipe workflows or agents",
-  "version": "0.25.3",
+  "version": "0.25.4",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-skills/skills/frontend-ai-guide/SKILL.md
+++ b/dev-skills/skills/frontend-ai-guide/SKILL.md
@@ -25,7 +25,7 @@ Pause the affected decision and review the design when detecting the following p
 4. **Making changes without checking dependencies** - Potential for unexpected impacts
 5. **Disabling code with comments** - Should use version control
 6. **Error suppression** - Hiding problems creates technical debt
-7. **Excessive use of type assertions (as)** - Abandoning type safety
+7. **Type assertions standing in for a guarantee** - Declaring a type the code does not check or a contract does not establish
 8. **Pass-through prop chains that obscure state ownership** - Use composition, Context, or the project's state layer when intermediate components only forward values and a broader owner is clearer; retain explicit props when they preserve local ownership and broader state ownership would add coordination while responsibility remains local
 9. **Components mixing independently changing responsibilities** - Split when rendering, state/data ownership, or reusable/testable behavior forms an independent responsibility; retain cohesive components when splitting would add avoidable prop/state synchronization
 
@@ -79,10 +79,10 @@ Keep concrete implementations separate while their similarity is accidental or t
 **Cause**: Surface-level fixes without understanding root cause
 **Avoidance**: Identify root cause with 5 Whys before fixing
 
-### Pattern 2: Abandoning Type Safety
-**Symptom**: Excessive use of any type or as
+### Pattern 2: Circumventing Type Guarantees
+**Symptom**: `any` or `as` declares a type that no check or contract establishes
 **Cause**: Impulse to avoid type errors
-**Avoidance**: Handle safely with unknown type and type guards
+**Avoidance**: Back the declared type with a check or an existing contract that guarantees it, at the boundary where that guarantee holds
 
 ### Pattern 3: Implementation Without Sufficient Testing
 **Symptom**: Many bugs after implementation

--- a/dev-skills/skills/frontend-ai-guide/SKILL.md
+++ b/dev-skills/skills/frontend-ai-guide/SKILL.md
@@ -25,7 +25,7 @@ Pause the affected decision and review the design when detecting the following p
 4. **Making changes without checking dependencies** - Potential for unexpected impacts
 5. **Disabling code with comments** - Should use version control
 6. **Error suppression** - Hiding problems creates technical debt
-7. **Type assertions standing in for a guarantee** - Declaring a type the code does not check or a contract does not establish
+7. **Type assertions standing in for a guarantee** - Declaring a type established by neither a check nor an existing contract
 8. **Pass-through prop chains that obscure state ownership** - Use composition, Context, or the project's state layer when intermediate components only forward values and a broader owner is clearer; retain explicit props when they preserve local ownership and broader state ownership would add coordination while responsibility remains local
 9. **Components mixing independently changing responsibilities** - Split when rendering, state/data ownership, or reusable/testable behavior forms an independent responsibility; retain cohesive components when splitting would add avoidable prop/state synchronization
 

--- a/dev-workflows-frontend/.claude-plugin/plugin.json
+++ b/dev-workflows-frontend/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflows-frontend",
   "description": "Skills + Subagents for React/TypeScript - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
-  "version": "0.25.3",
+  "version": "0.25.4",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows-frontend/agents/quality-fixer-frontend.md
+++ b/dev-workflows-frontend/agents/quality-fixer-frontend.md
@@ -253,7 +253,7 @@ Between tool calls, briefly report: which phase is running, the command executed
   - Split components when independent rendering, state, data, or test responsibilities create material coupling or verification cost; retain a cohesive component when splitting would add avoidable prop/state synchronization
   - Refactor deeply nested conditionals
 - **Type Error Fixes**
-  - Handle external API responses with unknown type and type guards
+  - Resolve external API response types by the typescript-rules boundary validation policy
   - Add necessary Props type definitions
   - Flexibly handle with generics or union types
 
@@ -261,7 +261,6 @@ Between tool calls, briefly report: which phase is running, the command executed
 
 ### TypeScript Errors
 - **Props type definition**: Add explicit type definitions for all component Props
-- **Unknown API responses**: Use `unknown` type with type guards for external data
 - **Event handlers**: Use proper React event types (`React.ChangeEvent`, `React.MouseEvent`)
 - **Refs**: Use `React.RefObject<T>` or `React.MutableRefObject<T>`
 

--- a/dev-workflows-frontend/skills/frontend-ai-guide/SKILL.md
+++ b/dev-workflows-frontend/skills/frontend-ai-guide/SKILL.md
@@ -25,7 +25,7 @@ Pause the affected decision and review the design when detecting the following p
 4. **Making changes without checking dependencies** - Potential for unexpected impacts
 5. **Disabling code with comments** - Should use version control
 6. **Error suppression** - Hiding problems creates technical debt
-7. **Excessive use of type assertions (as)** - Abandoning type safety
+7. **Type assertions standing in for a guarantee** - Declaring a type the code does not check or a contract does not establish
 8. **Pass-through prop chains that obscure state ownership** - Use composition, Context, or the project's state layer when intermediate components only forward values and a broader owner is clearer; retain explicit props when they preserve local ownership and broader state ownership would add coordination while responsibility remains local
 9. **Components mixing independently changing responsibilities** - Split when rendering, state/data ownership, or reusable/testable behavior forms an independent responsibility; retain cohesive components when splitting would add avoidable prop/state synchronization
 
@@ -79,10 +79,10 @@ Keep concrete implementations separate while their similarity is accidental or t
 **Cause**: Surface-level fixes without understanding root cause
 **Avoidance**: Identify root cause with 5 Whys before fixing
 
-### Pattern 2: Abandoning Type Safety
-**Symptom**: Excessive use of any type or as
+### Pattern 2: Circumventing Type Guarantees
+**Symptom**: `any` or `as` declares a type that no check or contract establishes
 **Cause**: Impulse to avoid type errors
-**Avoidance**: Handle safely with unknown type and type guards
+**Avoidance**: Back the declared type with a check or an existing contract that guarantees it, at the boundary where that guarantee holds
 
 ### Pattern 3: Implementation Without Sufficient Testing
 **Symptom**: Many bugs after implementation

--- a/dev-workflows-frontend/skills/frontend-ai-guide/SKILL.md
+++ b/dev-workflows-frontend/skills/frontend-ai-guide/SKILL.md
@@ -25,7 +25,7 @@ Pause the affected decision and review the design when detecting the following p
 4. **Making changes without checking dependencies** - Potential for unexpected impacts
 5. **Disabling code with comments** - Should use version control
 6. **Error suppression** - Hiding problems creates technical debt
-7. **Type assertions standing in for a guarantee** - Declaring a type the code does not check or a contract does not establish
+7. **Type assertions standing in for a guarantee** - Declaring a type established by neither a check nor an existing contract
 8. **Pass-through prop chains that obscure state ownership** - Use composition, Context, or the project's state layer when intermediate components only forward values and a broader owner is clearer; retain explicit props when they preserve local ownership and broader state ownership would add coordination while responsibility remains local
 9. **Components mixing independently changing responsibilities** - Split when rendering, state/data ownership, or reusable/testable behavior forms an independent responsibility; retain cohesive components when splitting would add avoidable prop/state synchronization
 

--- a/dev-workflows-fullstack/.claude-plugin/plugin.json
+++ b/dev-workflows-fullstack/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflows-fullstack",
   "description": "Skills + Subagents for fullstack development (backend + React/TypeScript) - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
-  "version": "0.25.3",
+  "version": "0.25.4",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows-fullstack/agents/quality-fixer-frontend.md
+++ b/dev-workflows-fullstack/agents/quality-fixer-frontend.md
@@ -253,7 +253,7 @@ Between tool calls, briefly report: which phase is running, the command executed
   - Split components when independent rendering, state, data, or test responsibilities create material coupling or verification cost; retain a cohesive component when splitting would add avoidable prop/state synchronization
   - Refactor deeply nested conditionals
 - **Type Error Fixes**
-  - Handle external API responses with unknown type and type guards
+  - Resolve external API response types by the typescript-rules boundary validation policy
   - Add necessary Props type definitions
   - Flexibly handle with generics or union types
 
@@ -261,7 +261,6 @@ Between tool calls, briefly report: which phase is running, the command executed
 
 ### TypeScript Errors
 - **Props type definition**: Add explicit type definitions for all component Props
-- **Unknown API responses**: Use `unknown` type with type guards for external data
 - **Event handlers**: Use proper React event types (`React.ChangeEvent`, `React.MouseEvent`)
 - **Refs**: Use `React.RefObject<T>` or `React.MutableRefObject<T>`
 

--- a/dev-workflows-fullstack/skills/frontend-ai-guide/SKILL.md
+++ b/dev-workflows-fullstack/skills/frontend-ai-guide/SKILL.md
@@ -25,7 +25,7 @@ Pause the affected decision and review the design when detecting the following p
 4. **Making changes without checking dependencies** - Potential for unexpected impacts
 5. **Disabling code with comments** - Should use version control
 6. **Error suppression** - Hiding problems creates technical debt
-7. **Excessive use of type assertions (as)** - Abandoning type safety
+7. **Type assertions standing in for a guarantee** - Declaring a type the code does not check or a contract does not establish
 8. **Pass-through prop chains that obscure state ownership** - Use composition, Context, or the project's state layer when intermediate components only forward values and a broader owner is clearer; retain explicit props when they preserve local ownership and broader state ownership would add coordination while responsibility remains local
 9. **Components mixing independently changing responsibilities** - Split when rendering, state/data ownership, or reusable/testable behavior forms an independent responsibility; retain cohesive components when splitting would add avoidable prop/state synchronization
 
@@ -79,10 +79,10 @@ Keep concrete implementations separate while their similarity is accidental or t
 **Cause**: Surface-level fixes without understanding root cause
 **Avoidance**: Identify root cause with 5 Whys before fixing
 
-### Pattern 2: Abandoning Type Safety
-**Symptom**: Excessive use of any type or as
+### Pattern 2: Circumventing Type Guarantees
+**Symptom**: `any` or `as` declares a type that no check or contract establishes
 **Cause**: Impulse to avoid type errors
-**Avoidance**: Handle safely with unknown type and type guards
+**Avoidance**: Back the declared type with a check or an existing contract that guarantees it, at the boundary where that guarantee holds
 
 ### Pattern 3: Implementation Without Sufficient Testing
 **Symptom**: Many bugs after implementation

--- a/dev-workflows-fullstack/skills/frontend-ai-guide/SKILL.md
+++ b/dev-workflows-fullstack/skills/frontend-ai-guide/SKILL.md
@@ -25,7 +25,7 @@ Pause the affected decision and review the design when detecting the following p
 4. **Making changes without checking dependencies** - Potential for unexpected impacts
 5. **Disabling code with comments** - Should use version control
 6. **Error suppression** - Hiding problems creates technical debt
-7. **Type assertions standing in for a guarantee** - Declaring a type the code does not check or a contract does not establish
+7. **Type assertions standing in for a guarantee** - Declaring a type established by neither a check nor an existing contract
 8. **Pass-through prop chains that obscure state ownership** - Use composition, Context, or the project's state layer when intermediate components only forward values and a broader owner is clearer; retain explicit props when they preserve local ownership and broader state ownership would add coordination while responsibility remains local
 9. **Components mixing independently changing responsibilities** - Split when rendering, state/data ownership, or reusable/testable behavior forms an independent responsibility; retain cohesive components when splitting would add avoidable prop/state synchronization
 

--- a/dev-workflows/.claude-plugin/plugin.json
+++ b/dev-workflows/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflows",
   "description": "Skills + Subagents for backend development - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
-  "version": "0.25.3",
+  "version": "0.25.4",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-workflows",
-  "version": "0.25.3",
+  "version": "0.25.4",
   "private": true,
   "type": "module",
   "engines": {

--- a/skills/frontend-ai-guide/SKILL.md
+++ b/skills/frontend-ai-guide/SKILL.md
@@ -25,7 +25,7 @@ Pause the affected decision and review the design when detecting the following p
 4. **Making changes without checking dependencies** - Potential for unexpected impacts
 5. **Disabling code with comments** - Should use version control
 6. **Error suppression** - Hiding problems creates technical debt
-7. **Excessive use of type assertions (as)** - Abandoning type safety
+7. **Type assertions standing in for a guarantee** - Declaring a type the code does not check or a contract does not establish
 8. **Pass-through prop chains that obscure state ownership** - Use composition, Context, or the project's state layer when intermediate components only forward values and a broader owner is clearer; retain explicit props when they preserve local ownership and broader state ownership would add coordination while responsibility remains local
 9. **Components mixing independently changing responsibilities** - Split when rendering, state/data ownership, or reusable/testable behavior forms an independent responsibility; retain cohesive components when splitting would add avoidable prop/state synchronization
 
@@ -79,10 +79,10 @@ Keep concrete implementations separate while their similarity is accidental or t
 **Cause**: Surface-level fixes without understanding root cause
 **Avoidance**: Identify root cause with 5 Whys before fixing
 
-### Pattern 2: Abandoning Type Safety
-**Symptom**: Excessive use of any type or as
+### Pattern 2: Circumventing Type Guarantees
+**Symptom**: `any` or `as` declares a type that no check or contract establishes
 **Cause**: Impulse to avoid type errors
-**Avoidance**: Handle safely with unknown type and type guards
+**Avoidance**: Back the declared type with a check or an existing contract that guarantees it, at the boundary where that guarantee holds
 
 ### Pattern 3: Implementation Without Sufficient Testing
 **Symptom**: Many bugs after implementation

--- a/skills/frontend-ai-guide/SKILL.md
+++ b/skills/frontend-ai-guide/SKILL.md
@@ -25,7 +25,7 @@ Pause the affected decision and review the design when detecting the following p
 4. **Making changes without checking dependencies** - Potential for unexpected impacts
 5. **Disabling code with comments** - Should use version control
 6. **Error suppression** - Hiding problems creates technical debt
-7. **Type assertions standing in for a guarantee** - Declaring a type the code does not check or a contract does not establish
+7. **Type assertions standing in for a guarantee** - Declaring a type established by neither a check nor an existing contract
 8. **Pass-through prop chains that obscure state ownership** - Use composition, Context, or the project's state layer when intermediate components only forward values and a broader owner is clearer; retain explicit props when they preserve local ownership and broader state ownership would add coordination while responsibility remains local
 9. **Components mixing independently changing responsibilities** - Split when rendering, state/data ownership, or reusable/testable behavior forms an independent responsibility; retain cohesive components when splitting would add avoidable prop/state synchronization
 


### PR DESCRIPTION
## Problem

`frontend-ai-guide` and `quality-fixer-frontend` prescribed `unknown` plus type guards as the single route for external data, while `typescript-rules` already owns that policy and permits bounded exceptions — including a generated client that enforces its contract at runtime. The fixed route both duplicated and contradicted the owning policy, and the backend counterpart (`ai-development-guide`) had already moved to a guarantee-based criterion, leaving the frontend side behind.

Two further problems came from the same place: the anti-pattern entry judged type assertions by how many were used rather than by whether anything backed them, and the fix guidance was stated twice in `quality-fixer-frontend`.

## Changes

**`skills/frontend-ai-guide/SKILL.md`** — criteria stated within this skill's own responsibility, with no dependency on another progressively disclosed skill

- Anti-pattern 7 now reads "Type assertions standing in for a guarantee — Declaring a type established by neither a check nor an existing contract", replacing the unmeasurable "Excessive use of type assertions (as)".
- Failure Pattern 2 becomes "Circumventing Type Guarantees"; its symptom and avoidance are stated as whether a check or an existing contract backs the declared type, rather than naming a single technique.

**`agents/quality-fixer-frontend.md`** — deferral to the preloaded owning policy

- External API response types are resolved by the `typescript-rules` boundary validation policy (the skill is preloaded through this agent's frontmatter).
- The duplicate React-specific "Unknown API responses" entry is removed; the auto-fix entry that already scopes `unknown` plus validation to untyped external API responses is kept unchanged.

**Versions** — patch bump to 0.25.4 across `package.json`, `.claude-plugin/marketplace.json`, and the four plugin manifests.

## Verification

`pnpm run sync`, `pnpm run sync:check`, `pnpm run check:skills-index`, and `claude plugin validate` for the marketplace manifest and all four plugins pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)