### PR TITLE
fix: stop reopening prior review and approval gates in build workflows

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "dev-workflows",
       "source": "./dev-workflows",
       "strict": true,
-      "version": "0.25.4",
+      "version": "0.25.5",
       "description": "Skills + Subagents for backend development - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
       "author": {
         "name": "Shinsuke Kagawa",
@@ -83,7 +83,7 @@
       "name": "dev-workflows-frontend",
       "source": "./dev-workflows-frontend",
       "strict": true,
-      "version": "0.25.4",
+      "version": "0.25.5",
       "description": "Skills + Subagents for React/TypeScript - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
       "author": {
         "name": "Shinsuke Kagawa",
@@ -157,7 +157,7 @@
       "name": "dev-workflows-fullstack",
       "source": "./dev-workflows-fullstack",
       "strict": true,
-      "version": "0.25.4",
+      "version": "0.25.5",
       "description": "Skills + Subagents for fullstack development (backend + React/TypeScript) - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
       "author": {
         "name": "Shinsuke Kagawa",
@@ -247,7 +247,7 @@
       "name": "dev-skills",
       "source": "./dev-skills",
       "strict": true,
-      "version": "0.25.4",
+      "version": "0.25.5",
       "description": "Lightweight skills for users with existing workflows - coding best practices, testing principles, and design guidelines without recipe workflows or agents",
       "author": {
         "name": "Shinsuke Kagawa",

--- a/dev-skills/.claude-plugin/plugin.json
+++ b/dev-skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-skills",
   "description": "Lightweight skills for users with existing workflows - coding best practices, testing principles, and design guidelines without recipe workflows or agents",
-  "version": "0.25.4",
+  "version": "0.25.5",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows-frontend/.claude-plugin/plugin.json
+++ b/dev-workflows-frontend/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflows-frontend",
   "description": "Skills + Subagents for React/TypeScript - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
-  "version": "0.25.4",
+  "version": "0.25.5",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows-frontend/skills/recipe-front-build/SKILL.md
+++ b/dev-workflows-frontend/skills/recipe-front-build/SKILL.md
@@ -21,7 +21,7 @@ Before the first finding disposition, read `references/review-resolution.md` fro
 **Execution Protocol**:
 1. **Invoke named specialists for deliverable production** — pass deliverable paths between them and validate their results (see subagents-orchestration-guide "Orchestrator Execution Boundary")
 2. **Follow the 4-step task cycle exactly**: execute → branch on executor result → quality-fix → commit
-3. **Enter autonomous mode** when user provides execution instruction with existing task files — this IS the batch approval
+3. **Enter autonomous mode** when the user provides execution instruction with an existing Work Plan or task files — this IS the batch approval
 4. **Scope**: Complete consumed task-set execution, post-implementation verification, consumed-task cleanup, and completion reporting in order, or stop autonomous execution at the current phase for a valid user-owned escalation. Advance only when the current phase's stated transition condition is satisfied.
 
 **CRITICAL**: Run quality-fixer-frontend before every commit.
@@ -53,8 +53,7 @@ Analyze the Consumed Task Set and determine the action required:
 | State | Criteria | Next Action |
 |-------|----------|-------------|
 | Tasks exist | Consumed Task Set is non-empty | User's execution instruction serves as batch approval → Enter autonomous execution immediately |
-| No tasks + approved plan exists | Consumed Task Set is empty but the resolved work plan has batch approval | Run task-decomposer; the approval already authorizes mechanical task materialization |
-| No tasks + unapproved plan exists | Consumed Task Set is empty and the resolved work plan is not approved | Review it when needed, then present the plan approval gate before task materialization |
+| No tasks + plan exists | Consumed Task Set is empty and the resolved work plan exists | User's execution instruction serves as batch approval → Run task-decomposer |
 | Neither exists + Design Doc exists | No plan, no Consumed Task Set, but `docs/design/*.md` exists | Invoke work-planner to create a work plan, then run document-reviewer (`dev-workflows-frontend:document-reviewer`, doc_type: WorkPlan). Run Review Resolution through correction re-review, its parent requirement or authority exits, and convergence, using work-planner for rerouted corrections; then present the resolved plan for batch approval before task materialization |
 | Neither exists | No plan, no Consumed Task Set, no Design Doc | Report missing prerequisites to user and stop |
 
@@ -62,17 +61,13 @@ Analyze the Consumed Task Set and determine the action required:
 
 When the Consumed Task Set is empty:
 
-### 1. Authorization Check
-
-Use the normal Work Plan review and approval gate when batch approval is absent. Existing batch approval authorizes task materialization directly.
-
-### 2. Task Materialization
+### 1. Task Materialization
 Invoke task-decomposer using Agent tool:
 - `subagent_type`: "dev-workflows-frontend:task-decomposer"
 - `description`: "Materialize work plan tasks"
 - `prompt`: "Read work plan at docs/plans/[plan-name].md and output individual single-commit task files in docs/plans/tasks/."
 
-### 3. Verify Generation
+### 2. Verify Generation
 Recompute the Consumed Task Set using the same restricted pattern from the Consumed Task Set section above. When it remains empty, apply Specialist Result Acceptance: validate the invocation and returned artifacts, correct recoverable input or naming errors, and rerun.
 
 **Flow**: Task generation → Consumed Task Set recompute → Autonomous execution (in this order)

--- a/dev-workflows-frontend/skills/subagents-orchestration-guide/SKILL.md
+++ b/dev-workflows-frontend/skills/subagents-orchestration-guide/SKILL.md
@@ -82,7 +82,7 @@ Workflow coordination is flat: the orchestrator issues every specialist call and
 
 ## Explicit Stop Points
 
-Autonomous execution MUST stop and wait for user input at these points.
+Apply these approval stops when producing or materially revising an artifact in the current workflow. A user instruction to proceed to a later phase accepts the preceding phases and authorizes entry into that phase; continue from that entry point rather than rechecking earlier review or approval records. In particular, a build instruction with an existing Work Plan grants batch approval for task materialization and implementation.
 **Use AskUserQuestion to present confirmations and questions.**
 
 Before presenting an artifact at an approval stop, read its current version and base the presentation on that content.
@@ -154,10 +154,9 @@ Rules:
 - An applied `unverified` discrepancy returns through a fresh owning technical-designer update invocation. Capability probing is reserved for the designer's review-triggered gate, with that fresh designer as the sole correction specialist
 - Fullstack layer sequencing is defined only in `references/monorepo-flow.md`
 - `design-sync` is required whenever multiple Design Docs exist
-- `task-decomposer` begins only after work plan review (document-reviewer, doc_type WorkPlan; Medium/Large) and batch approval
-- Work plan review runs Review Resolution through correction re-review, its parent requirement or authority exits, and convergence; batch approval is available only at its convergence condition
+- When creating or materially updating a Medium/Large Work Plan, run document-reviewer (doc_type WorkPlan) and Review Resolution through correction re-review, its parent requirement or authority exits, and convergence before presenting the plan for batch approval. Existing-plan build entry follows the phase acceptance rule in Explicit Stop Points.
 
-Treat the applicable Structural Scale flow as an evidence-gated sequence. Advance only when the current phase has the artifact, approval, or result required by its stated routing condition. Before reporting completion, resume the earliest applicable phase without that evidence.
+Start the applicable Structural Scale flow at the user-requested phase. Before reporting completion, verify the artifacts and results required by every applicable phase from that entry point through completion, and complete any missing work within those phases. Return to an earlier phase when a material change invalidates its outcome, using Handling Requirement Changes.
 
 ## Autonomous Execution Mode
 
@@ -168,7 +167,7 @@ Verify commit capability before autonomous mode. Let task-executor and quality-f
 Confirmed Small requirements or Medium/Large batch approval authorize task-executor implementation and quality-fixer corrections until completion or escalation.
 
 ### Autonomous Execution Summary
-For Medium/Large, after "batch approval for entire implementation phase" with work-planner, autonomously execute the following processes through completion or an escalation condition:
+For Medium/Large, after batch approval, including an existing-plan build instruction, autonomously execute the following processes through completion or an escalation condition:
 
 ```mermaid
 graph TD

--- a/dev-workflows-frontend/skills/subagents-orchestration-guide/references/monorepo-flow.md
+++ b/dev-workflows-frontend/skills/subagents-orchestration-guide/references/monorepo-flow.md
@@ -121,7 +121,7 @@ Pass both Design Doc paths as `design_docs`, the applicable `ui_spec`, and the s
 
 Pass both Design Docs, the applicable UI Spec, applicable PRD, and generated skeleton paths to work-planner. Compose phases around shared backend/frontend verification points. The generated skeleton file is consumed by the earliest task where its declared boundary becomes executable.
 
-Review the Work Plan with `doc_type: WorkPlan`, apply Review Resolution through work-planner, and stop for batch approval only after the review converges.
+When creating or materially updating the Work Plan, review it with `doc_type: WorkPlan`, apply Review Resolution through work-planner, and stop for batch approval only after the review converges. Existing-plan build entry follows the parent guide's phase acceptance rule.
 
 ## Task Materialization and Execution
 

--- a/dev-workflows-fullstack/.claude-plugin/plugin.json
+++ b/dev-workflows-fullstack/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflows-fullstack",
   "description": "Skills + Subagents for fullstack development (backend + React/TypeScript) - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
-  "version": "0.25.4",
+  "version": "0.25.5",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows-fullstack/skills/recipe-build/SKILL.md
+++ b/dev-workflows-fullstack/skills/recipe-build/SKILL.md
@@ -21,7 +21,7 @@ Before the first finding disposition, read `references/review-resolution.md` fro
 **Execution Protocol**:
 1. **Invoke named specialists for deliverable production** — pass deliverable paths between them and validate their results (see subagents-orchestration-guide "Orchestrator Execution Boundary")
 2. **Follow the 4-step task cycle exactly**: execute → branch on executor result → quality-fix → commit
-3. **Enter autonomous mode** when user provides execution instruction with existing task files — this IS the batch approval
+3. **Enter autonomous mode** when the user provides execution instruction with an existing Work Plan or task files — this IS the batch approval
 4. **Scope**: Complete consumed task-set execution, post-implementation verification, consumed-task cleanup, and completion reporting in order, or stop autonomous execution at the current phase for a valid user-owned escalation. Advance only when the current phase's stated transition condition is satisfied.
 
 **CRITICAL**: Run quality-fixer before every commit.
@@ -53,8 +53,7 @@ Analyze the Consumed Task Set and determine the action required:
 | State | Criteria | Next Action |
 |-------|----------|-------------|
 | Tasks exist | Consumed Task Set is non-empty | User's execution instruction serves as batch approval → Enter autonomous execution immediately |
-| No tasks + approved plan exists | Consumed Task Set is empty but the resolved work plan has batch approval | Run task-decomposer; the approval already authorizes mechanical task materialization |
-| No tasks + unapproved plan exists | Consumed Task Set is empty and the resolved work plan is not approved | Review it when needed, then present the plan approval gate before task materialization |
+| No tasks + plan exists | Consumed Task Set is empty and the resolved work plan exists | User's execution instruction serves as batch approval → Run task-decomposer |
 | Neither exists + Design Doc exists | No plan, no Consumed Task Set, but `docs/design/*.md` exists | Invoke work-planner to create a work plan, then run document-reviewer (`dev-workflows-fullstack:document-reviewer`, doc_type: WorkPlan). Run Review Resolution through correction re-review, its parent requirement or authority exits, and convergence, using work-planner for rerouted corrections; then present the resolved plan for batch approval before task materialization |
 | Neither exists | No plan, no Consumed Task Set, no Design Doc | Report missing prerequisites to user and stop |
 
@@ -62,17 +61,13 @@ Analyze the Consumed Task Set and determine the action required:
 
 When the Consumed Task Set is empty:
 
-### 1. Authorization Check
-
-Use the normal Work Plan review and approval gate when batch approval is absent. Existing batch approval authorizes task materialization directly.
-
-### 2. Task Materialization
+### 1. Task Materialization
 Invoke task-decomposer using Agent tool:
 - `subagent_type`: "dev-workflows-fullstack:task-decomposer"
 - `description`: "Materialize work plan tasks"
 - `prompt`: "Read work plan at docs/plans/[plan-name].md and output individual single-commit task files in docs/plans/tasks/."
 
-### 3. Verify Generation
+### 2. Verify Generation
 Recompute the Consumed Task Set using the same restricted pattern from the Consumed Task Set section above. When it remains empty, apply Specialist Result Acceptance: validate the invocation and returned artifacts, correct recoverable input or naming errors, and rerun.
 
 **Flow**: Task generation → Consumed Task Set recompute → Autonomous execution (in this order)

--- a/dev-workflows-fullstack/skills/recipe-front-build/SKILL.md
+++ b/dev-workflows-fullstack/skills/recipe-front-build/SKILL.md
@@ -21,7 +21,7 @@ Before the first finding disposition, read `references/review-resolution.md` fro
 **Execution Protocol**:
 1. **Invoke named specialists for deliverable production** — pass deliverable paths between them and validate their results (see subagents-orchestration-guide "Orchestrator Execution Boundary")
 2. **Follow the 4-step task cycle exactly**: execute → branch on executor result → quality-fix → commit
-3. **Enter autonomous mode** when user provides execution instruction with existing task files — this IS the batch approval
+3. **Enter autonomous mode** when the user provides execution instruction with an existing Work Plan or task files — this IS the batch approval
 4. **Scope**: Complete consumed task-set execution, post-implementation verification, consumed-task cleanup, and completion reporting in order, or stop autonomous execution at the current phase for a valid user-owned escalation. Advance only when the current phase's stated transition condition is satisfied.
 
 **CRITICAL**: Run quality-fixer-frontend before every commit.
@@ -53,8 +53,7 @@ Analyze the Consumed Task Set and determine the action required:
 | State | Criteria | Next Action |
 |-------|----------|-------------|
 | Tasks exist | Consumed Task Set is non-empty | User's execution instruction serves as batch approval → Enter autonomous execution immediately |
-| No tasks + approved plan exists | Consumed Task Set is empty but the resolved work plan has batch approval | Run task-decomposer; the approval already authorizes mechanical task materialization |
-| No tasks + unapproved plan exists | Consumed Task Set is empty and the resolved work plan is not approved | Review it when needed, then present the plan approval gate before task materialization |
+| No tasks + plan exists | Consumed Task Set is empty and the resolved work plan exists | User's execution instruction serves as batch approval → Run task-decomposer |
 | Neither exists + Design Doc exists | No plan, no Consumed Task Set, but `docs/design/*.md` exists | Invoke work-planner to create a work plan, then run document-reviewer (`dev-workflows-fullstack:document-reviewer`, doc_type: WorkPlan). Run Review Resolution through correction re-review, its parent requirement or authority exits, and convergence, using work-planner for rerouted corrections; then present the resolved plan for batch approval before task materialization |
 | Neither exists | No plan, no Consumed Task Set, no Design Doc | Report missing prerequisites to user and stop |
 
@@ -62,17 +61,13 @@ Analyze the Consumed Task Set and determine the action required:
 
 When the Consumed Task Set is empty:
 
-### 1. Authorization Check
-
-Use the normal Work Plan review and approval gate when batch approval is absent. Existing batch approval authorizes task materialization directly.
-
-### 2. Task Materialization
+### 1. Task Materialization
 Invoke task-decomposer using Agent tool:
 - `subagent_type`: "dev-workflows-fullstack:task-decomposer"
 - `description`: "Materialize work plan tasks"
 - `prompt`: "Read work plan at docs/plans/[plan-name].md and output individual single-commit task files in docs/plans/tasks/."
 
-### 3. Verify Generation
+### 2. Verify Generation
 Recompute the Consumed Task Set using the same restricted pattern from the Consumed Task Set section above. When it remains empty, apply Specialist Result Acceptance: validate the invocation and returned artifacts, correct recoverable input or naming errors, and rerun.
 
 **Flow**: Task generation → Consumed Task Set recompute → Autonomous execution (in this order)

--- a/dev-workflows-fullstack/skills/recipe-fullstack-build/SKILL.md
+++ b/dev-workflows-fullstack/skills/recipe-fullstack-build/SKILL.md
@@ -29,7 +29,7 @@ Before the first finding disposition, read `references/review-resolution.md` fro
    - `*-backend-task-*` → task-executor + quality-fixer
    - `*-frontend-task-*` → task-executor-frontend + quality-fixer-frontend
 3. **Follow the 4-step task cycle exactly**: execute → branch on executor result → quality-fix → commit
-4. **Enter autonomous mode** when user provides execution instruction with existing task files — this IS the batch approval
+4. **Enter autonomous mode** when the user provides execution instruction with an existing Work Plan or task files — this IS the batch approval
 5. **Scope**: Complete consumed task-set execution, post-implementation verification, consumed-task cleanup, and completion reporting in order, or stop autonomous execution at the current phase for a valid user-owned escalation. Advance only when the current phase's stated transition condition is satisfied.
 
 **CRITICAL**: Run layer-appropriate quality-fixer(s) before every commit.
@@ -61,8 +61,7 @@ Analyze the Consumed Task Set and determine the action required:
 | State | Criteria | Next Action |
 |-------|----------|-------------|
 | Tasks exist | Consumed Task Set is non-empty | User's execution instruction serves as batch approval → Enter autonomous execution immediately |
-| No tasks + approved plan exists | Consumed Task Set is empty but the resolved work plan has batch approval | Run task-decomposer; the approval already authorizes mechanical task materialization |
-| No tasks + unapproved plan exists | Consumed Task Set is empty and the resolved work plan is not approved | Review it when needed, then present the plan approval gate before task materialization |
+| No tasks + plan exists | Consumed Task Set is empty and the resolved work plan exists | User's execution instruction serves as batch approval → Run task-decomposer |
 | Neither exists + Design Doc exists | No plan, no Consumed Task Set, but `docs/design/*.md` exists | Invoke work-planner to create a work plan, then run document-reviewer (`dev-workflows-fullstack:document-reviewer`, doc_type: WorkPlan). Run Review Resolution through correction re-review, its parent requirement or authority exits, and convergence, using work-planner for rerouted corrections; then present the resolved plan for batch approval before task materialization |
 | Neither exists | No plan, no Consumed Task Set, no Design Doc | Report missing prerequisites to user and stop |
 
@@ -70,17 +69,13 @@ Analyze the Consumed Task Set and determine the action required:
 
 When the Consumed Task Set is empty:
 
-### 1. Authorization Check
-
-Use the normal Work Plan review and approval gate when batch approval is absent. Existing batch approval authorizes task materialization directly.
-
-### 2. Task Materialization
+### 1. Task Materialization
 Invoke task-decomposer using Agent tool:
 - `subagent_type`: "dev-workflows-fullstack:task-decomposer"
 - `description`: "Materialize work plan tasks"
 - `prompt`: "Read work plan at docs/plans/[plan-name].md and output individual single-commit task files in docs/plans/tasks/. Use layer-aware naming: {plan}-backend-task-{n}.md, {plan}-frontend-task-{n}.md from each Work Plan task's Executor lane."
 
-### 3. Verify Generation
+### 2. Verify Generation
 Recompute the Consumed Task Set using the same restricted pattern from the Consumed Task Set section above. When it remains empty, apply Specialist Result Acceptance: validate the invocation and returned artifacts, correct recoverable input or naming errors, and rerun.
 
 ## Pre-execution Checklist

--- a/dev-workflows-fullstack/skills/subagents-orchestration-guide/SKILL.md
+++ b/dev-workflows-fullstack/skills/subagents-orchestration-guide/SKILL.md
@@ -82,7 +82,7 @@ Workflow coordination is flat: the orchestrator issues every specialist call and
 
 ## Explicit Stop Points
 
-Autonomous execution MUST stop and wait for user input at these points.
+Apply these approval stops when producing or materially revising an artifact in the current workflow. A user instruction to proceed to a later phase accepts the preceding phases and authorizes entry into that phase; continue from that entry point rather than rechecking earlier review or approval records. In particular, a build instruction with an existing Work Plan grants batch approval for task materialization and implementation.
 **Use AskUserQuestion to present confirmations and questions.**
 
 Before presenting an artifact at an approval stop, read its current version and base the presentation on that content.
@@ -154,10 +154,9 @@ Rules:
 - An applied `unverified` discrepancy returns through a fresh owning technical-designer update invocation. Capability probing is reserved for the designer's review-triggered gate, with that fresh designer as the sole correction specialist
 - Fullstack layer sequencing is defined only in `references/monorepo-flow.md`
 - `design-sync` is required whenever multiple Design Docs exist
-- `task-decomposer` begins only after work plan review (document-reviewer, doc_type WorkPlan; Medium/Large) and batch approval
-- Work plan review runs Review Resolution through correction re-review, its parent requirement or authority exits, and convergence; batch approval is available only at its convergence condition
+- When creating or materially updating a Medium/Large Work Plan, run document-reviewer (doc_type WorkPlan) and Review Resolution through correction re-review, its parent requirement or authority exits, and convergence before presenting the plan for batch approval. Existing-plan build entry follows the phase acceptance rule in Explicit Stop Points.
 
-Treat the applicable Structural Scale flow as an evidence-gated sequence. Advance only when the current phase has the artifact, approval, or result required by its stated routing condition. Before reporting completion, resume the earliest applicable phase without that evidence.
+Start the applicable Structural Scale flow at the user-requested phase. Before reporting completion, verify the artifacts and results required by every applicable phase from that entry point through completion, and complete any missing work within those phases. Return to an earlier phase when a material change invalidates its outcome, using Handling Requirement Changes.
 
 ## Autonomous Execution Mode
 
@@ -168,7 +167,7 @@ Verify commit capability before autonomous mode. Let task-executor and quality-f
 Confirmed Small requirements or Medium/Large batch approval authorize task-executor implementation and quality-fixer corrections until completion or escalation.
 
 ### Autonomous Execution Summary
-For Medium/Large, after "batch approval for entire implementation phase" with work-planner, autonomously execute the following processes through completion or an escalation condition:
+For Medium/Large, after batch approval, including an existing-plan build instruction, autonomously execute the following processes through completion or an escalation condition:
 
 ```mermaid
 graph TD

--- a/dev-workflows-fullstack/skills/subagents-orchestration-guide/references/monorepo-flow.md
+++ b/dev-workflows-fullstack/skills/subagents-orchestration-guide/references/monorepo-flow.md
@@ -121,7 +121,7 @@ Pass both Design Doc paths as `design_docs`, the applicable `ui_spec`, and the s
 
 Pass both Design Docs, the applicable UI Spec, applicable PRD, and generated skeleton paths to work-planner. Compose phases around shared backend/frontend verification points. The generated skeleton file is consumed by the earliest task where its declared boundary becomes executable.
 
-Review the Work Plan with `doc_type: WorkPlan`, apply Review Resolution through work-planner, and stop for batch approval only after the review converges.
+When creating or materially updating the Work Plan, review it with `doc_type: WorkPlan`, apply Review Resolution through work-planner, and stop for batch approval only after the review converges. Existing-plan build entry follows the parent guide's phase acceptance rule.
 
 ## Task Materialization and Execution
 

--- a/dev-workflows/.claude-plugin/plugin.json
+++ b/dev-workflows/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflows",
   "description": "Skills + Subagents for backend development - Use skills for coding guidance, or run recipe workflows for full orchestrated agentic coding with specialized agents",
-  "version": "0.25.4",
+  "version": "0.25.5",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/dev-workflows/skills/recipe-build/SKILL.md
+++ b/dev-workflows/skills/recipe-build/SKILL.md
@@ -21,7 +21,7 @@ Before the first finding disposition, read `references/review-resolution.md` fro
 **Execution Protocol**:
 1. **Invoke named specialists for deliverable production** — pass deliverable paths between them and validate their results (see subagents-orchestration-guide "Orchestrator Execution Boundary")
 2. **Follow the 4-step task cycle exactly**: execute → branch on executor result → quality-fix → commit
-3. **Enter autonomous mode** when user provides execution instruction with existing task files — this IS the batch approval
+3. **Enter autonomous mode** when the user provides execution instruction with an existing Work Plan or task files — this IS the batch approval
 4. **Scope**: Complete consumed task-set execution, post-implementation verification, consumed-task cleanup, and completion reporting in order, or stop autonomous execution at the current phase for a valid user-owned escalation. Advance only when the current phase's stated transition condition is satisfied.
 
 **CRITICAL**: Run quality-fixer before every commit.
@@ -53,8 +53,7 @@ Analyze the Consumed Task Set and determine the action required:
 | State | Criteria | Next Action |
 |-------|----------|-------------|
 | Tasks exist | Consumed Task Set is non-empty | User's execution instruction serves as batch approval → Enter autonomous execution immediately |
-| No tasks + approved plan exists | Consumed Task Set is empty but the resolved work plan has batch approval | Run task-decomposer; the approval already authorizes mechanical task materialization |
-| No tasks + unapproved plan exists | Consumed Task Set is empty and the resolved work plan is not approved | Review it when needed, then present the plan approval gate before task materialization |
+| No tasks + plan exists | Consumed Task Set is empty and the resolved work plan exists | User's execution instruction serves as batch approval → Run task-decomposer |
 | Neither exists + Design Doc exists | No plan, no Consumed Task Set, but `docs/design/*.md` exists | Invoke work-planner to create a work plan, then run document-reviewer (`dev-workflows:document-reviewer`, doc_type: WorkPlan). Run Review Resolution through correction re-review, its parent requirement or authority exits, and convergence, using work-planner for rerouted corrections; then present the resolved plan for batch approval before task materialization |
 | Neither exists | No plan, no Consumed Task Set, no Design Doc | Report missing prerequisites to user and stop |
 
@@ -62,17 +61,13 @@ Analyze the Consumed Task Set and determine the action required:
 
 When the Consumed Task Set is empty:
 
-### 1. Authorization Check
-
-Use the normal Work Plan review and approval gate when batch approval is absent. Existing batch approval authorizes task materialization directly.
-
-### 2. Task Materialization
+### 1. Task Materialization
 Invoke task-decomposer using Agent tool:
 - `subagent_type`: "dev-workflows:task-decomposer"
 - `description`: "Materialize work plan tasks"
 - `prompt`: "Read work plan at docs/plans/[plan-name].md and output individual single-commit task files in docs/plans/tasks/."
 
-### 3. Verify Generation
+### 2. Verify Generation
 Recompute the Consumed Task Set using the same restricted pattern from the Consumed Task Set section above. When it remains empty, apply Specialist Result Acceptance: validate the invocation and returned artifacts, correct recoverable input or naming errors, and rerun.
 
 **Flow**: Task generation → Consumed Task Set recompute → Autonomous execution (in this order)

--- a/dev-workflows/skills/subagents-orchestration-guide/SKILL.md
+++ b/dev-workflows/skills/subagents-orchestration-guide/SKILL.md
@@ -82,7 +82,7 @@ Workflow coordination is flat: the orchestrator issues every specialist call and
 
 ## Explicit Stop Points
 
-Autonomous execution MUST stop and wait for user input at these points.
+Apply these approval stops when producing or materially revising an artifact in the current workflow. A user instruction to proceed to a later phase accepts the preceding phases and authorizes entry into that phase; continue from that entry point rather than rechecking earlier review or approval records. In particular, a build instruction with an existing Work Plan grants batch approval for task materialization and implementation.
 **Use AskUserQuestion to present confirmations and questions.**
 
 Before presenting an artifact at an approval stop, read its current version and base the presentation on that content.
@@ -154,10 +154,9 @@ Rules:
 - An applied `unverified` discrepancy returns through a fresh owning technical-designer update invocation. Capability probing is reserved for the designer's review-triggered gate, with that fresh designer as the sole correction specialist
 - Fullstack layer sequencing is defined only in `references/monorepo-flow.md`
 - `design-sync` is required whenever multiple Design Docs exist
-- `task-decomposer` begins only after work plan review (document-reviewer, doc_type WorkPlan; Medium/Large) and batch approval
-- Work plan review runs Review Resolution through correction re-review, its parent requirement or authority exits, and convergence; batch approval is available only at its convergence condition
+- When creating or materially updating a Medium/Large Work Plan, run document-reviewer (doc_type WorkPlan) and Review Resolution through correction re-review, its parent requirement or authority exits, and convergence before presenting the plan for batch approval. Existing-plan build entry follows the phase acceptance rule in Explicit Stop Points.
 
-Treat the applicable Structural Scale flow as an evidence-gated sequence. Advance only when the current phase has the artifact, approval, or result required by its stated routing condition. Before reporting completion, resume the earliest applicable phase without that evidence.
+Start the applicable Structural Scale flow at the user-requested phase. Before reporting completion, verify the artifacts and results required by every applicable phase from that entry point through completion, and complete any missing work within those phases. Return to an earlier phase when a material change invalidates its outcome, using Handling Requirement Changes.
 
 ## Autonomous Execution Mode
 
@@ -168,7 +167,7 @@ Verify commit capability before autonomous mode. Let task-executor and quality-f
 Confirmed Small requirements or Medium/Large batch approval authorize task-executor implementation and quality-fixer corrections until completion or escalation.
 
 ### Autonomous Execution Summary
-For Medium/Large, after "batch approval for entire implementation phase" with work-planner, autonomously execute the following processes through completion or an escalation condition:
+For Medium/Large, after batch approval, including an existing-plan build instruction, autonomously execute the following processes through completion or an escalation condition:
 
 ```mermaid
 graph TD

--- a/dev-workflows/skills/subagents-orchestration-guide/references/monorepo-flow.md
+++ b/dev-workflows/skills/subagents-orchestration-guide/references/monorepo-flow.md
@@ -121,7 +121,7 @@ Pass both Design Doc paths as `design_docs`, the applicable `ui_spec`, and the s
 
 Pass both Design Docs, the applicable UI Spec, applicable PRD, and generated skeleton paths to work-planner. Compose phases around shared backend/frontend verification points. The generated skeleton file is consumed by the earliest task where its declared boundary becomes executable.
 
-Review the Work Plan with `doc_type: WorkPlan`, apply Review Resolution through work-planner, and stop for batch approval only after the review converges.
+When creating or materially updating the Work Plan, review it with `doc_type: WorkPlan`, apply Review Resolution through work-planner, and stop for batch approval only after the review converges. Existing-plan build entry follows the parent guide's phase acceptance rule.
 
 ## Task Materialization and Execution
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-workflows",
-  "version": "0.25.4",
+  "version": "0.25.5",
   "private": true,
   "type": "module",
   "engines": {

--- a/skills/recipe-build/SKILL.md
+++ b/skills/recipe-build/SKILL.md
@@ -21,7 +21,7 @@ Before the first finding disposition, read `references/review-resolution.md` fro
 **Execution Protocol**:
 1. **Invoke named specialists for deliverable production** — pass deliverable paths between them and validate their results (see subagents-orchestration-guide "Orchestrator Execution Boundary")
 2. **Follow the 4-step task cycle exactly**: execute → branch on executor result → quality-fix → commit
-3. **Enter autonomous mode** when user provides execution instruction with existing task files — this IS the batch approval
+3. **Enter autonomous mode** when the user provides execution instruction with an existing Work Plan or task files — this IS the batch approval
 4. **Scope**: Complete consumed task-set execution, post-implementation verification, consumed-task cleanup, and completion reporting in order, or stop autonomous execution at the current phase for a valid user-owned escalation. Advance only when the current phase's stated transition condition is satisfied.
 
 **CRITICAL**: Run quality-fixer before every commit.
@@ -53,8 +53,7 @@ Analyze the Consumed Task Set and determine the action required:
 | State | Criteria | Next Action |
 |-------|----------|-------------|
 | Tasks exist | Consumed Task Set is non-empty | User's execution instruction serves as batch approval → Enter autonomous execution immediately |
-| No tasks + approved plan exists | Consumed Task Set is empty but the resolved work plan has batch approval | Run task-decomposer; the approval already authorizes mechanical task materialization |
-| No tasks + unapproved plan exists | Consumed Task Set is empty and the resolved work plan is not approved | Review it when needed, then present the plan approval gate before task materialization |
+| No tasks + plan exists | Consumed Task Set is empty and the resolved work plan exists | User's execution instruction serves as batch approval → Run task-decomposer |
 | Neither exists + Design Doc exists | No plan, no Consumed Task Set, but `docs/design/*.md` exists | Invoke work-planner to create a work plan, then run document-reviewer (`dev-workflows:document-reviewer`, doc_type: WorkPlan). Run Review Resolution through correction re-review, its parent requirement or authority exits, and convergence, using work-planner for rerouted corrections; then present the resolved plan for batch approval before task materialization |
 | Neither exists | No plan, no Consumed Task Set, no Design Doc | Report missing prerequisites to user and stop |
 
@@ -62,17 +61,13 @@ Analyze the Consumed Task Set and determine the action required:
 
 When the Consumed Task Set is empty:
 
-### 1. Authorization Check
-
-Use the normal Work Plan review and approval gate when batch approval is absent. Existing batch approval authorizes task materialization directly.
-
-### 2. Task Materialization
+### 1. Task Materialization
 Invoke task-decomposer using Agent tool:
 - `subagent_type`: "dev-workflows:task-decomposer"
 - `description`: "Materialize work plan tasks"
 - `prompt`: "Read work plan at docs/plans/[plan-name].md and output individual single-commit task files in docs/plans/tasks/."
 
-### 3. Verify Generation
+### 2. Verify Generation
 Recompute the Consumed Task Set using the same restricted pattern from the Consumed Task Set section above. When it remains empty, apply Specialist Result Acceptance: validate the invocation and returned artifacts, correct recoverable input or naming errors, and rerun.
 
 **Flow**: Task generation → Consumed Task Set recompute → Autonomous execution (in this order)

--- a/skills/recipe-front-build/SKILL.md
+++ b/skills/recipe-front-build/SKILL.md
@@ -21,7 +21,7 @@ Before the first finding disposition, read `references/review-resolution.md` fro
 **Execution Protocol**:
 1. **Invoke named specialists for deliverable production** — pass deliverable paths between them and validate their results (see subagents-orchestration-guide "Orchestrator Execution Boundary")
 2. **Follow the 4-step task cycle exactly**: execute → branch on executor result → quality-fix → commit
-3. **Enter autonomous mode** when user provides execution instruction with existing task files — this IS the batch approval
+3. **Enter autonomous mode** when the user provides execution instruction with an existing Work Plan or task files — this IS the batch approval
 4. **Scope**: Complete consumed task-set execution, post-implementation verification, consumed-task cleanup, and completion reporting in order, or stop autonomous execution at the current phase for a valid user-owned escalation. Advance only when the current phase's stated transition condition is satisfied.
 
 **CRITICAL**: Run quality-fixer-frontend before every commit.
@@ -53,8 +53,7 @@ Analyze the Consumed Task Set and determine the action required:
 | State | Criteria | Next Action |
 |-------|----------|-------------|
 | Tasks exist | Consumed Task Set is non-empty | User's execution instruction serves as batch approval → Enter autonomous execution immediately |
-| No tasks + approved plan exists | Consumed Task Set is empty but the resolved work plan has batch approval | Run task-decomposer; the approval already authorizes mechanical task materialization |
-| No tasks + unapproved plan exists | Consumed Task Set is empty and the resolved work plan is not approved | Review it when needed, then present the plan approval gate before task materialization |
+| No tasks + plan exists | Consumed Task Set is empty and the resolved work plan exists | User's execution instruction serves as batch approval → Run task-decomposer |
 | Neither exists + Design Doc exists | No plan, no Consumed Task Set, but `docs/design/*.md` exists | Invoke work-planner to create a work plan, then run document-reviewer (`dev-workflows-frontend:document-reviewer`, doc_type: WorkPlan). Run Review Resolution through correction re-review, its parent requirement or authority exits, and convergence, using work-planner for rerouted corrections; then present the resolved plan for batch approval before task materialization |
 | Neither exists | No plan, no Consumed Task Set, no Design Doc | Report missing prerequisites to user and stop |
 
@@ -62,17 +61,13 @@ Analyze the Consumed Task Set and determine the action required:
 
 When the Consumed Task Set is empty:
 
-### 1. Authorization Check
-
-Use the normal Work Plan review and approval gate when batch approval is absent. Existing batch approval authorizes task materialization directly.
-
-### 2. Task Materialization
+### 1. Task Materialization
 Invoke task-decomposer using Agent tool:
 - `subagent_type`: "dev-workflows-frontend:task-decomposer"
 - `description`: "Materialize work plan tasks"
 - `prompt`: "Read work plan at docs/plans/[plan-name].md and output individual single-commit task files in docs/plans/tasks/."
 
-### 3. Verify Generation
+### 2. Verify Generation
 Recompute the Consumed Task Set using the same restricted pattern from the Consumed Task Set section above. When it remains empty, apply Specialist Result Acceptance: validate the invocation and returned artifacts, correct recoverable input or naming errors, and rerun.
 
 **Flow**: Task generation → Consumed Task Set recompute → Autonomous execution (in this order)

--- a/skills/recipe-fullstack-build/SKILL.md
+++ b/skills/recipe-fullstack-build/SKILL.md
@@ -29,7 +29,7 @@ Before the first finding disposition, read `references/review-resolution.md` fro
    - `*-backend-task-*` → task-executor + quality-fixer
    - `*-frontend-task-*` → task-executor-frontend + quality-fixer-frontend
 3. **Follow the 4-step task cycle exactly**: execute → branch on executor result → quality-fix → commit
-4. **Enter autonomous mode** when user provides execution instruction with existing task files — this IS the batch approval
+4. **Enter autonomous mode** when the user provides execution instruction with an existing Work Plan or task files — this IS the batch approval
 5. **Scope**: Complete consumed task-set execution, post-implementation verification, consumed-task cleanup, and completion reporting in order, or stop autonomous execution at the current phase for a valid user-owned escalation. Advance only when the current phase's stated transition condition is satisfied.
 
 **CRITICAL**: Run layer-appropriate quality-fixer(s) before every commit.
@@ -61,8 +61,7 @@ Analyze the Consumed Task Set and determine the action required:
 | State | Criteria | Next Action |
 |-------|----------|-------------|
 | Tasks exist | Consumed Task Set is non-empty | User's execution instruction serves as batch approval → Enter autonomous execution immediately |
-| No tasks + approved plan exists | Consumed Task Set is empty but the resolved work plan has batch approval | Run task-decomposer; the approval already authorizes mechanical task materialization |
-| No tasks + unapproved plan exists | Consumed Task Set is empty and the resolved work plan is not approved | Review it when needed, then present the plan approval gate before task materialization |
+| No tasks + plan exists | Consumed Task Set is empty and the resolved work plan exists | User's execution instruction serves as batch approval → Run task-decomposer |
 | Neither exists + Design Doc exists | No plan, no Consumed Task Set, but `docs/design/*.md` exists | Invoke work-planner to create a work plan, then run document-reviewer (`dev-workflows:document-reviewer`, doc_type: WorkPlan). Run Review Resolution through correction re-review, its parent requirement or authority exits, and convergence, using work-planner for rerouted corrections; then present the resolved plan for batch approval before task materialization |
 | Neither exists | No plan, no Consumed Task Set, no Design Doc | Report missing prerequisites to user and stop |
 
@@ -70,17 +69,13 @@ Analyze the Consumed Task Set and determine the action required:
 
 When the Consumed Task Set is empty:
 
-### 1. Authorization Check
-
-Use the normal Work Plan review and approval gate when batch approval is absent. Existing batch approval authorizes task materialization directly.
-
-### 2. Task Materialization
+### 1. Task Materialization
 Invoke task-decomposer using Agent tool:
 - `subagent_type`: "dev-workflows:task-decomposer"
 - `description`: "Materialize work plan tasks"
 - `prompt`: "Read work plan at docs/plans/[plan-name].md and output individual single-commit task files in docs/plans/tasks/. Use layer-aware naming: {plan}-backend-task-{n}.md, {plan}-frontend-task-{n}.md from each Work Plan task's Executor lane."
 
-### 3. Verify Generation
+### 2. Verify Generation
 Recompute the Consumed Task Set using the same restricted pattern from the Consumed Task Set section above. When it remains empty, apply Specialist Result Acceptance: validate the invocation and returned artifacts, correct recoverable input or naming errors, and rerun.
 
 ## Pre-execution Checklist

--- a/skills/subagents-orchestration-guide/SKILL.md
+++ b/skills/subagents-orchestration-guide/SKILL.md
@@ -82,7 +82,7 @@ Workflow coordination is flat: the orchestrator issues every specialist call and
 
 ## Explicit Stop Points
 
-Autonomous execution MUST stop and wait for user input at these points.
+Apply these approval stops when producing or materially revising an artifact in the current workflow. A user instruction to proceed to a later phase accepts the preceding phases and authorizes entry into that phase; continue from that entry point rather than rechecking earlier review or approval records. In particular, a build instruction with an existing Work Plan grants batch approval for task materialization and implementation.
 **Use AskUserQuestion to present confirmations and questions.**
 
 Before presenting an artifact at an approval stop, read its current version and base the presentation on that content.
@@ -154,10 +154,9 @@ Rules:
 - An applied `unverified` discrepancy returns through a fresh owning technical-designer update invocation. Capability probing is reserved for the designer's review-triggered gate, with that fresh designer as the sole correction specialist
 - Fullstack layer sequencing is defined only in `references/monorepo-flow.md`
 - `design-sync` is required whenever multiple Design Docs exist
-- `task-decomposer` begins only after work plan review (document-reviewer, doc_type WorkPlan; Medium/Large) and batch approval
-- Work plan review runs Review Resolution through correction re-review, its parent requirement or authority exits, and convergence; batch approval is available only at its convergence condition
+- When creating or materially updating a Medium/Large Work Plan, run document-reviewer (doc_type WorkPlan) and Review Resolution through correction re-review, its parent requirement or authority exits, and convergence before presenting the plan for batch approval. Existing-plan build entry follows the phase acceptance rule in Explicit Stop Points.
 
-Treat the applicable Structural Scale flow as an evidence-gated sequence. Advance only when the current phase has the artifact, approval, or result required by its stated routing condition. Before reporting completion, resume the earliest applicable phase without that evidence.
+Start the applicable Structural Scale flow at the user-requested phase. Before reporting completion, verify the artifacts and results required by every applicable phase from that entry point through completion, and complete any missing work within those phases. Return to an earlier phase when a material change invalidates its outcome, using Handling Requirement Changes.
 
 ## Autonomous Execution Mode
 
@@ -168,7 +167,7 @@ Verify commit capability before autonomous mode. Let task-executor and quality-f
 Confirmed Small requirements or Medium/Large batch approval authorize task-executor implementation and quality-fixer corrections until completion or escalation.
 
 ### Autonomous Execution Summary
-For Medium/Large, after "batch approval for entire implementation phase" with work-planner, autonomously execute the following processes through completion or an escalation condition:
+For Medium/Large, after batch approval, including an existing-plan build instruction, autonomously execute the following processes through completion or an escalation condition:
 
 ```mermaid
 graph TD

--- a/skills/subagents-orchestration-guide/references/monorepo-flow.md
+++ b/skills/subagents-orchestration-guide/references/monorepo-flow.md
@@ -121,7 +121,7 @@ Pass both Design Doc paths as `design_docs`, the applicable `ui_spec`, and the s
 
 Pass both Design Docs, the applicable UI Spec, applicable PRD, and generated skeleton paths to work-planner. Compose phases around shared backend/frontend verification points. The generated skeleton file is consumed by the earliest task where its declared boundary becomes executable.
 
-Review the Work Plan with `doc_type: WorkPlan`, apply Review Resolution through work-planner, and stop for batch approval only after the review converges.
+When creating or materially updating the Work Plan, review it with `doc_type: WorkPlan`, apply Review Resolution through work-planner, and stop for batch approval only after the review converges. Existing-plan build entry follows the parent guide's phase acceptance rule.
 
 ## Task Materialization and Execution
 


### PR DESCRIPTION
Starting a build with an existing Work Plan could reopen earlier review and approval gates. Build recipes now treat the execution instruction as batch approval and proceed directly to task materialization. Shared and monorepo guidance preserves reviews for newly created or materially revised plans and checks all required work from the requested entry phase onward.

Bumps the package and all four local marketplace plugins to 0.25.5 and synchronizes the distributed plugin files.

Validation: `pnpm sync:check`, `pnpm check:skills-index`, `claude plugin validate` for the marketplace and all four plugins, and `git diff --check` passed. Live Claude session behavior has not been tested.
